### PR TITLE
Implement Periodic Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,15 @@ The format of the JSON file configuration is as follows:
         "check": ["/bin/sensor.sh"]
       }
     ]
-  }
+  },
+  "tasks": [
+    {
+      "name": "task",
+      "command": ["/bin/task.sh","arg1"],
+      "frequency": "1500ms",
+      "timeout": "100ms"
+    }
+  ]
 }
 ```
 
@@ -203,6 +211,16 @@ If a `telemetry` option is provided, ContainerPilot will expose a [Prometheus](h
 
 Details of how to configure the telemetry endpoint and how the telemetry endpoint works can be found in the [telemetry README](https://github.com/joyent/containerpilot/blob/master/telemetry/README.md).
 
+#### Tasks (Optional):
+
+Tasks are commands that are run periodically. They are typically used to perform housekeeping such as incremental back-ups, or pushing metrics to systems that cannot collect metrics through service discovery like Prometheus.
+
+Tasks are defined the following properties:
+
+- `command` is the executable (and its arguments) that will run when the task executes.
+- `frequency` is the time between executions of the task. Supports milliseconds, seconds, minutes. The frequency must be a positive non-zero duration with a time unit suffix. (Example: `60s`) Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `timeout` is the amount of time to wait before forcibly killing the task.  Tasks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This value is optional and defaults to the `frequency`
+- `name` is a friendly name given to the task for logging purposes - this has no effect on the task execution. This value is optional, and defaults to the `command` if not given.
 
 #### Other fields:
 

--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ Tasks are commands that are run periodically. They are typically used to perform
 Tasks are defined the following properties:
 
 - `command` is the executable (and its arguments) that will run when the task executes.
-- `frequency` is the time between executions of the task. Supports milliseconds, seconds, minutes. The frequency must be a positive non-zero duration with a time unit suffix. (Example: `60s`) Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
-- `timeout` is the amount of time to wait before forcibly killing the task.  Tasks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This value is optional and defaults to the `frequency`
+- `frequency` is the time between executions of the task. Supports milliseconds, seconds, minutes. The frequency must be a positive non-zero duration with a time unit suffix. (Example: `60s`) Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`. The minimum frequency is `1ms`
+- `timeout` is the amount of time to wait before forcibly killing the task.  Tasks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This value is optional and defaults to the `frequency`. The minimum timeout is `1ms`
 - `name` is a friendly name given to the task for logging purposes - this has no effect on the task execution. This value is optional, and defaults to the `command` if not given.
 
 #### Other fields:

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Tasks are defined the following properties:
 - `timeout` is the amount of time to wait before forcibly killing the task.  Tasks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This value is optional and defaults to the `frequency`. The minimum timeout is `1ms`
 - `name` is a friendly name given to the task for logging purposes - this has no effect on the task execution. This value is optional, and defaults to the `command` if not given.
 
+*Note on task frequency:* **pick a frequency greater than 50ms**. Although the task configuration permits frequencies as fast a 1ms, the overhead of spawning a process and its lifecycle is likely to be anywhere from 2ms to 25ms. Your task may not be able to run at all, or it might always be killed before it gets any useful work done.
+
 #### Other fields:
 
 - `onStart` is the executable (and its arguments) that will be called immediately prior to starting the shimmed application. This field is optional. If the `onStart` handler returns a non-zero exit code, ContainerPilot will exit.

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -67,6 +67,11 @@ func (b *Backend) PollAction() {
 	}
 }
 
+// PollStop does nothing in a Backend
+func (b *Backend) PollStop() {
+	// Nothing to do
+}
+
 // CheckForUpstreamChanges checks the service discovery endpoint for any changes
 // in a dependent backend. Returns true when there has been a change.
 func (b *Backend) CheckForUpstreamChanges() bool {

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/utils"
 )
@@ -84,6 +85,7 @@ func (b *Backend) OnChange() (int, error) {
 		// reset command object because it can't be reused
 		b.onChangeCmd = utils.ArgsToCmd(b.onChangeCmd.Args)
 	}()
