### PR TITLE
Rename Containerbuddy to ContainerPilot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 ## Contributing
 
-Please report any issues you encounter with Containerbuddy or its documentation by opening a Github issue (https://github.com/joyent/containerbuddy/issues). Roadmap items will be maintained as [enhancements](https://github.com/joyent/containerbuddy/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement). PRs are welcome on any issue.
+Please report any issues you encounter with ContainerPilot or its documentation by opening a Github issue (https://github.com/joyent/containerpilot/issues). Roadmap items will be maintained as [enhancements](https://github.com/joyent/containerpilot/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement). PRs are welcome on any issue.
 
 
 Thanks to the following contributors:
-- [@bbox-kula](https://github.com/bbox-kula): [first steps to allowing multiple discovery backends](https://github.com/joyent/containerbuddy/pull/4)
+- [@bbox-kula](https://github.com/bbox-kula): [first steps to allowing multiple discovery backends](https://github.com/joyent/containerpilot/pull/4)
 - [@justenwalker](https://github.com/justenwalker): hooks for preStop and postStop, deregistering services on SIGTERM, config templates, TravisCI integration, improved interface config parsing, and many many more code contributions.
-- [@wleese](https://github.com/wleese): [support for CONSUL_HTTP_TOKEN auth](https://github.com/joyent/containerbuddy/pull/79)
+- [@wleese](https://github.com/wleese): [support for CONSUL_HTTP_TOKEN auth](https://github.com/joyent/containerpilot/pull/79)

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN  go get github.com/golang/lint/golint \
 
 ENV CGO_ENABLED 0
 ENV GO15VENDOREXPERIMENT 1
-ENV GOPATH /go:/cb
+ENV GOPATH /go:/cp

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "github.com/joyent/containerbuddy",
+	"ImportPath": "github.com/joyent/containerpilot",
 	"GoVersion": "go1.6",
 	"Deps": [
 		{

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/joyent/containerbuddy/discovery"
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/discovery"
+	"github.com/joyent/containerpilot/utils"
 )
 
 // Backend represents a command to execute when another application changes

--- a/backends/backends_test.go
+++ b/backends/backends_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/utils"
 )
 
 func TestOnChangeCmd(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/joyent/containerbuddy/backends"
-	"github.com/joyent/containerbuddy/discovery"
-	"github.com/joyent/containerbuddy/services"
-	"github.com/joyent/containerbuddy/telemetry"
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/backends"
+	"github.com/joyent/containerpilot/discovery"
+	"github.com/joyent/containerpilot/services"
+	"github.com/joyent/containerpilot/telemetry"
+	"github.com/joyent/containerpilot/utils"
 )
 
 var (
@@ -43,7 +43,7 @@ func GetConfig() *Config {
 	return globalConfig
 }
 
-// Config is the top-level Containerbuddy Configuration
+// Config is the top-level ContainerPilot Configuration
 type Config struct {
 	Consul          string          `json:"consul,omitempty"`
 	Etcd            json.RawMessage `json:"etcd,omitempty"`
@@ -88,7 +88,7 @@ func LoadConfig() (*Config, error) {
 		os.Exit(0)
 	}
 	if configFlag == "" {
-		configFlag = os.Getenv("CONTAINERBUDDY")
+		configFlag = os.Getenv("CONTAINERPILOT")
 	}
 
 	if cfg, err := parseConfig(configFlag); err != nil {
@@ -112,12 +112,12 @@ func initializeConfig(cfg *Config) (*Config, error) {
 
 	// onStart has been deprecated for preStart. Remove in 2.0
 	if cfg.PreStart != nil && cfg.OnStart != nil {
-		fmt.Println("The onStart option has been deprecated in favor of preStart. Containerbuddy will use only the preStart option provided")
+		fmt.Println("The onStart option has been deprecated in favor of preStart. ContainerPilot will use only the preStart option provided")
 	}
 
 	// alias the onStart behavior to preStart
 	if cfg.PreStart == nil && cfg.OnStart != nil {
-		fmt.Println("The onStart option has been deprecated in favor of preStart. Containerbuddy will use the onStart option as a preStart")
+		fmt.Println("The onStart option has been deprecated in favor of preStart. ContainerPilot will use the onStart option as a preStart")
 		cfg.PreStart = cfg.OnStart
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -194,7 +194,7 @@ func TestMetricServiceCreation(t *testing.T) {
 				t.Errorf("Expected telemetry service but got %v", config.Services)
 			} else {
 				service := config.Services[0]
-				if service.Name != "containerbuddy" {
+				if service.Name != "containerpilot" {
 					t.Errorf("Got incorrect service back: %v", service)
 				}
 			}

--- a/config/logging_test.go
+++ b/config/logging_test.go
@@ -18,7 +18,7 @@ func TestLoggingBootstrap(t *testing.T) {
 		t.Errorf("Expected output to Stdout")
 	}
 	if _, ok := std.Formatter.(*DefaultLogFormatter); !ok {
-		t.Errorf("Expected *containerbuddy.DefaultLogFormatter got: %v", reflect.TypeOf(std.Formatter))
+		t.Errorf("Expected *containerpilot.DefaultLogFormatter got: %v", reflect.TypeOf(std.Formatter))
 	}
 }
 

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -17,7 +17,7 @@ func TestParseEnvironment(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-	env := parseEnvironment([]string{"NAME=Template", "USER=buddy"})
+	env := parseEnvironment([]string{"NAME=Template", "USER=pilot"})
 	validateTemplate(t, "One var", `Hello, {{.NAME}}!`, env, "Hello, Template!")
 	validateTemplate(t, "Var undefined", `Hello, {{.NONAME}}!`, env, "Hello, !")
 	validateTemplate(t, "Default", `Hello, {{.NONAME | default "World" }}!`, env, "Hello, World!")

--- a/core/poll.go
+++ b/core/poll.go
@@ -1,7 +1,7 @@
 package core
 
 import (
-	"github.com/joyent/containerbuddy/config"
+	"github.com/joyent/containerpilot/config"
 	"time"
 )
 

--- a/core/signals.go
+++ b/core/signals.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/joyent/containerbuddy/config"
-	"github.com/joyent/containerbuddy/services"
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/config"
+	"github.com/joyent/containerpilot/services"
+	"github.com/joyent/containerpilot/utils"
 )
 
 // globals are eeeeevil

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/joyent/containerbuddy/config"
-	"github.com/joyent/containerbuddy/discovery"
-	"github.com/joyent/containerbuddy/services"
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/config"
+	"github.com/joyent/containerpilot/discovery"
+	"github.com/joyent/containerpilot/services"
+	"github.com/joyent/containerpilot/utils"
 )
 
 // ------------------------------------------

--- a/discovery/consul.go
+++ b/discovery/consul.go
@@ -91,7 +91,7 @@ func (c *Consul) registerCheck(service ServiceDefinition) error {
 		&consul.AgentCheckRegistration{
 			ID:        service.ID,
 			Name:      service.ID,
-			Notes:     fmt.Sprintf("TTL for %s set by containerbuddy", service.Name),
+			Notes:     fmt.Sprintf("TTL for %s set by containerpilot", service.Name),
 			ServiceID: service.ID,
 			AgentServiceCheck: consul.AgentServiceCheck{
 				TTL: fmt.Sprintf("%ds", service.TTL),

--- a/discovery/etcd.go
+++ b/discovery/etcd.go
@@ -56,7 +56,7 @@ func parseEndpoints(raw json.RawMessage) []string {
 // NewEtcdConfig creates a new service discovery backend for etcd
 func NewEtcdConfig(config json.RawMessage) Etcd {
 	etcd := Etcd{
-		Prefix: "/containerbuddy",
+		Prefix: "/containerpilot",
 	}
 	var rawConfig etcdRawConfig
 	etcdConfig := client.Config{}

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -22,7 +22,7 @@ Fixtures Directory: `integration_tests/fixtures`
 
 - Folders in the fixtures directory will be built as docker images in alphabetical order
 - Each folder should contain a `Dockerfile` and any resources necessary to build the image
-- The resulting image will be named `cbfix_fixture_name`
+- The resulting image will be named `cpfix_fixture_name`
 
 *Note*: Since fixtures are created in alpha order, they can have FROM directives for previously created images
 
@@ -42,7 +42,7 @@ This script can make some assumptions:
   - `COMPOSE_FILE`
   - `COMPOSE_PROJECT_NAME` - The name of the test folder
   - `DOCKER_IP` - The IP of docker on the host machine
-  - `CONTAINERBUDDY_BIN` - Absolute path to containerbuddy binary on the host.
+  - `CONTAINERPILOT_BIN` - Absolute path to containerpilot binary on the host.
 - all fixtures in `integration_tests/fixtures` are created and are available as images
 
 ## How tests are executed
@@ -52,7 +52,7 @@ This script can make some assumptions:
 - For each fixture:
   - Copy `build` into `integration_test/fixtures/fixture_name/build` so it can easily be sourced by the `Dockerfile`
   - `cd integration_tests/fixtures/fixture_name`
-  - `docker build -t cbfix_fixture_name .`
+  - `docker build -t cpfix_fixture_name .`
 
 ### Run tests
 - Scan through all folders in `integration_tests/tests` in alpha order

--- a/integration_tests/fixtures/app/Dockerfile
+++ b/integration_tests/fixtures/app/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 RUN npm install -g json http-server
 
-COPY build/containerbuddy /bin/containerbuddy
+COPY build/containerpilot /bin/containerpilot
 COPY app-with-consul.json /app-with-consul.json
 COPY app-with-etcd.json /app-with-etcd.json
 COPY reload-app.sh /reload-app.sh
@@ -15,8 +15,8 @@ COPY reload-app-etcd.sh /reload-app-etcd.sh
 COPY sensor.sh /sensor.sh
 
 # by default use app-consul.json, allows for override in docker-compose
-ENV CONTAINERBUDDY=file:///app-with-consul.json
+ENV CONTAINERPILOT=file:///app-with-consul.json
 
-ENTRYPOINT [ "/bin/containerbuddy", \
+ENTRYPOINT [ "/bin/containerpilot", \
              "/usr/local/bin/node", \
              "/usr/local/bin/http-server", "/srv", "-p", "8000"]

--- a/integration_tests/fixtures/app/app-with-consul.json
+++ b/integration_tests/fixtures/app/app-with-consul.json
@@ -28,7 +28,7 @@
     "port": 9090,
     "sensors": [
        {
-        "namespace": "containerbuddy",
+        "namespace": "containerpilot",
         "subsystem": "app",
         "name": "some_counter",
         "help": "help text",

--- a/integration_tests/fixtures/app/app-with-etcd.json
+++ b/integration_tests/fixtures/app/app-with-etcd.json
@@ -1,7 +1,7 @@
 {
   "etcd":{
       "endpoints": "http://etcd:4001",
-      "prefix": "/containerbuddy"
+      "prefix": "/containerpilot"
   },
   "preStart": "/reload-app-etcd.sh",
   "services": [

--- a/integration_tests/fixtures/app/reload-app-etcd.sh
+++ b/integration_tests/fixtures/app/reload-app-etcd.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # get all the healthy application servers and write the json to file
-curl -s etcd:4001/v2/keys/containerbuddy/app | json > /tmp/lastQuery.json
+curl -s etcd:4001/v2/keys/containerpilot/app | json > /tmp/lastQuery.json
 
 cat <<EOF > /srv/index.html
 <html>
 <head>
-<title>Containerbuddy Demo</title>
+<title>ContainerPilot Demo</title>
 <script>
 function timedRefresh(timeoutPeriod) {
     setTimeout("location.reload(true);",timeoutPeriod);
@@ -14,7 +14,7 @@ function timedRefresh(timeoutPeriod) {
 </script>
 </head>
 <body onload="JavaScript:timedRefresh(5000);">
-<h1>Containerbuddy Demo</h1>
+<h1>ContainerPilot Demo</h1>
 <h2>This page served by app server: $(hostname)</h2>
 Last service health check changed at $(date):
 <pre>

--- a/integration_tests/fixtures/app/reload-app.sh
+++ b/integration_tests/fixtures/app/reload-app.sh
@@ -6,7 +6,7 @@ curl -s consul:8500/v1/health/service/app?passing | json > /tmp/lastQuery.json
 cat <<EOF > /srv/index.html
 <html>
 <head>
-<title>Containerbuddy Demo</title>
+<title>ContainerPilot Demo</title>
 <script>
 function timedRefresh(timeoutPeriod) {
     setTimeout("location.reload(true);",timeoutPeriod);
@@ -14,7 +14,7 @@ function timedRefresh(timeoutPeriod) {
 </script>
 </head>
 <body onload="JavaScript:timedRefresh(5000);">
-<h1>Containerbuddy Demo</h1>
+<h1>ContainerPilot Demo</h1>
 <h2>This page served by app server: $(hostname)</h2>
 Last service health check changed at $(date):
 <pre>

--- a/integration_tests/fixtures/nginx/Dockerfile
+++ b/integration_tests/fixtures/nginx/Dockerfile
@@ -1,4 +1,4 @@
-# Nginx container including Containerbuddy
+# Nginx container including ContainerPilot
 FROM alpine:3.3
 
 # install nginx and tooling we need
@@ -17,14 +17,14 @@ RUN curl -Lo /tmp/consul_template_0.11.0_linux_amd64.zip https://github.com/hash
 RUN curl -Lo /bin/confd https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64 && \
     chmod 755 /bin/confd
 
-# add Containerbuddy build and configuration
-COPY build/containerbuddy /bin/containerbuddy
+# add ContainerPilot build and configuration
+COPY build/containerpilot /bin/containerpilot
 COPY etc /etc
 
 EXPOSE 80
 
 # by default use nginx-with-consul.json, allows for override in docker-compose
-ENV CONTAINERBUDDY=file:///etc/nginx-with-consul.json
+ENV CONTAINERPILOT=file:///etc/nginx-with-consul.json
 
-ENTRYPOINT [ "/bin/containerbuddy", \
+ENTRYPOINT [ "/bin/containerpilot", \
              "nginx", "-g", "daemon off;"]

--- a/integration_tests/fixtures/nginx/etc/confd/conf.d/nginx-confd.toml
+++ b/integration_tests/fixtures/nginx/etc/confd/conf.d/nginx-confd.toml
@@ -2,7 +2,7 @@
 src = "nginx-etcd.tmpl"
 dest = "/etc/nginx/nginx.conf"
 owner = "nginx"
-prefix = "/containerbuddy"
+prefix = "/containerpilot"
 mode = "0644"
 keys = [
   "/app"

--- a/integration_tests/fixtures/nginx/etc/nginx-with-etcd.json
+++ b/integration_tests/fixtures/nginx/etc/nginx-with-etcd.json
@@ -1,7 +1,7 @@
 {
   "etcd":{
       "endpoints": "http://etcd:4001",
-      "prefix": "/containerbuddy"
+      "prefix": "/containerpilot"
   },
   "services": [
     {

--- a/integration_tests/fixtures/test_probe/src/etcd.go
+++ b/integration_tests/fixtures/test_probe/src/etcd.go
@@ -28,7 +28,7 @@ func NewEtcdProbe() (EtcdProbe, error) {
 		return nil, err
 	}
 	kapi := etcd.NewKeysAPI(client)
-	return EtcdProbe(etcdClient{Client: client, API: kapi, Prefix: "/containerbuddy"}), nil
+	return EtcdProbe(etcdClient{Client: client, API: kapi, Prefix: "/containerpilot"}), nil
 }
 
 // WaitForServices waits for the healthy services count to equal the count

--- a/integration_tests/fixtures/test_probe/src/test_discovery.go
+++ b/integration_tests/fixtures/test_probe/src/test_discovery.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-// TestDiscovery tests that Containerbuddy registers all services and that
+// TestDiscovery tests that ContainerPilot registers all services and that
 // Nginx has a working route to App
 func TestDiscovery(args []string) bool {
 

--- a/integration_tests/fixtures/test_probe/src/test_sigterm.go
+++ b/integration_tests/fixtures/test_probe/src/test_sigterm.go
@@ -2,7 +2,7 @@ package main
 
 import "log"
 
-// TestSigterm tests that containerbuddy will deregister the service on a SIGTERM
+// TestSigterm tests that containerpilot will deregister the service on a SIGTERM
 func TestSigterm(args []string) bool {
 	if len(args) != 1 {
 		log.Println("TestSigterm requires 1 argument")

--- a/integration_tests/fixtures/zombie_maker/Dockerfile
+++ b/integration_tests/fixtures/zombie_maker/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:3.3
 
-ADD build/containerbuddy /bin/containerbuddy
+ADD build/containerpilot /bin/containerpilot
 ADD app.json /app.json
 
 ADD zombie.sh /zombie.sh
 RUN chmod 755 /zombie.sh
 
 ENTRYPOINT [\
-  "/bin/containerbuddy","-config=file:///app.json",\
+  "/bin/containerpilot","-config=file:///app.json",\
   "tail","-f"]

--- a/integration_tests/tests/test_discovery_consul/docker-compose.yml
+++ b/integration_tests/tests/test_discovery_consul/docker-compose.yml
@@ -1,26 +1,26 @@
 consul:
-    image: "cbfix_consul"
+    image: "cpfix_consul"
     mem_limit: 128m
     hostname: consul
 
 app:
-    image: "cbfix_app"
+    image: "cpfix_app"
     mem_limit: 128m
     links:
       - consul:consul
     volumes:
-      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
 nginx:
-    image: "cbfix_nginx"
+    image: "cpfix_nginx"
     mem_limit: 128m
     links:
       - consul:consul
     volumes:
-      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
 test:
-    image: "cbfix_test_probe"
+    image: "cpfix_test_probe"
     mem_limit: 128m
     links:
       - app:app

--- a/integration_tests/tests/test_discovery_etcd/docker-compose.yml
+++ b/integration_tests/tests/test_discovery_etcd/docker-compose.yml
@@ -1,32 +1,32 @@
 etcd:
-    image: "cbfix_etcd"
+    image: "cpfix_etcd"
     mem_limit: 128m
     hostname: etcd
     ports:
       - 4001:4001
 
 app:
-    image: "cbfix_app"
+    image: "cpfix_app"
     mem_limit: 128m
     links:
       - etcd:etcd
     environment:
-      - CONTAINERBUDDY=file:///app-with-etcd.json
+      - CONTAINERPILOT=file:///app-with-etcd.json
     volumes:
-      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
 nginx:
-    image: "cbfix_nginx"
+    image: "cpfix_nginx"
     mem_limit: 128m
     links:
       - etcd:etcd
     environment:
-      - CONTAINERBUDDY=file:///etc/nginx-with-etcd.json
+      - CONTAINERPILOT=file:///etc/nginx-with-etcd.json
     volumes:
-      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
 test:
-    image: "cbfix_test_probe"
+    image: "cpfix_test_probe"
     mem_limit: 128m
     links:
       - app:app

--- a/integration_tests/tests/test_reap_zombies/docker-compose.yml
+++ b/integration_tests/tests/test_reap_zombies/docker-compose.yml
@@ -1,12 +1,12 @@
 consul:
-    image: "cbfix_consul"
+    image: "cpfix_consul"
     mem_limit: 256m
     hostname: consul
 
 app:
-    image: "cbfix_zombie_maker"
+    image: "cpfix_zombie_maker"
     mem_limit: 512m
     links:
       - consul:consul
     volumes:
-      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'

--- a/integration_tests/tests/test_sighup_deadlock/docker-compose.yml
+++ b/integration_tests/tests/test_sighup_deadlock/docker-compose.yml
@@ -1,16 +1,16 @@
 consul:
-    image: "cbfix_consul"
+    image: "cpfix_consul"
     mem_limit: 256m
     hostname: consul
 
 app:
-    image: "cbfix_app"
+    image: "cpfix_app"
     mem_limit: 512m
     links:
       - consul:consul
 
 test:
-    image: "cbfix_test_probe"
+    image: "cpfix_test_probe"
     mem_limit: 128m
     links:
       - consul:consul

--- a/integration_tests/tests/test_sighup_deadlock/run.sh
+++ b/integration_tests/tests/test_sighup_deadlock/run.sh
@@ -4,7 +4,7 @@ docker-compose up -d consul app
 APP_ID="$(docker-compose ps -q app)"
 docker-compose run --no-deps test /go/bin/test_probe test_sighup_deadlock $APP_ID > /dev/null 2>&1
 result=$?
-TEST_ID=$(docker ps -l -f "ancestor=cbfix_test_probe" --format="{{.ID}}")
+TEST_ID=$(docker ps -l -f "ancestor=cpfix_test_probe" --format="{{.ID}}")
 docker logs $TEST_ID
 docker rm -f $TEST_ID > /dev/null 2>&1
 exit $result

--- a/integration_tests/tests/test_sigterm/docker-compose.yml
+++ b/integration_tests/tests/test_sigterm/docker-compose.yml
@@ -1,18 +1,18 @@
 consul:
-    image: "cbfix_consul"
+    image: "cpfix_consul"
     mem_limit: 256m
     hostname: consul
 
 app:
-    image: "cbfix_app"
+    image: "cpfix_app"
     mem_limit: 512m
     links:
       - consul:consul
     volumes:
-      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
 test:
-    image: "cbfix_test_probe"
+    image: "cpfix_test_probe"
     mem_limit: 128m
     links:
       - consul:consul

--- a/integration_tests/tests/test_sigterm/run.sh
+++ b/integration_tests/tests/test_sigterm/run.sh
@@ -4,7 +4,7 @@ docker-compose up -d consul app > /dev/null 2>&1
 APP_ID="$(docker-compose ps -q app)"
 docker-compose run --no-deps test /go/bin/test_probe test_sigterm $APP_ID > /dev/null 2>&1
 result=$?
-TEST_ID=$(docker ps -l -f "ancestor=cbfix_test_probe" --format="{{.ID}}")
+TEST_ID=$(docker ps -l -f "ancestor=cpfix_test_probe" --format="{{.ID}}")
 docker logs $TEST_ID
 docker rm -f $TEST_ID > /dev/null 2>&1
 exit $result

--- a/integration_tests/tests/test_telemetry/docker-compose.yml
+++ b/integration_tests/tests/test_telemetry/docker-compose.yml
@@ -1,14 +1,14 @@
 consul:
-    image: "cbfix_consul"
+    image: "cpfix_consul"
     mem_limit: 128m
     hostname: consul
 
 app:
-    image: "cbfix_app"
+    image: "cpfix_app"
     mem_limit: 128m
     links:
       - consul:consul
     ports:
       - 9090:9090
     volumes:
-      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'

--- a/integration_tests/tests/test_telemetry/run.sh
+++ b/integration_tests/tests/test_telemetry/run.sh
@@ -11,7 +11,7 @@ IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${APP_ID})
 # this interface takes a while to converge
 for i in {20..1}; do
     sleep 1
-    docker exec -it ${APP_ID} curl -v -s --fail ${IP}:9090/metrics | grep 'containerbuddy_app_some_counter 42' && break
+    docker exec -it ${APP_ID} curl -v -s --fail ${IP}:9090/metrics | grep 'containerpilot_app_some_counter 42' && break
 done
 
 result=$?

--- a/integration_tests/tests/test_version_flag/docker-compose.yml
+++ b/integration_tests/tests/test_version_flag/docker-compose.yml
@@ -1,6 +1,6 @@
 app:
-    image: "cbfix_test_probe"
+    image: "cpfix_test_probe"
     mem_limit: 128m
     volumes:
-      - '${CONTAINERBUDDY_BIN}:/bin/containerbuddy:ro'
-    command: /bin/containerbuddy -version
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
+    command: /bin/containerpilot -version

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main // import "github.com/joyent/containerbuddy"
+package main // import "github.com/joyent/containerpilot"
 
 import (
 	"flag"
@@ -6,12 +6,12 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/joyent/containerbuddy/config"
-	"github.com/joyent/containerbuddy/core"
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/config"
+	"github.com/joyent/containerpilot/core"
+	"github.com/joyent/containerpilot/utils"
 )
 
-// Main executes the containerbuddy CLI
+// Main executes the containerpilot CLI
 func main() {
 	// make sure we use only a single CPU so as not to cause
 	// contention on the main application

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 
 .PHONY: clean test integration consul etcd run-consul run-etcd example example-consul example-etcd ship dockerfile docker cover lint vendor
 
-IMPORT_PATH := github.com/joyent/containerbuddy
+IMPORT_PATH := github.com/joyent/containerpilot
 VERSION ?= dev-build-not-for-release
 LDFLAGS := -X ${IMPORT_PATH}/config.GitHash='$(shell git rev-parse --short HEAD)' -X ${IMPORT_PATH}/config.Version='${VERSION}'
 
@@ -15,62 +15,62 @@ COMPOSE_PREFIX_ETCD := exetcd
 COMPOSE_PREFIX_CONSUL := exconsul
 
 DOCKERRUN := docker run --rm \
-	--link containerbuddy_consul:consul \
-	--link containerbuddy_etcd:etcd \
+	--link containerpilot_consul:consul \
+	--link containerpilot_etcd:etcd \
 	-v ${ROOT}/vendor:/go/src \
-	-v ${ROOT}:/cb/src/${IMPORT_PATH} \
-	-w /cb/src/${IMPORT_PATH} \
-	containerbuddy_build
+	-v ${ROOT}:/cp/src/${IMPORT_PATH} \
+	-w /cp/src/${IMPORT_PATH} \
+	containerpilot_build
 
 DOCKERBUILD := docker run --rm \
 	-e LDFLAGS="${LDFLAGS}" \
 	-v ${ROOT}/vendor:/go/src \
-	-v ${ROOT}:/cb/src/${IMPORT_PATH} \
-	-w /cb/src/${IMPORT_PATH} \
-	containerbuddy_build
+	-v ${ROOT}:/cp/src/${IMPORT_PATH} \
+	-w /cp/src/${IMPORT_PATH} \
+	containerpilot_build
 
 clean:
 	rm -rf build release cover vendor
-	docker rmi -f containerbuddy_build > /dev/null 2>&1 || true
-	docker rm -f containerbuddy_consul > /dev/null 2>&1 || true
-	docker rm -f containerbuddy_etcd > /dev/null 2>&1 || true
+	docker rmi -f containerpilot_build > /dev/null 2>&1 || true
+	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
+	docker rm -f containerpilot_etcd > /dev/null 2>&1 || true
 	./scripts/test.sh clean
 
 # ----------------------------------------------
 # docker build
 
 # default top-level target
-build: build/containerbuddy
+build: build/containerpilot
 
-build/containerbuddy:  build/containerbuddy_build */*.go vendor
-	${DOCKERBUILD} go build -o build/containerbuddy -ldflags "$(LDFLAGS)"
+build/containerpilot:  build/containerpilot_build */*.go vendor
+	${DOCKERBUILD} go build -o build/containerpilot -ldflags "$(LDFLAGS)"
 	@rm -rf src || true
 
 # builds the builder container
-build/containerbuddy_build:
+build/containerpilot_build:
 	mkdir -p ${ROOT}/build
-	docker rmi -f containerbuddy_build > /dev/null 2>&1 || true
-	docker build -t containerbuddy_build ${ROOT}
-	docker inspect -f "{{ .ID }}" containerbuddy_build > build/containerbuddy_build
+	docker rmi -f containerpilot_build > /dev/null 2>&1 || true
+	docker build -t containerpilot_build ${ROOT}
+	docker inspect -f "{{ .ID }}" containerpilot_build > build/containerpilot_build
 
 # shortcut target for other targets: asserts a
 # working test environment
-docker: build/containerbuddy_build consul etcd
+docker: build/containerpilot_build consul etcd
 
 # top-level target for vendoring our packages: godep restore requires
 # being in the package directory so we have to run this for each package
-vendor: build/containerbuddy_build
+vendor: build/containerpilot_build
 	${DOCKERBUILD} godep restore
 
 # fetch a dependency via go get, vendor it, and then save into the parent
 # package's Godeps
 # usage DEP=github.com/owner/package make add-dep
-add-dep: build/containerbuddy_build
+add-dep: build/containerpilot_build
 	docker run --rm \
 		-e LDFLAGS="${LDFLAGS}" \
-		-v ${ROOT}:/cb/src/${IMPORT_PATH} \
-		-w /cb/src/${IMPORT_PATH} \
-		containerbuddy_build \
+		-v ${ROOT}:/cp/src/${IMPORT_PATH} \
+		-w /cp/src/${IMPORT_PATH} \
+		containerpilot_build \
 		bash ./scripts/add_dep.sh DEP=$(DEP)
 
 # ----------------------------------------------
@@ -95,14 +95,14 @@ integration: build
 
 # Consul Backend
 consul:
-	docker rm -f containerbuddy_consul > /dev/null 2>&1 || true
-	docker run -d -m 256m --name containerbuddy_consul \
+	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
+	docker run -d -m 256m --name containerpilot_consul \
 		progrium/consul:latest -server -bootstrap-expect 1 -ui-dir /ui
 
 # Etcd Backend
 etcd:
-	docker rm -f containerbuddy_etcd > /dev/null 2>&1 || true
-	docker run -d -m 256m --name containerbuddy_etcd -h etcd quay.io/coreos/etcd:v2.0.8 \
+	docker rm -f containerpilot_etcd > /dev/null 2>&1 || true
+	docker run -d -m 256m --name containerpilot_etcd -h etcd quay.io/coreos/etcd:v2.0.8 \
 		-name etcd0 \
 		-advertise-client-urls http://etcd:2379,http://etcd:4001 \
 		-listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 \
@@ -116,7 +116,7 @@ release: build
 	mkdir -p release
 	git tag $(VERSION)
 	git push joyent --tags
-	cd build && tar -czf ../release/containerbuddy-$(VERSION).tar.gz containerbuddy
+	cd build && tar -czf ../release/containerpilot-$(VERSION).tar.gz containerpilot
 	@echo
 	@echo Upload this file to Github release:
-	@sha1sum release/containerbuddy-$(VERSION).tar.gz
+	@sha1sum release/containerpilot-$(VERSION).tar.gz

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -2,7 +2,7 @@
 OUT=${OUT:-cover/cover.out}
 TMP=${TMP:-cover/temp.out}
 echo "mode: set" > $OUT
-for pkg in $(go list ./... | grep -v '/vendor/\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerbuddy+');
+for pkg in $(go list ./... | grep -v '/vendor/\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerpilot+');
 do
   go test -v -coverprofile=$TMP $pkg
   if [ -f $TMP  ]; then

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 result=0
-for pkg in $(go list ./... | grep -v '/vendor/\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerbuddy+'); do
+for pkg in $(go list ./... | grep -v '/vendor/\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerpilot+'); do
   if golint $pkg; then
     result=1
   fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -47,7 +47,7 @@ fi
 export DOCKER_IP
 debug "DOCKER_IP=$DOCKER_IP"
 
-export FIXTURE_PREFIX=${FIXTURE_PREFIX:-"cbfix_"}
+export FIXTURE_PREFIX=${FIXTURE_PREFIX:-"cpfix_"}
 debug "FIXTURE_PREFIX=$FIXTURE_PREFIX"
 
 debug "ROOT_DIR=$ROOT_DIR"
@@ -58,7 +58,7 @@ debug "TESTS_DIR=$TESTS_DIR"
 
 create_test_fixtures() {
   banner "Create Test Fixtures"
-  if [ ! -f "$DIR/build/containerbuddy" ]; then die "Containerbuddy not built. Did you make?"; fi
+  if [ ! -f "$DIR/build/containerpilot" ]; then die "ContainerPilot not built. Did you make?"; fi
   find $FIXTURE_DIR -maxdepth 1 -mindepth 1 -type d | \
     sort | \
     while read FDIR; do
@@ -114,7 +114,7 @@ run_test() {
     cd $TDIR
     export COMPOSE_PROJECT_NAME="$(basename $TDIR)"
     export COMPOSE_FILE="./docker-compose.yml"
-    export CONTAINERBUDDY_BIN="$DIR/build/containerbuddy"
+    export CONTAINERPILOT_BIN="$DIR/build/containerpilot"
     log "TEST: $COMPOSE_PROJECT_NAME"
     build_test_compose
     chmod 755 "./run.sh"

--- a/scripts/unit_test.sh
+++ b/scripts/unit_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-go test -v $(go list ./... | grep -v '/vendor\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerbuddy+')
+go test -v $(go list ./... | grep -v '/vendor\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerpilot+')

--- a/services/services.go
+++ b/services/services.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/joyent/containerbuddy/discovery"
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/discovery"
+	"github.com/joyent/containerpilot/utils"
 )
 
 // Service configures the service, discovery data, and health checks

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/utils"
 )
 
 func TestHealthCheck(t *testing.T) {

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,12 +1,12 @@
-# Containerbuddy Telemetry
+# ContainerPilot Telemetry
 
-If a `telemetry` option is provided, Containerbuddy will expose a [Prometheus](http://prometheus.io) HTTP client interface that can be used to scrape performance telemetry. The telemetry interface is advertised as a service to the discovery service similar to services configured via the `services` block. Each `sensor` for the telemetry service will run periodically and record values in the [Prometheus client library](https://github.com/prometheus/client_golang). A Prometheus server can then make HTTP requests to the telemetry endpoint.
+If a `telemetry` option is provided, ContainerPilot will expose a [Prometheus](http://prometheus.io) HTTP client interface that can be used to scrape performance telemetry. The telemetry interface is advertised as a service to the discovery service similar to services configured via the `services` block. Each `sensor` for the telemetry service will run periodically and record values in the [Prometheus client library](https://github.com/prometheus/client_golang). A Prometheus server can then make HTTP requests to the telemetry endpoint.
 
 ### Configuring Telemetry
 
-The top-level telemetry configuration defines the telemetry HTTP endpoint. This endpoint will be advertised to Consul (or other discovery service) just as a typical Containerbuddy `service` block is. The service will be called `containerbuddy` and will be served on the path `/metrics`. The telemetry service will send periodic heartbeats to the discovery service to identify that it is still operating. Unlike a typical Containerbuddy service, there is no user-defined health check for the telemetry service endpoint, and you don't need to configure the poll/TTL; it will send a 15 second heartbeat every 5 seconds.
+The top-level telemetry configuration defines the telemetry HTTP endpoint. This endpoint will be advertised to Consul (or other discovery service) just as a typical ContainerPilot `service` block is. The service will be called `containerpilot` and will be served on the path `/metrics`. The telemetry service will send periodic heartbeats to the discovery service to identify that it is still operating. Unlike a typical ContainerPilot service, there is no user-defined health check for the telemetry service endpoint, and you don't need to configure the poll/TTL; it will send a 15 second heartbeat every 5 seconds.
 
-A minimal configuration for Containerbuddy including telemetry might look like this:
+A minimal configuration for ContainerPilot including telemetry might look like this:
 
 ```json
 {
@@ -35,23 +35,23 @@ The fields are as follows:
 - `port` is the port the telemetry service will advertise to the discovery service. (Default value is 9090.)
 - `interfaces` is an optional single or array of interface specifications. If given, the IP of the service will be obtained from the first interface specification that matches. (Default value is `["eth0:inet"]`)
 - `tags` is an optional array of tags. If the discovery service supports it (Consul does), the service will register itself with these tags.
-- `sensors` is an optional array of sensor configurations (see below). If no sensors are provided, then the telemetry endpoint will still be exposed and will show only telemetry about Containerbuddy internals.
+- `sensors` is an optional array of sensor configurations (see below). If no sensors are provided, then the telemetry endpoint will still be exposed and will show only telemetry about ContainerPilot internals.
 
 ### Configuring Sensors
 
 The `sensors` field is a list of user-defined sensors that the telemetry service will use to collect telemetry. Each time a sensor is polled, the user-defined `check` executable will be run. If the value that the `check` returns from stdout can be parsed as a 64-bit float, then the telemetry collector will receive that value.
 
-*The protocol between Containerbuddy and the sensors is a preview and may change. Although we'll attempt to keep backwards compatibility with sensors as described below, as real-world use cases are developed we may discover that the current format is more limited than we'd like. If you're using telemetry, be sure to review the changelogs of the next few releases.*
+*The protocol between ContainerPilot and the sensors is a preview and may change. Although we'll attempt to keep backwards compatibility with sensors as described below, as real-world use cases are developed we may discover that the current format is more limited than we'd like. If you're using telemetry, be sure to review the changelogs of the next few releases.*
 
 The fields for a sensor are as follows:
 
-- `namespace`, `subsystem`, and `name` are the names that the Prometheus client library will use to construct the name for the telemetry. These three names are concatenated with underscores `_` to become the final name that is scraped recorded by Prometheus. In the example above the metric recorded would be named `my_namespace_my_subsystem_my_event_count`. You can leave off the `namespace` and `subsystem` values and put everything into the `name` field if desired; the option to provide these other fields is simply for convenience of those who might be generating Containerbuddy configurations programmatically. Please see the [Prometheus documents on naming](http://prometheus.io/docs/practices/naming/) for best practices on how to name your telemetry.
+- `namespace`, `subsystem`, and `name` are the names that the Prometheus client library will use to construct the name for the telemetry. These three names are concatenated with underscores `_` to become the final name that is scraped recorded by Prometheus. In the example above the metric recorded would be named `my_namespace_my_subsystem_my_event_count`. You can leave off the `namespace` and `subsystem` values and put everything into the `name` field if desired; the option to provide these other fields is simply for convenience of those who might be generating ContainerPilot configurations programmatically. Please see the [Prometheus documents on naming](http://prometheus.io/docs/practices/naming/) for best practices on how to name your telemetry.
 - `help` is the help text that will be associated with the metric recorded by Prometheus. This is useful for debugging by giving a more verbose description.
 - `type` is the type of collector Prometheus will use (one of `counter`, `gauge`, `histogram` or `summary`). See [below](#Collector_types) for details.
 - `poll` is the time in seconds between running the `check`.
 - `check` is the executable (and its arguments) that is called when it is time to perform a telemetry collection.
 
-The check executable is expected to return via stdout a value that can be parsed as a single 64-bit float number. Whitespace will be trimmed, but any other text in the stdout of the executable will cause the metric to be dropped. If you need to return additional information for logging, you should return this via stderr (which Containerbuddy will pass along to the Docker engine).
+The check executable is expected to return via stdout a value that can be parsed as a single 64-bit float number. Whitespace will be trimmed, but any other text in the stdout of the executable will cause the metric to be dropped. If you need to return additional information for logging, you should return this via stderr (which ContainerPilot will pass along to the Docker engine).
 
 For example, a `check` field like `"check": ["/usr/bin/free"]` is not a working check because the output contains multiple fields as well as text.
 
@@ -68,7 +68,7 @@ This check script will return exactly one numeric value on stdout, and sends add
 
 ### Collector types
 
-Containerbuddy supports all four of the [metric types](http://prometheus.io/docs/concepts/metric_types/) available in the Prometheus API. Briefly these are:
+ContainerPilot supports all four of the [metric types](http://prometheus.io/docs/concepts/metric_types/) available in the Prometheus API. Briefly these are:
 
 *Counter*
 

--- a/telemetry/sensors.go
+++ b/telemetry/sensors.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/telemetry/sensors_test.go
+++ b/telemetry/sensors_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/joyent/containerbuddy/utils"
+	"github.com/joyent/containerpilot/utils"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -30,7 +30,7 @@ type Telemetry struct {
 func NewTelemetry(raw json.RawMessage) (*Telemetry, error) {
 	t := &Telemetry{
 		Port:        9090,
-		ServiceName: "containerbuddy",
+		ServiceName: "containerpilot",
 		Url:         "/metrics",
 		TTL:         15,
 		Poll:        5,
@@ -45,7 +45,7 @@ func NewTelemetry(raw json.RawMessage) (*Telemetry, error) {
 	}
 	// note that we don't return an error if there are no sensors
 	// because the prometheus handler will still pick up metrics
-	// internal to Containerbuddy (i.e. the golang runtime)
+	// internal to ContainerPilot (i.e. the golang runtime)
 	if t.SensorConfigs != nil {
 		if sensors, err := NewSensors(t.SensorConfigs); err != nil {
 			return nil, err


### PR DESCRIPTION
We're renaming Containerbuddy to ContainerPilot to simplify and clarify the relationship between autopilot pattern—the approach to automating our applications—and ContainerPilot—the shared library that makes it easy to build autopilot pattern applications.

@misterbisson this PR renames Containerbuddy to be ContainerPilot.

```
$ grep -rni buddy *
$ echo $?
1
```