### PR TITLE
Use a pointer receiver on Backend.PollAction

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -60,7 +60,7 @@ func (b Backend) PollTime() int {
 // PollAction implements Pollable for Backend.
 // If the values in the discovery service have changed since the last run,
 // we fire the on change handler.
-func (b Backend) PollAction() {
+func (b *Backend) PollAction() {
 	if b.CheckForUpstreamChanges() {
 		b.OnChange()
 	}

--- a/utils/run_test.go
+++ b/utils/run_test.go
@@ -32,3 +32,14 @@ func TestRunNothing(t *testing.T) {
 		t.Errorf("Expected exit (0,nil) but got (%d,%s)", code, err)
 	}
 }
+
+func TestReuseCmd(t *testing.T) {
+	cmd := ArgsToCmd([]string{"true"})
+	if code, err := Run(cmd); code != 0 || err != nil {
+		t.Errorf("Expected exit (0,nil) but got (%d,%s)", code, err)
+	}
+	cmd = ArgsToCmd(cmd.Args)
+	if code, err := Run(cmd); code != 0 || err != nil {
+		t.Errorf("Expected exit (0,nil) but got (%d,%s)", code, err)
+	}
+}


### PR DESCRIPTION
If the PollAction does not use a pointer receiver (as we're doing on Service and Sensor), then the Backend's healthCheckCmd will never be reset and the next onChange event will fail with the error "already running".

cc @justenwalker @misterbisson 