-	exitCode, err := utils.Run(b.onChangeCmd)
+
+	exitCode, err := utils.RunWithFields(b.onChangeCmd, log.Fields{"process": "OnChange", "backend": b.Name})
 	return exitCode, err
 }

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/utils"
@@ -53,8 +54,8 @@ func NewBackends(raw json.RawMessage, disc discovery.DiscoveryService) ([]*Backe
 
 // PollTime implements Pollable for Backend
 // It returns the backend's poll interval.
-func (b Backend) PollTime() int {
-	return b.Poll
+func (b Backend) PollTime() time.Duration {
+	return time.Duration(b.Poll) * time.Second
 }
 
 // PollAction implements Pollable for Backend.

--- a/config/config.go
+++ b/config/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	TelemetryConfig json.RawMessage `json:"telemetry,omitempty"`
 	Services        []*services.Service
 	Backends        []*backends.Backend
-	Tasks           []tasks.Task
+	Tasks           []*tasks.Task
 	Telemetry       *telemetry.Telemetry
 	PreStartCmd     *exec.Cmd
 	PreStopCmd      *exec.Cmd

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/joyent/containerpilot/backends"
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/services"
+	"github.com/joyent/containerpilot/tasks"
 	"github.com/joyent/containerpilot/telemetry"
 	"github.com/joyent/containerpilot/utils"
 )
@@ -55,9 +56,11 @@ type Config struct {
 	StopTimeout     int             `json:"stopTimeout"`
 	ServicesConfig  json.RawMessage `json:"services,omitempty"`
 	BackendsConfig  json.RawMessage `json:"backends,omitempty"`
+	TasksConfig     json.RawMessage `json:"tasks,omitempty"`
 	TelemetryConfig json.RawMessage `json:"telemetry,omitempty"`
 	Services        []*services.Service
 	Backends        []*backends.Backend
+	Tasks           []tasks.Task
 	Telemetry       *telemetry.Telemetry
 	PreStartCmd     *exec.Cmd
 	PreStopCmd      *exec.Cmd
@@ -204,6 +207,14 @@ func initializeConfig(cfg *Config) (*Config, error) {
 				cfg.Services = append(cfg.Services, telemetryService)
 			}
 		}
+	}
+
+	if cfg.TasksConfig != nil {
+		tasks, err := tasks.NewTasks(cfg.TasksConfig)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Tasks = tasks
 	}
 
 	configLock.Lock()

--- a/core/poll.go
+++ b/core/poll.go
@@ -1,8 +1,9 @@
 package core
 
 import (
-	"github.com/joyent/containerpilot/config"
 	"time"
+
+	"github.com/joyent/containerpilot/config"
 )
 
 // Set up polling functions and write their quit channels
@@ -20,6 +21,11 @@ func HandlePolling(cfg *config.Config) {
 			quit = append(quit, poll(sensor))
 		}
 		cfg.Telemetry.Serve()
+	}
+	if cfg.Tasks != nil {
+		for _, task := range cfg.Tasks {
+			task.Start()
+		}
 	}
 	cfg.QuitChannels = quit
 }

