### PR TITLE
Fix panic in json config highlight function

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -277,11 +277,17 @@ func highlightError(data []byte, pos int64) (int, int, string) {
 		readBytes := int64(len(scanner.Bytes()))
 		offset += readBytes
 		if offset >= pos-1 {
-			highlight = fmt.Sprintf("%s^", strings.Repeat("-", int(7+col-1)))
+			count := int(7 + col - 1)
+			if count > 0 {
+				highlight = fmt.Sprintf("%s^", strings.Repeat("-", count))
+			}
 			break
 		}
 		col -= readBytes + 1
 		line++
+	}
+	if col < 0 {
+		highlight = "Do you have an extra comma somewhere?"
 	}
 	return line, int(col), fmt.Sprintf("%s%s%s", prevLine, thisLine, highlight)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -176,6 +176,18 @@ func TestJSONTemplateParseError2(t *testing.T) {
 		"Parse error at line:col [5:5]")
 }
 
+func TestParseTrailingComma(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	testParseExpectError(t,
+		`{
+			"consul": "consul:8500",
+			"tasks": [{
+				"command": ["echo","hi"]
+			},
+		]
+	}`, "Do you have an extra comma somewhere?")
+}
+
 func TestMetricServiceCreation(t *testing.T) {
 
 	jsonFragment := []byte(`{


### PR DESCRIPTION
- Guard against negative column values which cause a panic when drawing
  the hightlight arrow.
- If column is negative, instead print message about an extra comma,
  which is the most likely case for this error.

Fixes #125