--- a/core/poll.go
+++ b/core/poll.go
@@ -33,7 +33,7 @@ func HandlePolling(cfg *config.Config) {
 // Every `pollTime` seconds, run the `PollingFunc` function.
 // Expect a bool on the quit channel to stop gracefully.
 func poll(pollable Pollable) chan bool {
-	ticker := time.NewTicker(time.Duration(pollable.PollTime()) * time.Second)
+	ticker := time.NewTicker(pollable.PollTime())
 	quit := make(chan bool)
 	go func() {
 		for {
@@ -52,6 +52,6 @@ func poll(pollable Pollable) chan bool {
 
 // Pollable is base abstraction for backends and services that support polling
 type Pollable interface {
-	PollTime() int
+	PollTime() time.Duration
 	PollAction()
 }

--- a/core/poll.go
+++ b/core/poll.go
@@ -24,7 +24,7 @@ func HandlePolling(cfg *config.Config) {
 	}
 	if cfg.Tasks != nil {
 		for _, task := range cfg.Tasks {
-			task.Start()
+			quit = append(quit, poll(task))
 		}
 	}
 	cfg.QuitChannels = quit

--- a/core/poll.go
+++ b/core/poll.go
@@ -43,6 +43,7 @@ func poll(pollable Pollable) chan bool {
 					pollable.PollAction()
 				}
 			case <-quit:
+				pollable.PollStop()
 				return
 			}
 		}
@@ -54,4 +55,5 @@ func poll(pollable Pollable) chan bool {
 type Pollable interface {
 	PollTime() time.Duration
 	PollAction()
+	PollStop()
 }

--- a/core/poll_test.go
+++ b/core/poll_test.go
@@ -7,7 +7,7 @@ import (
 
 type DummyPollable struct{}
 
-func (p DummyPollable) PollTime() int { return 1 }
+func (p DummyPollable) PollTime() time.Duration { return time.Duration(1) * time.Second }
 func (p DummyPollable) PollAction() {
 	time.Sleep(5 * time.Second)
 	panic("We should never reach this code because the channel should close.")

--- a/core/poll_test.go
+++ b/core/poll_test.go
@@ -12,6 +12,7 @@ func (p DummyPollable) PollAction() {
 	time.Sleep(5 * time.Second)
 	panic("We should never reach this code because the channel should close.")
 }
+func (p DummyPollable) PollStop() {}
 
 // Verify we have no obvious crashing paths in the poll code and that we handle
 // a closed channel immediately as expected and gracefully.

--- a/core/signals.go
+++ b/core/signals.go
@@ -50,7 +50,7 @@ func terminate(cfg *config.Config) {
 	})
 
 	// Run and wait for preStop command to exit
-	utils.Run(cfg.PreStopCmd)
+	utils.RunWithFields(cfg.PreStopCmd, log.Fields{"process": "PreStop"})
 
 	cmd := cfg.Command
 	if cmd == nil || cmd.Process == nil {

--- a/core/signals.go
+++ b/core/signals.go
@@ -100,9 +100,6 @@ func stopPolling(cfg *config.Config) {
 	for _, quit := range cfg.QuitChannels {
 		quit <- true
 	}
-	for _, task := range cfg.Tasks {
-		task.Stop()
-	}
 }
 
 type serviceFunc func(service *services.Service)

--- a/core/signals.go
+++ b/core/signals.go
@@ -100,6 +100,11 @@ func stopPolling(cfg *config.Config) {
 	for _, quit := range cfg.QuitChannels {
 		quit <- true
 	}
+	for _, task := range cfg.Tasks {
+		if err := task.Stop(); err != nil {
+			log.Errorf("Unable to stop task: %v", err)
+		}
+	}
 }
 
 type serviceFunc func(service *services.Service)

--- a/core/signals.go
+++ b/core/signals.go
@@ -101,9 +101,7 @@ func stopPolling(cfg *config.Config) {
 		quit <- true
 	}
 	for _, task := range cfg.Tasks {
-		if err := task.Stop(); err != nil {
-			log.Errorf("Unable to stop task: %v", err)
-		}
+		task.Stop()
 	}
 }
 

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -65,19 +65,16 @@ func TestTerminateSignal(t *testing.T) {
 
 	config := getSignalTestConfig()
 	startTime := time.Now()
-	quit := make(chan int, 1)
 	go func() {
 		if exitCode, _ := utils.ExecuteAndWait(config.Command); exitCode != 2 {
 			t.Fatalf("Expected exit code 2 but got %d", exitCode)
 		}
-		quit <- 1
 	}()
 	// we need time for the forked process to start up and this is async
 	runtime.Gosched()
 	time.Sleep(10 * time.Millisecond)
 
 	terminate(config)
-	close(quit)
 	elapsed := time.Since(startTime)
 	if elapsed.Seconds() > float64(config.StopTimeout) {
 		t.Fatalf("Expected elapsed time <= %d seconds, but was %.2f",

--- a/integration_tests/fixtures/app/Dockerfile
+++ b/integration_tests/fixtures/app/Dockerfile
@@ -13,6 +13,7 @@ COPY app-with-etcd.json /app-with-etcd.json
 COPY reload-app.sh /reload-app.sh
 COPY reload-app-etcd.sh /reload-app-etcd.sh
 COPY sensor.sh /sensor.sh
+COPY task.sh /task.sh
 
 # by default use app-consul.json, allows for override in docker-compose
 ENV CONTAINERPILOT=file:///app-with-consul.json

--- a/integration_tests/fixtures/app/app-with-consul.json
+++ b/integration_tests/fixtures/app/app-with-consul.json
@@ -1,6 +1,10 @@
 {
   "consul": "consul:8500",
   "preStart": "/reload-app.sh",
+  "logging": {
+    "level": "DEBUG",
+    "format": "text"
+  },
   "services": [
     {
       "name": "app",
@@ -37,5 +41,23 @@
         "check": ["/sensor.sh", "count"]
        }
     ]
-  }
+  },
+  "tasks": [
+    {
+      "name": "task1",
+      "command": ["/task.sh","0.2","/task1.txt"],
+      "frequency": "500ms"
+    },
+    {
+      "name": "task2",
+      "command": ["/task.sh","2","/task2.txt"],
+      "frequency": "1500ms"
+    },
+    {
+      "name": "task3",
+      "command": ["/task.sh","2","/task3.txt"],
+      "frequency": "1500ms",
+      "timeout": "100ms"
+    }
+  ]
 }

--- a/integration_tests/fixtures/app/task.sh
+++ b/integration_tests/fixtures/app/task.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SLEEP=${1:-"1"}
+FILE=${2:-"/tmp/test"}
+
+trap "echo INTERRUPTED >> $FILE" SIGINT SIGTERM SIGQUIT
+
+echo $(date +%s.%N) >> "$FILE"
+sleep $SLEEP &
+wait

--- a/integration_tests/tests/test_sighup_deadlock/run.sh
+++ b/integration_tests/tests/test_sighup_deadlock/run.sh
@@ -5,6 +5,11 @@ APP_ID="$(docker-compose ps -q app)"
 docker-compose run --no-deps test /go/bin/test_probe test_sighup_deadlock $APP_ID > /dev/null 2>&1
 result=$?
 TEST_ID=$(docker ps -l -f "ancestor=cpfix_test_probe" --format="{{.ID}}")
-docker logs $TEST_ID
+if [ $result -ne 0 ]; then
+  echo "==== TEST LOGS ===="
+  docker logs $TEST_ID
+  echo "==== APP LOGS ===="
+  docker logs $APP_ID
+fi
 docker rm -f $TEST_ID > /dev/null 2>&1
 exit $result

--- a/integration_tests/tests/test_tasks/docker-compose.yml
+++ b/integration_tests/tests/test_tasks/docker-compose.yml
@@ -1,0 +1,14 @@
+consul:
+    image: "cpfix_consul"
+    mem_limit: 128m
+    hostname: consul
+
+app:
+    image: "cpfix_app"
+    mem_limit: 128m
+    links:
+      - consul:consul
+    ports:
+      - 9090:9090
+    volumes:
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'

--- a/integration_tests/tests/test_tasks/run.sh
+++ b/integration_tests/tests/test_tasks/run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# start up consul and app
+docker-compose up -d consul
+sleep 2
+docker-compose up -d app
+
+APP_ID="$(docker-compose ps -q app)"
+
+sleep 3.5
+docker logs ${APP_ID} > ${APP_ID}.log
+docker exec ${APP_ID} cat /task1.txt > ${APP_ID}.task1
+docker exec ${APP_ID} cat /task2.txt > ${APP_ID}.task2
+docker exec ${APP_ID} cat /task3.txt > ${APP_ID}.task3
+
+PASS=0
+
+## TASK 1
+TASK1_TOS=$(cat ${APP_ID}.log | grep "task1 timeout" | wc -l | tr -d '[[:space:]]')
+TASK1_RUNS=$(cat ${APP_ID}.task1 | wc -l | tr -d '[[:space:]]')
+rm ${APP_ID}.task1
+
+if [ $TASK1_RUNS -ne 7 ]; then
+  echo "Expected task1 to have 7 executions: got $TASK1_RUNS"
+  PASS=1
+fi
+if [ $TASK1_TOS -gt 0 ]; then
+  echo "Expected task1 to never time out: got $TASK1_TOS"
+  PASS=1
+fi
+
+## TASK 2
+TASK2_TOS=$(cat ${APP_ID}.log | grep "task2 timeout after 1500ms" | wc -l | tr -d '[[:space:]]')
+TASK2_RUNS=$(cat ${APP_ID}.task2 | wc -l | tr -d '[[:space:]]')
+rm ${APP_ID}.task2
+
+if [ $TASK2_RUNS -ne 2 ]; then
+  echo "Expected task2 to have 2 executions: got $TASK2_RUNS"
+  PASS=1
+fi
+if [ $TASK2_TOS -ne 1 ]; then
+  echo "Expected task2 to have 1 timeouts after 1500ms: got $TASK2_TOS"
+  PASS=1
+fi
+
+## TASK 3
+TASK3_TOS=$(cat ${APP_ID}.log | grep "task3 timeout after 100ms" | wc -l | tr -d '[[:space:]]')
+TASK3_RUNS=$(cat ${APP_ID}.task3 | wc -l | tr -d '[[:space:]]')
+
+if [ $TASK3_RUNS -ne 2 ]; then
+  echo "Expected task3 to have 2 executions: got $TASK3_RUNS"
+  PASS=1
+fi
+if [ $TASK3_TOS -ne 2 ]; then
+  echo "Expected task3 to have 2 timeouts after 100ms: got $TASK3_TOS"
+  PASS=1
+fi
+
+rm ${APP_ID}.task3
+
+rm ${APP_ID}.log
+
+result=$PASS
+
+# cleanup
+docker-compose rm -f
+exit $result

--- a/makefile
+++ b/makefile
@@ -88,8 +88,9 @@ cover: docker
 	${DOCKERRUN} bash ./scripts/cover.sh
 
 # run integration tests
+TEST ?= "all"
 integration: build
-	./scripts/test.sh
+	./scripts/test.sh test $(TEST)
 
 # ------ Backends
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -133,7 +133,7 @@ run_tests() {
   FAILED=$TESTS_DIR/failed.log
   rm -f $FAILED
   TARGET="$1"
-  if [ -z "$TARGET" ]; then
+  if [ -z "$TARGET" ] || [ "$TARGET" = "all" ]; then
     ## Run All Tests
     for TDIR in $(find $TESTS_DIR -maxdepth 1 -mindepth 1 -type d ); do
       run_test $TDIR

--- a/scripts/unit_test.sh
+++ b/scripts/unit_test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-go test -v $(go list ./... | grep -v '/vendor\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerpilot+')
+go test -v $(go list ./... | grep -v '/vendor\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerpilot+') -bench .

--- a/services/services.go
+++ b/services/services.go
@@ -120,6 +120,11 @@ func (s *Service) PollAction() {
 	}
 }
 
+// PollStop does nothing in a Service
+func (s *Service) PollStop() {
+	// Nothing to do
+}
+
 // SendHeartbeat sends a heartbeat for this service
 func (s *Service) SendHeartbeat() {
 	s.discoveryService.SendHeartbeat(s.definition)

--- a/services/services.go
+++ b/services/services.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/utils"
 )
@@ -155,6 +156,6 @@ func (s *Service) CheckHealth() (int, error) {
 	if s.healthCheckCmd == nil {
 		return 0, nil
 	}
-	exitCode, err := utils.Run(s.healthCheckCmd)
+	exitCode, err := utils.RunWithFields(s.healthCheckCmd, log.Fields{"process": "health", "serviceName": s.Name, "serviceID": s.ID})
 	return exitCode, err
 }

--- a/services/services.go
+++ b/services/services.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/utils"
@@ -106,8 +107,8 @@ func parseService(s *Service, disc discovery.DiscoveryService) error {
 
 // PollTime implements Pollable for Service
 // It returns the service's poll interval.
-func (s Service) PollTime() int {
-	return s.Poll
+func (s Service) PollTime() time.Duration {
+	return time.Duration(s.Poll) * time.Second
 }
 
 // PollAction implements Pollable for Service.

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -1,0 +1,177 @@
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/joyent/containerpilot/utils"
+)
+
+// TaskConfig configures tasks that run periodically
+type TaskConfig struct {
+	Name      string   `json:"name"`
+	Args      []string `json:"command"`
+	Frequency string   `json:"frequency"`
+	Timeout   string   `json:"timeout,omitempty"`
+
+	freqDuration    time.Duration
+	timeoutDuration time.Duration
+	cmd             *exec.Cmd
+	quitChannel     chan int
+	lock            *sync.Mutex
+	ticker          *time.Ticker
+	logWriters      []io.WriteCloser
+}
+
+// Task a task that runs periodically until killed
+type Task interface {
+	Start() error
+	Stop() error
+}
+
+func (t *TaskConfig) closeLogs() {
+	if t.logWriters == nil {
+		return
+	}
+	for _, w := range t.logWriters {
+		if err := w.Close(); err != nil {
+			log.Errorf("Unable to close log writer : %v", err)
+		}
+	}
+}
+
+// NewTasks parses json config into an array of Tasks
+func NewTasks(raw json.RawMessage) ([]Task, error) {
+	var tasks []Task
+	if raw == nil {
+		return tasks, nil
+	}
+	var configs []*TaskConfig
+	if err := json.Unmarshal(raw, &configs); err != nil {
+		return nil, fmt.Errorf("Task configuration error: %v", err)
+	}
+	for _, t := range configs {
+		if err := parseTask(t); err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, nil
+}
+
+func parseTask(task *TaskConfig) error {
+	if task.Args == nil || len(task.Args) == 0 {
+		return fmt.Errorf("Task did not provide a command")
+	}
+	if task.Name == "" {
+		task.Name = strings.Join(task.Args, " ")
+	}
+	freq, err := time.ParseDuration(task.Frequency)
+	if err != nil {
+		return fmt.Errorf("Unable to parse frequency %s: %v", task.Frequency, err)
+	}
+	task.freqDuration = freq
+	task.timeoutDuration = freq
+	task.lock = &sync.Mutex{}
+	if task.Timeout != "" {
+		timeout, err := time.ParseDuration(task.Timeout)
+		if err != nil {
+			return fmt.Errorf("Unable to parse timeout %s: %v", task.Timeout, err)
+		}
+		task.timeoutDuration = timeout
+	} else {
+		task.Timeout = task.Frequency
+	}
+	task.quitChannel = make(chan int)
+	return nil
+}
+
+// Start starts the task
+func (t *TaskConfig) Start() error {
+
+	t.ticker = time.NewTicker(t.freqDuration)
+
+	go func() {
+		for {
+			select {
+			case <-t.ticker.C:
+				t.execute()
+			case <-t.quitChannel:
+				t.ticker.Stop()
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (t *TaskConfig) kill(cmd *exec.Cmd) error {
+	if cmd != nil && cmd.Process != nil {
+		log.Warnf("Killing task %s: %d", t.Name, cmd.Process.Pid)
+		return cmd.Process.Kill()
+	}
+	return nil
+}
+
+func (t *TaskConfig) execute() {
+	t.lock.Lock()
+	cmd := utils.ArgsToCmd(t.Args)
+	t.cmd = cmd
+	fields := make(map[string]interface{})
+	fields["task"] = t.Name
+	t.logWriters = []io.WriteCloser{
+		utils.NewLogWriter(fields, 5),
+		utils.NewLogWriter(fields, 4),
+	}
+	cmd.Stdout = t.logWriters[0]
+	cmd.Stderr = t.logWriters[1]
+	if err := cmd.Start(); err != nil {
+		defer t.lock.Unlock()
+		defer t.closeLogs()
+		log.Errorf("Unable to start task %s: %v", t.Name, err)
+		return
+	}
+	t.lock.Unlock()
+	t.run(cmd)
+}
+
+func (t *TaskConfig) run(cmd *exec.Cmd) {
+	defer t.closeLogs()
+	ticker := time.NewTicker(t.timeoutDuration)
+	quit := make(chan int)
+	go func() {
+		defer ticker.Stop()
+		select {
+		case <-ticker.C:
+			log.Warnf("Task %s timeout after %s: '%s'", t.Name, t.Timeout, t.Args)
+			if err := t.kill(cmd); err != nil {
+				log.Errorf("Error killing task %s: %v", t.Name, err)
+			}
+			// Swallow quit signal
+			<-quit
+			return
+		case <-quit:
+			return
+		}
+	}()
+	_, err := cmd.Process.Wait()
+	if err != nil {
+		log.Errorf("Task %s exited with error: %v", t.Name, err)
+	}
+	quit <- 0
+}
+
+// Stop stops a task from executing and kills the currently running execution
+func (t *TaskConfig) Stop() error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	log.Infof("task.Stop: %s", t.Name)
+	t.quitChannel <- 0
+	return t.kill(t.cmd)
+}

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -134,6 +134,7 @@ func (t *TaskConfig) kill(cmd *exec.Cmd) error {
 }
 
 func (t *TaskConfig) execute() {
+	log.Debugf("task[%s].execute init", t.Name)
 	cmd := utils.ArgsToCmd(t.Args)
 	t.cmd = cmd
 	fields := make(map[string]interface{})
@@ -145,6 +146,7 @@ func (t *TaskConfig) execute() {
 	cmd.Stdout = t.logWriters[0]
 	cmd.Stderr = t.logWriters[1]
 	defer t.closeLogs()
+	log.Debugf("task[%s].execute start", t.Name)
 	if err := cmd.Start(); err != nil {
 		log.Errorf("Unable to start task %s: %v", t.Name, err)
 		return

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -94,8 +94,7 @@ func (t *Task) PollAction() {
 	log.Debugf("task[%s].PollAction", t.Name)
 	cmd := utils.ArgsToCmd(t.Args)
 	t.cmd = cmd
-	fields := make(map[string]interface{})
-	fields["task"] = t.Name
+	fields := log.Fields{"process": "task", "task": t.Name}
 	stdout := utils.NewLogWriter(fields, log.InfoLevel)
 	stderr := utils.NewLogWriter(fields, log.DebugLevel)
 	t.logWriters = []io.WriteCloser{stdout, stderr}

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -88,12 +88,11 @@ func (t *Task) PollAction() {
 	t.cmd = cmd
 	fields := make(map[string]interface{})
 	fields["task"] = t.Name
-	t.logWriters = []io.WriteCloser{
-		utils.NewLogWriter(fields, 5),
-		utils.NewLogWriter(fields, 4),
-	}
-	cmd.Stdout = t.logWriters[0]
-	cmd.Stderr = t.logWriters[1]
+	stdout := utils.NewLogWriter(fields, log.InfoLevel)
+	stderr := utils.NewLogWriter(fields, log.DebugLevel)
+	t.logWriters = []io.WriteCloser{stdout, stderr}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	defer t.closeLogs()
 	log.Debugf("task[%s].PollAction start", t.Name)
 	if err := cmd.Start(); err != nil {

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -1,0 +1,76 @@
+package tasks
+
+import "testing"
+import "time"
+import "io/ioutil"
+import "os"
+import "reflect"
+
+func TestTaskConfig(t *testing.T) {
+	tmpf, err := ioutil.TempFile("", "gotest")
+	defer func() {
+		tmpf.Close()
+		os.Remove(tmpf.Name())
+	}()
+	if err != nil {
+		t.Fatalf("Unexpeced error: %v", err)
+	}
+	task := &TaskConfig{
+		Args:      []string{"testdata/test.sh", "echoOut", ".", tmpf.Name()},
+		Frequency: "100ms",
+	}
+	err = parseTask(task)
+	if err != nil {
+		t.Fatalf("Unexpeced error: %v", err)
+	}
+	// Should print 10 dots (1 per ms)
+	expected := []byte("..........")
+	task.Start()
+	ticker := time.NewTicker(1050 * time.Millisecond)
+	select {
+	case <-ticker.C:
+		task.Stop()
+	}
+	content, err := ioutil.ReadAll(tmpf)
+	if err != nil {
+		t.Fatalf("Unexpeced error: %v", err)
+	}
+	if !reflect.DeepEqual(expected, content) {
+		t.Errorf("Expected %v but got %v", expected, content)
+	}
+}
+
+func TestScheduledTaskTimeoutConfig(t *testing.T) {
+	tmpf, err := ioutil.TempFile("", "gotest")
+	defer func() {
+		tmpf.Close()
+		os.Remove(tmpf.Name())
+	}()
+	if err != nil {
+		t.Fatalf("Unexpeced error: %v", err)
+	}
+	task := &TaskConfig{
+		Args:      []string{"testdata/test.sh", "printDots", tmpf.Name()},
+		Frequency: "1000ms",
+		Timeout:   "200ms",
+	}
+	err = parseTask(task)
+	if err != nil {
+		t.Fatalf("Unexpeced error: %v", err)
+	}
+	// Should print 2 dots (timeout 250ms after printing 1 dot every 100ms)
+	expected := []byte("..")
+	task.Start()
+	ticker := time.NewTicker(1050 * time.Millisecond)
+	select {
+	case <-ticker.C:
+		task.Stop()
+	}
+	content, err := ioutil.ReadAll(tmpf)
+	if err != nil {
+		t.Fatalf("Unexpeced error: %v", err)
+	}
+	if !reflect.DeepEqual(expected, content) {
+		t.Errorf("Expected %v but got %v", expected, content)
+	}
+}

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -1,6 +1,7 @@
 package tasks
 
 import "testing"
+import "runtime"
 import "time"
 import "io/ioutil"
 import "os"
@@ -51,7 +52,7 @@ func TestScheduledTaskTimeoutConfig(t *testing.T) {
 	}
 	task := &TaskConfig{
 		Args:      []string{"testdata/test.sh", "printDots", tmpf.Name()},
-		Frequency: "1000ms",
+		Frequency: "400ms",
 		Timeout:   "200ms",
 	}
 	err = parseTask(task)
@@ -61,7 +62,10 @@ func TestScheduledTaskTimeoutConfig(t *testing.T) {
 	// Should print 2 dots (timeout 250ms after printing 1 dot every 100ms)
 	expected := []byte("..")
 	task.Start()
-	ticker := time.NewTicker(1050 * time.Millisecond)
+	// Ensure the task has time to start
+	runtime.Gosched()
+	// Wait for task to start + 250ms
+	ticker := time.NewTicker(650 * time.Millisecond)
 	select {
 	case <-ticker.C:
 		task.Stop()
@@ -71,6 +75,6 @@ func TestScheduledTaskTimeoutConfig(t *testing.T) {
 		t.Fatalf("Unexpeced error: %v", err)
 	}
 	if !reflect.DeepEqual(expected, content) {
-		t.Errorf("Expected %v but got %v", expected, content)
+		t.Errorf("Expected %s but got %s", expected, content)
 	}
 }

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -26,6 +27,73 @@ func poll(task *Task) chan bool {
 		}
 	}()
 	return quit
+}
+
+func expectParseError(t *testing.T, task *Task, errContains string) {
+	if err := parseTask(task); err != nil {
+		if !strings.Contains(err.Error(), errContains) {
+			t.Errorf("Expected error '%s' but got: %v", errContains, err)
+		}
+		return
+	}
+	t.Errorf("Expected error '%s' but didn't get any", errContains)
+}
+
+func expectNoParseError(t *testing.T, task *Task) {
+	if err := parseTask(task); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func expectDuration(t *testing.T, actual time.Duration, expectedString string) {
+	expected, err := time.ParseDuration(expectedString)
+	if err != nil {
+		t.Fatalf("expectedString '%s' failed to parse: %v", expectedString, err)
+	}
+	if expected != actual {
+		t.Errorf("expected duration %v but got %v", expected, actual)
+	}
+}
+
+func TestTaskParseDuration(t *testing.T) {
+	task := &Task{
+		Args:      []string{"/usr/bin/true"},
+		Frequency: "1ms",
+	}
+	expectNoParseError(t, task)
+	expectDuration(t, task.freqDuration, "1ms")
+	expectDuration(t, task.timeoutDuration, "1ms")
+
+	task = &Task{
+		Args:      []string{"/usr/bin/true"},
+		Frequency: "10s",
+		Timeout:   "10",
+	}
+	expectNoParseError(t, task)
+	expectDuration(t, task.freqDuration, "10s")
+	expectDuration(t, task.timeoutDuration, "10s")
+
+	task = &Task{
+		Args:      []string{"/usr/bin/true"},
+		Frequency: "10",
+		Timeout:   "1s",
+	}
+	expectNoParseError(t, task)
+	expectDuration(t, task.freqDuration, "10s")
+	expectDuration(t, task.timeoutDuration, "1s")
+
+	task.Frequency = "-1ms"
+	expectParseError(t, task, "Frequency -1ms cannot be less that 1ms")
+
+	task.Frequency = "1ns"
+	expectParseError(t, task, "Frequency 1ns cannot be less that 1ms")
+
+	task.Frequency = "1ms"
+	task.Timeout = "-1ms"
+	expectParseError(t, task, "Timeout -1ms cannot be less that 1ms")
+
+	task.Timeout = "1ns"
+	expectParseError(t, task, "Timeout 1ns cannot be less that 1ms")
 }
 
 func TestTask(t *testing.T) {

--- a/tasks/testdata/test.sh
+++ b/tasks/testdata/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+trap 'exit 2' SIGTERM
+
+usage() {
+    cat <<EOF
+usage: $0 [COMMAND]
+
+Does nothing.
+
+EOF
+}
+
+echoOut() {
+  echo -n "$1" >> $2
+}
+
+printDots() {
+  for i in {1..10}; do
+    echo -n "." >> "$1"
+    sleep 0.1
+  done
+}
+
+cmd="${1:-usage}"
+shift
+$cmd "$@"

--- a/telemetry/sensors.go
+++ b/telemetry/sensors.go
@@ -43,6 +43,11 @@ func (s *Sensor) PollAction() {
 	}
 }
 
+// PollStop does nothing in a Sensor
+func (s *Sensor) PollStop() {
+	// Nothing to do
+}
+
 func (s *Sensor) observe() (string, error) {
 	defer func() {
 		// reset command object because it can't be reused

--- a/telemetry/sensors.go
+++ b/telemetry/sensors.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/utils"
@@ -29,8 +30,8 @@ type Sensor struct {
 
 // PollTime implements Pollable for Sensor
 // It returns the sensor's poll interval.
-func (s Sensor) PollTime() int {
-	return s.Poll
+func (s Sensor) PollTime() time.Duration {
+	return time.Duration(s.Poll) * time.Second
 }
 
 // PollAction implements Pollable for Sensor.

--- a/utils/duration.go
+++ b/utils/duration.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ParseDuration parses the given duration with multiple type support
+// int (defaults to seconds)
+// string with units
+// string without units (default to seconds)
+func ParseDuration(duration interface{}) (time.Duration, error) {
+	switch t := duration.(type) {
+	default:
+		return time.Second, fmt.Errorf("unexpected duration of type %T\n", t)
+	case int64:
+		return time.Duration(t) * time.Second, nil
+	case int32:
+		return time.Duration(t) * time.Second, nil
+	case int16:
+		return time.Duration(t) * time.Second, nil
+	case int8:
+		return time.Duration(t) * time.Second, nil
+	case int:
+		return time.Duration(t) * time.Second, nil
+	case uint64:
+		return time.Duration(t) * time.Second, nil
+	case uint32:
+		return time.Duration(t) * time.Second, nil
+	case uint16:
+		return time.Duration(t) * time.Second, nil
+	case uint8:
+		return time.Duration(t) * time.Second, nil
+	case uint:
+		return time.Duration(t) * time.Second, nil
+	case string:
+		if i, err := strconv.Atoi(t); err == nil {
+			return time.ParseDuration(fmt.Sprintf("%ds", i))
+		}
+		return time.ParseDuration(t)
+	}
+}

--- a/utils/duration_test.go
+++ b/utils/duration_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func expectDuration(t *testing.T, in interface{}, expected time.Duration) {
+	actual, err := ParseDuration(in)
+	if err != nil {
+		t.Errorf("Expected %v but got error: %v", expected, err)
+	}
+	if actual != expected {
+		t.Errorf("Expected %v but got %v", expected, actual)
+	}
+}
+
+func expectError(t *testing.T, in interface{}, errContains string) {
+	actual, err := ParseDuration(in)
+	if err == nil {
+		t.Errorf("Expected error but got: %v", actual)
+	}
+	if !strings.Contains(err.Error(), errContains) {
+		t.Errorf("Expected error '*%s*' but got: %v", errContains, err)
+	}
+}
+
+func TestParseDuration(t *testing.T) {
+
+	// Bare ints
+	expectDuration(t, 1, time.Second)
+	expectDuration(t, 10, 10*time.Second)
+
+	// Other ints
+	expectDuration(t, int64(10), 10*time.Second)
+	expectDuration(t, int32(10), 10*time.Second)
+	expectDuration(t, int16(10), 10*time.Second)
+	expectDuration(t, int8(10), 10*time.Second)
+	expectDuration(t, uint64(10), 10*time.Second)
+	expectDuration(t, uint32(10), 10*time.Second)
+	expectDuration(t, uint16(10), 10*time.Second)
+	expectDuration(t, uint8(10), 10*time.Second)
+
+	// Without Units
+	expectDuration(t, "1", time.Second)
+	expectDuration(t, "10", 10*time.Second)
+
+	// With Units
+	expectDuration(t, "10ns", 10*time.Nanosecond)
+	expectDuration(t, "10us", 10*time.Microsecond)
+	expectDuration(t, "10ms", 10*time.Millisecond)
+	expectDuration(t, "10s", 10*time.Second)
+	expectDuration(t, "10m", 10*time.Minute)
+	expectDuration(t, "10h", 10*time.Hour)
+
+	// Some parse errors
+	expectError(t, "asf", "invalid duration")
+	expectError(t, "20yy", "unknown unit yy")
+
+	// Fractional
+	expectError(t, 10.10, "unexpected duration of type float")
+}

--- a/utils/log_writer.go
+++ b/utils/log_writer.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"bufio"
+	"io"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// NewLogWriter pipes stdout/err logs to logrus
+func NewLogWriter(fields log.Fields, level log.Level) io.WriteCloser {
+	r, w := io.Pipe()
+	go func() {
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			entry := log.WithFields(fields)
+			entry.Level = level
+			entry.Println(scanner.Text())
+		}
+	}()
+	return w
+}

--- a/utils/run_test.go
+++ b/utils/run_test.go
@@ -15,6 +15,12 @@ func TestRunSuccess(t *testing.T) {
 	}
 }
 
+func BenchmarkRunSuccess(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Run(StrToCmd("./testdata/test.sh doNothing"))
+	}
+}
+
 func TestRunFailed(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/utils/testdata/test.sh
+++ b/utils/testdata/test.sh
@@ -20,6 +20,10 @@ failStuff() {
     exit -1
 }
 
+doNothing() {
+  exit 0
+}
+
 sleepStuff() {
     echo "Sleeping 10 seconds..."
     sleep 10


### PR DESCRIPTION
For #87 (Periodic Tasks)

## Periodic Tasks

This feature adds periodic tasks which are defined by a new `tasks` section which is array of objects such as:

```json
"tasks": [
    {
      "name": "task",
      "command": ["/bin/task.sh","arg1"],
      "frequency": "1500ms",
      "timeout": "100ms"
    }
  ]
```

More information on usage is in the README

## Integration Tests - Single Test

I found it useful to run a single integration test at a time. I added that capability to the Makefile.

```
$ make integration TEST=test_tasks
```

## utils.NewLogWriter

One thing of note is that there are now a lot of commands mapping standard out/standard error directly to the main stderr/stdout. This is problematic if I like to keep my shimmed application logging to stdout and ContainerPilot to stderr.

I put in a utility function `utils. NewLogWriter ` which can be used as a pipe to `logrus`. This basically makes these commands log using the preferred logging framework rather than raw standard out/standard err. It might be generally useful for the other ancillary commands like `preStart` `preStop` `postStop` and anything else we run that is not the shimmed application.