### PR TITLE
Refactor: Config to Application State

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,7 @@
 {
 	"ImportPath": "github.com/joyent/containerpilot",
 	"GoVersion": "go1.6",
+	"GodepVersion": "v62",
 	"Deps": [
 		{
 			"ImportPath": "github.com/Sirupsen/logrus",
@@ -48,6 +49,10 @@
 		{
 			"ImportPath": "github.com/matttproud/golang_protobuf_extensions/pbutil",
 			"Rev": "d0c3fe89de86839aecf2e0579c40ba3bb336a453"
+		},
+		{
+			"ImportPath": "github.com/mitchellh/mapstructure",
+			"Rev": "d2dd0262208475919e1a362f675cfc0e7c10e905"
 		},
 		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus",

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -16,7 +16,7 @@ type Backend struct {
 	Name             string          `json:"name"`
 	Poll             int             `json:"poll"` // time in seconds
 	OnChangeExec     json.RawMessage `json:"onChange"`
-	Tag              string          `json:"tag,omitempty"`
+	Tag              string          `json:"tag"`
 	discoveryService discovery.DiscoveryService
 	lastState        interface{}
 	onChangeCmd      *exec.Cmd

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -13,10 +13,10 @@ import (
 
 // Backend represents a command to execute when another application changes
 type Backend struct {
-	Name             string          `json:"name"`
-	Poll             int             `json:"poll"` // time in seconds
-	OnChangeExec     json.RawMessage `json:"onChange"`
-	Tag              string          `json:"tag"`
+	Name             string      `json:"name"`
+	Poll             int         `json:"poll"` // time in seconds
+	OnChangeExec     interface{} `json:"onChange"`
+	Tag              string      `json:"tag"`
 	discoveryService discovery.DiscoveryService
 	lastState        interface{}
 	onChangeCmd      *exec.Cmd

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -1,7 +1,6 @@
 package backends
 
 import (
-	"encoding/json"
 	"fmt"
 	"os/exec"
 	"time"
@@ -13,21 +12,21 @@ import (
 
 // Backend represents a command to execute when another application changes
 type Backend struct {
-	Name             string      `json:"name"`
-	Poll             int         `json:"poll"` // time in seconds
-	OnChangeExec     interface{} `json:"onChange"`
-	Tag              string      `json:"tag"`
+	Name             string      `mapstructure:"name"`
+	Poll             int         `mapstructure:"poll"` // time in seconds
+	OnChangeExec     interface{} `mapstructure:"onChange"`
+	Tag              string      `mapstructure:"tag"`
 	discoveryService discovery.DiscoveryService
 	lastState        interface{}
 	onChangeCmd      *exec.Cmd
 }
 
-func NewBackends(raw json.RawMessage, disc discovery.DiscoveryService) ([]*Backend, error) {
+func NewBackends(raw []interface{}, disc discovery.DiscoveryService) ([]*Backend, error) {
 	if raw == nil {
 		return []*Backend{}, nil
 	}
 	backends := make([]*Backend, 0)
-	if err := json.Unmarshal(raw, &backends); err != nil {
+	if err := utils.DecodeRaw(raw, &backends); err != nil {
 		return nil, fmt.Errorf("Backend configuration error: %v", err)
 	}
 	for _, b := range backends {

--- a/backends/backends_test.go
+++ b/backends/backends_test.go
@@ -1,6 +1,7 @@
 package backends
 
 import (
+	"encoding/json"
 	"os/exec"
 	"reflect"
 	"testing"
@@ -41,7 +42,12 @@ func TestBackendsParse(t *testing.T) {
 }
 ]`)
 
-	if backends, err := NewBackends(jsonFragment, nil); err != nil {
+	var raw []interface{}
+	if err := json.Unmarshal(jsonFragment, &raw); err != nil {
+		t.Fatalf("Unexpected error decoding JSON: %v", err)
+	}
+
+	if backends, err := NewBackends(raw, nil); err != nil {
 		t.Fatalf("Could not parse backends JSON: %s", err)
 	} else {
 		validateCommandParsed(t, "onChange", backends[0].onChangeCmd,

--- a/config/commands.go
+++ b/config/commands.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/joyent/containerpilot/utils"
+	"github.com/prometheus/common/log"
+)
+
+// ParsePreStart ...
+func (cfg *Config) ParsePreStart() (*exec.Cmd, error) {
+	// onStart has been deprecated for preStart. Remove in 2.0
+	if cfg.PreStart != nil && cfg.OnStart != nil {
+		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use only the preStart option provided")
+	}
+
+	// alias the onStart behavior to preStart
+	if cfg.PreStart == nil && cfg.OnStart != nil {
+		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use the onStart option as a preStart")
+		cfg.PreStart = cfg.OnStart
+	}
+	return parseCommand("preStart", cfg.PreStart)
+}
+
+// ParsePreStop ...
+func (cfg *Config) ParsePreStop() (*exec.Cmd, error) {
+	return parseCommand("preStop", cfg.PreStop)
+}
+
+// ParsePostStop ...
+func (cfg *Config) ParsePostStop() (*exec.Cmd, error) {
+	return parseCommand("postStop", cfg.PostStop)
+}
+
+func parseCommand(name string, args interface{}) (*exec.Cmd, error) {
+	cmd, err := utils.ParseCommandArgs(args)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse `%s`: %s", name, err)
+	}
+	return cmd, nil
+}

--- a/config/commands.go
+++ b/config/commands.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os/exec"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/utils"
-	"github.com/prometheus/common/log"
 )
 
 // ParsePreStart ...

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ import (
 
 // Config is the top-level ContainerPilot Configuration
 type Config struct {
-	Consul          string          `json:"consul"`
+	Consul          interface{}     `json:"consul"`
 	Etcd            json.RawMessage `json:"etcd"`
 	LogConfig       *LogConfig      `json:"logging"`
 	OnStart         json.RawMessage `json:"onStart"`
@@ -46,12 +46,16 @@ const (
 // ParseDiscoveryService ...
 func (cfg *Config) ParseDiscoveryService() (discovery.DiscoveryService, error) {
 	var discoveryService discovery.DiscoveryService
+	var err error
 	discoveryCount := 0
 	for _, discoveryBackend := range []string{"Consul", "Etcd"} {
 		switch discoveryBackend {
 		case "Consul":
-			if cfg.Consul != "" {
-				discoveryService = discovery.NewConsulConfig(cfg.Consul)
+			if cfg.Consul != nil {
+				discoveryService, err = discovery.NewConsulConfig(cfg.Consul)
+				if err != nil {
+					return nil, err
+				}
 				discoveryCount++
 			}
 		case "Etcd":

--- a/config/config.go
+++ b/config/config.go
@@ -22,18 +22,18 @@ import (
 
 // Config is the top-level ContainerPilot Configuration
 type Config struct {
-	Consul          string          `json:"consul,omitempty"`
-	Etcd            json.RawMessage `json:"etcd,omitempty"`
-	LogConfig       *LogConfig      `json:"logging,omitempty"`
-	OnStart         json.RawMessage `json:"onStart,omitempty"`
-	PreStart        json.RawMessage `json:"preStart,omitempty"`
-	PreStop         json.RawMessage `json:"preStop,omitempty"`
-	PostStop        json.RawMessage `json:"postStop,omitempty"`
+	Consul          string          `json:"consul"`
+	Etcd            json.RawMessage `json:"etcd"`
+	LogConfig       *LogConfig      `json:"logging"`
+	OnStart         json.RawMessage `json:"onStart"`
+	PreStart        json.RawMessage `json:"preStart"`
+	PreStop         json.RawMessage `json:"preStop"`
+	PostStop        json.RawMessage `json:"postStop"`
 	StopTimeout     int             `json:"stopTimeout"`
-	ServicesConfig  json.RawMessage `json:"services,omitempty"`
-	BackendsConfig  json.RawMessage `json:"backends,omitempty"`
-	TasksConfig     json.RawMessage `json:"tasks,omitempty"`
-	TelemetryConfig json.RawMessage `json:"telemetry,omitempty"`
+	ServicesConfig  json.RawMessage `json:"services"`
+	BackendsConfig  json.RawMessage `json:"backends"`
+	TasksConfig     json.RawMessage `json:"tasks"`
+	TelemetryConfig json.RawMessage `json:"telemetry"`
 
 	ConfigFlag string
 }

--- a/config/config.go
+++ b/config/config.go
@@ -5,13 +5,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"flag"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"os/exec"
 	"strings"
-	"sync"
 
 	"github.com/joyent/containerpilot/backends"
 	"github.com/joyent/containerpilot/discovery"
@@ -19,13 +16,8 @@ import (
 	"github.com/joyent/containerpilot/tasks"
 	"github.com/joyent/containerpilot/telemetry"
 	"github.com/joyent/containerpilot/utils"
-)
 
-var (
-	// Version is the version for this build, set at build time via LDFLAGS
-	Version string
-	// GitHash is the short-form commit hash of this build, set at build time
-	GitHash string
+	log "github.com/Sirupsen/logrus"
 )
 
 // Passing around config as a context to functions would be the ideomatic way.
@@ -33,16 +25,6 @@ var (
 // effect function calls in the main goroutine. Wherever possible we should be
 // accessing via `GetConfig` at the "top" of a goroutine and then use the config
 // as context for a function after that.
-var (
-	globalConfig *Config
-	configLock   = new(sync.RWMutex)
-)
-
-func GetConfig() *Config {
-	configLock.RLock()
-	defer configLock.RUnlock()
-	return globalConfig
-}
 
 // Config is the top-level ContainerPilot Configuration
 type Config struct {
@@ -58,16 +40,8 @@ type Config struct {
 	BackendsConfig  json.RawMessage `json:"backends,omitempty"`
 	TasksConfig     json.RawMessage `json:"tasks,omitempty"`
 	TelemetryConfig json.RawMessage `json:"telemetry,omitempty"`
-	Services        []*services.Service
-	Backends        []*backends.Backend
-	Tasks           []*tasks.Task
-	Telemetry       *telemetry.Telemetry
-	PreStartCmd     *exec.Cmd
-	PreStopCmd      *exec.Cmd
-	PostStopCmd     *exec.Cmd
-	Command         *exec.Cmd
-	QuitChannels    []chan bool
-	ConfigFlag      string
+
+	ConfigFlag string
 }
 
 const (
@@ -75,73 +49,10 @@ const (
 	defaultStopTimeout int = 5
 )
 
-func LoadConfig() (*Config, error) {
-
-	var configFlag string
-	var versionFlag bool
-
-	if !flag.Parsed() {
-		flag.StringVar(&configFlag, "config", "",
-			"JSON config or file:// path to JSON config file.")
-		flag.BoolVar(&versionFlag, "version", false, "Show version identifier and quit.")
-		flag.Parse()
-	}
-	if versionFlag {
-		fmt.Printf("Version: %s\nGitHash: %s\n", Version, GitHash)
-		os.Exit(0)
-	}
-	if configFlag == "" {
-		configFlag = os.Getenv("CONTAINERPILOT")
-	}
-
-	if cfg, err := parseConfig(configFlag); err != nil {
-		return nil, err
-	} else {
-		return initializeConfig(cfg)
-	}
-}
-
-func ReloadConfig(configFlag string) (*Config, error) {
-	if cfg, err := parseConfig(configFlag); err != nil {
-		return nil, err
-	} else {
-		return initializeConfig(cfg)
-	}
-}
-
-func initializeConfig(cfg *Config) (*Config, error) {
+// ParseDiscoveryService ...
+func (cfg *Config) ParseDiscoveryService() (discovery.DiscoveryService, error) {
 	var discoveryService discovery.DiscoveryService
 	discoveryCount := 0
-
-	// onStart has been deprecated for preStart. Remove in 2.0
-	if cfg.PreStart != nil && cfg.OnStart != nil {
-		fmt.Println("The onStart option has been deprecated in favor of preStart. ContainerPilot will use only the preStart option provided")
-	}
-
-	// alias the onStart behavior to preStart
-	if cfg.PreStart == nil && cfg.OnStart != nil {
-		fmt.Println("The onStart option has been deprecated in favor of preStart. ContainerPilot will use the onStart option as a preStart")
-		cfg.PreStart = cfg.OnStart
-	}
-
-	preStartCmd, err := utils.ParseCommandArgs(cfg.PreStart)
-	if err != nil {
-		return nil, fmt.Errorf("Could not parse `preStart`: %s", err)
-	}
-	cfg.PreStartCmd = preStartCmd
-
-	preStopCmd, err := utils.ParseCommandArgs(cfg.PreStop)
-	if err != nil {
-		return nil, fmt.Errorf("Could not parse `preStop`: %s", err)
-	}
-	cfg.PreStopCmd = preStopCmd
-
-	postStopCmd, err := utils.ParseCommandArgs(cfg.PostStop)
-	if err != nil {
-		return nil, fmt.Errorf("Could not parse `postStop`: %s", err)
-	}
-	cfg.PostStopCmd = postStopCmd
-
 	for _, discoveryBackend := range []string{"Consul", "Etcd"} {
 		switch discoveryBackend {
 		case "Consul":
@@ -156,75 +67,124 @@ func initializeConfig(cfg *Config) (*Config, error) {
 			}
 		}
 	}
-
 	if discoveryCount == 0 {
 		return nil, errors.New("No discovery backend defined")
 	} else if discoveryCount > 1 {
 		return nil, errors.New("More than one discovery backend defined")
 	}
-
-	if cfg.LogConfig != nil {
-		err := cfg.LogConfig.init()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if cfg.StopTimeout == 0 {
-		cfg.StopTimeout = defaultStopTimeout
-	}
-
-	if backends, err := backends.NewBackends(cfg.BackendsConfig,
-		discoveryService); err != nil {
-		return nil, err
-	} else {
-		cfg.Backends = backends
-	}
-
-	if services, err := services.NewServices(cfg.ServicesConfig,
-		discoveryService); err != nil {
-		return nil, err
-	} else {
-		cfg.Services = services
-	}
-
-	if cfg.TelemetryConfig != nil {
-		if t, err := telemetry.NewTelemetry(cfg.TelemetryConfig); err != nil {
-			return nil, err
-		} else {
-			cfg.Telemetry = t
-			// create a new service for Telemetry
-			if telemetryService, err := services.NewService(
-				t.ServiceName,
-				t.Poll,
-				t.Port,
-				t.TTL,
-				t.Interfaces,
-				t.Tags,
-				discoveryService); err != nil {
-				return nil, err
-			} else {
-				cfg.Services = append(cfg.Services, telemetryService)
-			}
-		}
-	}
-
-	if cfg.TasksConfig != nil {
-		tasks, err := tasks.NewTasks(cfg.TasksConfig)
-		if err != nil {
-			return nil, err
-		}
-		cfg.Tasks = tasks
-	}
-
-	configLock.Lock()
-	globalConfig = cfg
-	configLock.Unlock()
-
-	return cfg, nil
+	return discoveryService, nil
 }
 
-func parseConfig(configFlag string) (*Config, error) {
+func parseCommand(name string, args json.RawMessage) (*exec.Cmd, error) {
+	cmd, err := utils.ParseCommandArgs(args)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse `%s`: %s", name, err)
+	}
+	return cmd, nil
+}
+
+// InitLogging ...
+func (cfg *Config) InitLogging() error {
+	if cfg.LogConfig != nil {
+		return cfg.LogConfig.init()
+	}
+	return nil
+}
+
+// ParsePreStart ...
+func (cfg *Config) ParsePreStart() (*exec.Cmd, error) {
+	// onStart has been deprecated for preStart. Remove in 2.0
+	if cfg.PreStart != nil && cfg.OnStart != nil {
+		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use only the preStart option provided")
+	}
+
+	// alias the onStart behavior to preStart
+	if cfg.PreStart == nil && cfg.OnStart != nil {
+		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use the onStart option as a preStart")
+		cfg.PreStart = cfg.OnStart
+	}
+	return parseCommand("preStart", cfg.PreStart)
+}
+
+// ParsePreStop ...
+func (cfg *Config) ParsePreStop() (*exec.Cmd, error) {
+	return parseCommand("preStop", cfg.PreStop)
+}
+
+// ParsePostStop ...
+func (cfg *Config) ParsePostStop() (*exec.Cmd, error) {
+	return parseCommand("postStop", cfg.PostStop)
+}
+
+// ParseBackends ...
+func (cfg *Config) ParseBackends(discoveryService discovery.DiscoveryService) ([]*backends.Backend, error) {
+	backends, err := backends.NewBackends(cfg.BackendsConfig, discoveryService)
+	if err != nil {
+		return nil, err
+	}
+	return backends, nil
+}
+
+// ParseServices ...
+func (cfg *Config) ParseServices(discoveryService discovery.DiscoveryService) ([]*services.Service, error) {
+	services, err := services.NewServices(cfg.ServicesConfig, discoveryService)
+	if err != nil {
+		return nil, err
+	}
+	return services, nil
+}
+
+// ParseStopTimeout ...
+func (cfg *Config) ParseStopTimeout() (int, error) {
+	if cfg.StopTimeout == 0 {
+		return defaultStopTimeout, nil
+	}
+	return cfg.StopTimeout, nil
+}
+
+// ParseTelemetry ...
+func (cfg *Config) ParseTelemetry() (*telemetry.Telemetry, error) {
+	if cfg.TelemetryConfig == nil {
+		return nil, nil
+	}
+	t, err := telemetry.NewTelemetry(cfg.TelemetryConfig)
+	if err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// CreateTelemetryService ...
+func CreateTelemetryService(t *telemetry.Telemetry, discoveryService discovery.DiscoveryService) (*services.Service, error) {
+	// create a new service for Telemetry
+	svc, err := services.NewService(
+		t.ServiceName,
+		t.Poll,
+		t.Port,
+		t.TTL,
+		t.Interfaces,
+		t.Tags,
+		discoveryService)
+	if err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+// ParseTasks ...
+func (cfg *Config) ParseTasks() ([]*tasks.Task, error) {
+	if cfg.TasksConfig == nil {
+		return nil, nil
+	}
+	tasks, err := tasks.NewTasks(cfg.TasksConfig)
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
+// ParseConfig ...
+func ParseConfig(configFlag string) (*Config, error) {
 	if configFlag == "" {
 		return nil, errors.New("-config flag is required")
 	}
@@ -245,7 +205,7 @@ func parseConfig(configFlag string) (*Config, error) {
 		return nil, fmt.Errorf(
 			"Could not apply template to config: %s", err)
 	}
-	cfg, err := unmarshalConfig(template)
+	cfg, err := UnmarshalConfig(template)
 	if cfg != nil {
 		// store so we can reload
 		cfg.ConfigFlag = configFlag
@@ -253,7 +213,8 @@ func parseConfig(configFlag string) (*Config, error) {
 	return cfg, err
 }
 
-func unmarshalConfig(data []byte) (*Config, error) {
+// UnmarshalConfig unmarshalls the raw config bytes into a Config struct
+func UnmarshalConfig(data []byte) (*Config, error) {
 	config := &Config{}
 	if err := json.Unmarshal(data, &config); err != nil {
 		syntax, ok := err.(*json.SyntaxError)

--- a/config/config.go
+++ b/config/config.go
@@ -20,12 +20,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-// Passing around config as a context to functions would be the ideomatic way.
-// But we need to support configuration reload from signals and have that reload
-// effect function calls in the main goroutine. Wherever possible we should be
-// accessing via `GetConfig` at the "top" of a goroutine and then use the config
-// as context for a function after that.
-
 // Config is the top-level ContainerPilot Configuration
 type Config struct {
 	Consul          string          `json:"consul,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -18,18 +18,18 @@ import (
 
 // Config is the top-level ContainerPilot Configuration
 type Config struct {
-	Consul          interface{}     `json:"consul"`
-	Etcd            interface{}     `json:"etcd"`
-	LogConfig       *LogConfig      `json:"logging"`
-	OnStart         interface{}     `json:"onStart"`
-	PreStart        interface{}     `json:"preStart"`
-	PreStop         interface{}     `json:"preStop"`
-	PostStop        interface{}     `json:"postStop"`
-	StopTimeout     int             `json:"stopTimeout"`
-	ServicesConfig  json.RawMessage `json:"services"`
-	BackendsConfig  json.RawMessage `json:"backends"`
-	TasksConfig     json.RawMessage `json:"tasks"`
-	TelemetryConfig json.RawMessage `json:"telemetry"`
+	Consul          interface{}   `json:"consul"`
+	Etcd            interface{}   `json:"etcd"`
+	LogConfig       *LogConfig    `json:"logging"`
+	OnStart         interface{}   `json:"onStart"`
+	PreStart        interface{}   `json:"preStart"`
+	PreStop         interface{}   `json:"preStop"`
+	PostStop        interface{}   `json:"postStop"`
+	StopTimeout     int           `json:"stopTimeout"`
+	ServicesConfig  []interface{} `json:"services"`
+	BackendsConfig  []interface{} `json:"backends"`
+	TasksConfig     []interface{} `json:"tasks"`
+	TelemetryConfig interface{}   `json:"telemetry"`
 
 	ConfigFlag string
 }

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ import (
 // Config is the top-level ContainerPilot Configuration
 type Config struct {
 	Consul          interface{}     `json:"consul"`
-	Etcd            json.RawMessage `json:"etcd"`
+	Etcd            interface{}     `json:"etcd"`
 	LogConfig       *LogConfig      `json:"logging"`
 	OnStart         json.RawMessage `json:"onStart"`
 	PreStart        json.RawMessage `json:"preStart"`
@@ -60,7 +60,10 @@ func (cfg *Config) ParseDiscoveryService() (discovery.DiscoveryService, error) {
 			}
 		case "Etcd":
 			if cfg.Etcd != nil {
-				discoveryService = discovery.NewEtcdConfig(cfg.Etcd)
+				discoveryService, err = discovery.NewEtcdConfig(cfg.Etcd)
+				if err != nil {
+					return nil, err
+				}
 				discoveryCount++
 			}
 		}

--- a/config/logging.go
+++ b/config/logging.go
@@ -14,8 +14,8 @@ import (
 // LogConfig configures the log levels
 type LogConfig struct {
 	Level  string `json:"level"`
-	Format string `json:"format,omitempty"`
-	Output string `json:"output,omitempty"`
+	Format string `json:"format"`
+	Output string `json:"output"`
 }
 
 var defaultLog = &LogConfig{

--- a/core/app.go
+++ b/core/app.go
@@ -278,10 +278,12 @@ func (a *App) Reload() error {
 
 	newCfg, err := config.ParseConfig(a.ConfigFlag)
 	if err != nil {
+		log.Errorf("Error parsing config: %v", err)
 		return err
 	}
 	newApp, err := InitializeApp(newCfg)
 	if err != nil {
+		log.Errorf("Error initializing config: %v", err)
 		return err
 	}
 

--- a/core/app.go
+++ b/core/app.go
@@ -173,6 +173,10 @@ func (a *App) Run() {
 	if 1 == os.Getpid() {
 		reapChildren()
 	}
+	command, err := utils.ParseCommandArgs(flag.Args())
+	if err != nil {
+		log.Errorf("Unable to parse command arguments: %v", err)
+	}
 	a.handleSignals()
 	// Run the preStart handler, if any, and exit if it returns an error
 	if preStartCode, err := utils.RunWithFields(a.PreStartCmd, log.Fields{"process": "PreStart"}); err != nil {
@@ -184,10 +188,10 @@ func (a *App) Run() {
 		// Run our main application and capture its stdout/stderr.
 		// This will block until the main application exits and then os.Exit
 		// with the exit code of that application.
-		a.Command = utils.ArgsToCmd(flag.Args())
-		a.Command.Stderr = os.Stderr
-		a.Command.Stdout = os.Stdout
-		code, err := utils.ExecuteAndWait(a.Command)
+		a.Command = command
+		command.Stderr = os.Stderr
+		command.Stdout = os.Stdout
+		code, err := utils.ExecuteAndWait(command)
 		if err != nil {
 			log.Println(err)
 		}

--- a/core/app.go
+++ b/core/app.go
@@ -300,6 +300,9 @@ func (a *App) load(newApp *App) {
 	a.Services = newApp.Services
 	a.Backends = newApp.Backends
 	a.StopTimeout = newApp.StopTimeout
+	if a.Telemetry != nil {
+		a.Telemetry.Shutdown()
+	}
 	a.Telemetry = newApp.Telemetry
 	a.Tasks = newApp.Tasks
 	a.HandleSignals()

--- a/core/app.go
+++ b/core/app.go
@@ -76,11 +76,7 @@ func LoadApp() (*App, error) {
 		configFlag = os.Getenv("CONTAINERPILOT")
 	}
 
-	cfg, err := config.ParseConfig(configFlag)
-	if err != nil {
-		return nil, err
-	}
-	app, err := NewApp(cfg)
+	app, err := NewApp(configFlag)
 	if err != nil {
 		return nil, err
 	}
@@ -88,8 +84,12 @@ func LoadApp() (*App, error) {
 }
 
 // NewApp creates a new App from the config
-func NewApp(cfg *config.Config) (*App, error) {
+func NewApp(configFlag string) (*App, error) {
 	a := EmptyApp()
+	cfg, err := config.ParseConfig(configFlag)
+	if err != nil {
+		return nil, err
+	}
 
 	// onStart has been deprecated for preStart. Remove in 2.0
 	if cfg.PreStart != nil && cfg.OnStart != nil {
@@ -282,12 +282,7 @@ func (a *App) Reload() error {
 	defer a.signalLock.Unlock()
 	log.Infof("Reloading configuration.")
 
-	newCfg, err := config.ParseConfig(a.ConfigFlag)
-	if err != nil {
-		log.Errorf("Error parsing config: %v", err)
-		return err
-	}
-	newApp, err := NewApp(newCfg)
+	newApp, err := NewApp(a.ConfigFlag)
 	if err != nil {
 		log.Errorf("Error initializing config: %v", err)
 		return err

--- a/core/app.go
+++ b/core/app.go
@@ -1,0 +1,339 @@
+package core
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/joyent/containerpilot/backends"
+	"github.com/joyent/containerpilot/config"
+	"github.com/joyent/containerpilot/discovery"
+	"github.com/joyent/containerpilot/services"
+	"github.com/joyent/containerpilot/tasks"
+	"github.com/joyent/containerpilot/telemetry"
+	"github.com/joyent/containerpilot/utils"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	// Version is the version for this build, set at build time via LDFLAGS
+	Version string
+	// GitHash is the short-form commit hash of this build, set at build time
+	GitHash string
+)
+
+// App ...
+type App struct {
+	DiscoveryService discovery.DiscoveryService
+	Services         []*services.Service
+	Backends         []*backends.Backend
+	Tasks            []*tasks.Task
+	Telemetry        *telemetry.Telemetry
+	PreStartCmd      *exec.Cmd
+	PreStopCmd       *exec.Cmd
+	PostStopCmd      *exec.Cmd
+	Command          *exec.Cmd
+	StopTimeout      int
+	QuitChannels     []chan bool
+	maintModeLock    *sync.RWMutex
+	signalLock       *sync.RWMutex
+	paused           bool
+	ConfigFlag       string
+}
+
+// NewApp ...
+func NewApp() *App {
+	app := &App{}
+	app.maintModeLock = &sync.RWMutex{}
+	app.signalLock = &sync.RWMutex{}
+	return app
+}
+
+// LoadApp ...
+func LoadApp() (*App, error) {
+
+	var configFlag string
+	var versionFlag bool
+
+	if !flag.Parsed() {
+		flag.StringVar(&configFlag, "config", "",
+			"JSON config or file:// path to JSON config file.")
+		flag.BoolVar(&versionFlag, "version", false, "Show version identifier and quit.")
+		flag.Parse()
+	}
+	if versionFlag {
+		fmt.Printf("Version: %s\nGitHash: %s\n", Version, GitHash)
+		os.Exit(0)
+	}
+	if configFlag == "" {
+		configFlag = os.Getenv("CONTAINERPILOT")
+	}
+
+	cfg, err := config.ParseConfig(configFlag)
+	if err != nil {
+		return nil, err
+	}
+	app, err := InitializeApp(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return app, nil
+}
+
+// InitializeApp creates a new App from the config
+func InitializeApp(cfg *config.Config) (*App, error) {
+	a := NewApp()
+
+	// onStart has been deprecated for preStart. Remove in 2.0
+	if cfg.PreStart != nil && cfg.OnStart != nil {
+		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use only the preStart option provided")
+	}
+
+	// alias the onStart behavior to preStart
+	if cfg.PreStart == nil && cfg.OnStart != nil {
+		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use the onStart option as a preStart")
+		cfg.PreStart = cfg.OnStart
+	}
+
+	preStartCmd, err := cfg.ParsePreStart()
+	if err != nil {
+		return nil, err
+	}
+	a.PreStartCmd = preStartCmd
+
+	preStopCmd, err := cfg.ParsePreStop()
+	if err != nil {
+		return nil, err
+	}
+	a.PreStopCmd = preStopCmd
+
+	postStopCmd, err := cfg.ParsePostStop()
+	if err != nil {
+		return nil, err
+	}
+	a.PostStopCmd = postStopCmd
+
+	stopTimeout, err := cfg.ParseStopTimeout()
+	if err != nil {
+		return nil, err
+	}
+	a.StopTimeout = stopTimeout
+
+	discoveryService, err := cfg.ParseDiscoveryService()
+	if err != nil {
+		return nil, err
+	}
+	a.DiscoveryService = discoveryService
+
+	backends, err := cfg.ParseBackends(discoveryService)
+	if err != nil {
+		return nil, err
+	}
+	a.Backends = backends
+
+	services, err := cfg.ParseServices(discoveryService)
+	if err != nil {
+		return nil, err
+	}
+	a.Services = services
+
+	telemetry, err := cfg.ParseTelemetry()
+	if err != nil {
+		return nil, err
+	}
+
+	if telemetry != nil {
+		telemetryService, err2 := config.CreateTelemetryService(telemetry, discoveryService)
+		if err2 != nil {
+			return nil, err2
+		}
+		a.Telemetry = telemetry
+		a.Services = append(a.Services, telemetryService)
+	}
+
+	tasks, err := cfg.ParseTasks()
+	if err != nil {
+		return nil, err
+	}
+	a.Tasks = tasks
+
+	return a, nil
+}
+
+// Run ...
+func (a *App) Run() {
+	// Run the preStart handler, if any, and exit if it returns an error
+	if preStartCode, err := utils.RunWithFields(a.PreStartCmd, log.Fields{"process": "PreStart"}); err != nil {
+		os.Exit(preStartCode)
+	}
+
+	// Set up handlers for polling and to accept signal interrupts
+	if 1 == os.Getpid() {
+		ReapChildren()
+	}
+	a.HandleSignals()
+	a.HandlePolling()
+
+	if len(flag.Args()) != 0 {
+		// Run our main application and capture its stdout/stderr.
+		// This will block until the main application exits and then os.Exit
+		// with the exit code of that application.
+		a.Command = utils.ArgsToCmd(flag.Args())
+		a.Command.Stderr = os.Stderr
+		a.Command.Stdout = os.Stdout
+		code, err := utils.ExecuteAndWait(a.Command)
+		if err != nil {
+			log.Println(err)
+		}
+		// Run the PostStop handler, if any, and exit if it returns an error
+		if postStopCode, err := utils.RunWithFields(a.PostStopCmd, log.Fields{"process": "PostStop"}); err != nil {
+			os.Exit(postStopCode)
+		}
+		os.Exit(code)
+	}
+
+	// block forever, as we're polling in the two polling functions and
+	// did not os.Exit by waiting on an external application.
+	select {}
+}
+
+// ToggleMaintenanceMode marks all services for maintenance
+func (a *App) ToggleMaintenanceMode() {
+	a.maintModeLock.RLock()
+	a.signalLock.Lock()
+	defer a.signalLock.Unlock()
+	defer a.maintModeLock.RUnlock()
+	a.paused = !a.paused
+	if a.paused {
+		a.forAllServices(markServiceForMaintenance)
+	}
+}
+
+// InMaintenanceMode checks if the App is in maintenance mode
+func (a *App) InMaintenanceMode() bool {
+	// we wrap access to `paused` in a RLock so that if we're in the middle of
+	// marking services for maintenance we don't get stale reads
+	a.maintModeLock.RLock()
+	defer a.maintModeLock.RUnlock()
+	return a.paused
+}
+
+// Terminate kills the application
+func (a *App) Terminate() {
+	a.signalLock.Lock()
+	defer a.signalLock.Unlock()
+	a.stopPolling()
+	a.forAllServices(deregisterService)
+
+	// Run and wait for preStop command to exit
+	utils.RunWithFields(a.PreStopCmd, log.Fields{"process": "PreStop"})
+
+	cmd := a.Command
+	if cmd == nil || cmd.Process == nil {
+		// Not managing the process, so don't do anything
+		return
+	}
+	if a.StopTimeout > 0 {
+		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+			log.Warnf("Error sending SIGTERM to application: %s", err)
+		} else {
+			time.AfterFunc(time.Duration(a.StopTimeout)*time.Second, func() {
+				log.Infof("Killing Process %#v", cmd.Process)
+				cmd.Process.Kill()
+			})
+			return
+		}
+	}
+	log.Infof("Killing Process %#v", a.Command.Process)
+	cmd.Process.Kill()
+}
+
+func (a *App) stopPolling() {
+	for _, quit := range a.QuitChannels {
+		quit <- true
+	}
+}
+
+func markServiceForMaintenance(service *services.Service) {
+	log.Infof("Marking for maintenance: %s", service.Name)
+	service.MarkForMaintenance()
+}
+
+func deregisterService(service *services.Service) {
+	log.Infof("Deregistering service: %s", service.Name)
+	service.Deregister()
+}
+
+// Reload ...
+func (a *App) Reload() error {
+	a.signalLock.Lock()
+	defer a.signalLock.Unlock()
+	log.Infof("Reloading configuration.")
+
+	newCfg, err := config.ParseConfig(a.ConfigFlag)
+	if err != nil {
+		return err
+	}
+	newApp, err := InitializeApp(newCfg)
+	if err != nil {
+		return err
+	}
+
+	a.stopPolling()
+	a.forAllServices(deregisterService)
+	signal.Reset()
+
+	a.load(newApp)
+	return nil
+}
+
+func (a *App) load(newApp *App) {
+	a.DiscoveryService = newApp.DiscoveryService
+	a.PostStopCmd = newApp.PostStopCmd
+	a.PreStopCmd = newApp.PreStopCmd
+	a.Services = newApp.Services
+	a.Backends = newApp.Backends
+	a.StopTimeout = newApp.StopTimeout
+	a.Telemetry = newApp.Telemetry
+	a.Tasks = newApp.Tasks
+	a.HandleSignals()
+	a.HandlePolling()
+}
+
+type serviceFunc func(service *services.Service)
+
+func (a *App) forAllServices(fn serviceFunc) {
+	for _, service := range a.Services {
+		fn(service)
+	}
+}
+
+// HandlePolling sets up polling functions and write their quit channels
+// back to our config
+func (a *App) HandlePolling() {
+	var quit []chan bool
+	for _, backend := range a.Backends {
+		quit = append(quit, a.poll(backend))
+	}
+	for _, service := range a.Services {
+		quit = append(quit, a.poll(service))
+	}
+	if a.Telemetry != nil {
+		for _, sensor := range a.Telemetry.Sensors {
+			quit = append(quit, a.poll(sensor))
+		}
+		a.Telemetry.Serve()
+	}
+	if a.Tasks != nil {
+		for _, task := range a.Tasks {
+			quit = append(quit, a.poll(task))
+		}
+	}
+	a.QuitChannels = quit
+}

--- a/core/app.go
+++ b/core/app.go
@@ -169,16 +169,15 @@ func NewApp(cfg *config.Config) (*App, error) {
 
 // Run starts the application and blocks until finished
 func (a *App) Run() {
-	// Run the preStart handler, if any, and exit if it returns an error
-	if preStartCode, err := utils.RunWithFields(a.PreStartCmd, log.Fields{"process": "PreStart"}); err != nil {
-		os.Exit(preStartCode)
-	}
-
 	// Set up handlers for polling and to accept signal interrupts
 	if 1 == os.Getpid() {
 		reapChildren()
 	}
 	a.handleSignals()
+	// Run the preStart handler, if any, and exit if it returns an error
+	if preStartCode, err := utils.RunWithFields(a.PreStartCmd, log.Fields{"process": "PreStart"}); err != nil {
+		os.Exit(preStartCode)
+	}
 	a.handlePolling()
 
 	if len(flag.Args()) != 0 {

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -58,7 +58,10 @@ func TestValidConfigParse(t *testing.T) {
 
 	os.Setenv("TEST", "HELLO")
 	os.Args = []string{"this", "-config", testJSON, "/testdata/test.sh", "valid1", "--debug"}
-	app, _ := LoadApp()
+	app, err := LoadApp()
+	if err != nil {
+		t.Fatalf("Unexpected error in LoadApp: %v", err)
+	}
 
 	if len(app.Backends) != 2 || len(app.Services) != 2 {
 		t.Errorf("Expected 2 backends and 2 services but got: %v", app)

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -117,17 +117,17 @@ func TestServiceConfigRequiredFields(t *testing.T) {
 func TestBackendConfigRequiredFields(t *testing.T) {
 	// Missing `name`
 	var testJSON = []byte(`{"consul": "consul:8500", "backends": [
-                           {"name": "", "poll": 30, "ttl": 19, "onChange": "true"}]}`)
+                           {"name": "", "poll": 30, "onChange": "true"}]}`)
 	validateParseError(t, testJSON, []string{"`name`"})
 
 	// Missing `poll`
 	testJSON = []byte(`{"consul": "consul:8500", "backends": [
-                       {"name": "name", "ttl": 19, "onChange": "true"}]}`)
+                       {"name": "name", "onChange": "true"}]}`)
 	validateParseError(t, testJSON, []string{"`poll`"})
 
 	// Missing `onChange`
 	testJSON = []byte(`{"consul": "consul:8500", "backends": [
-                       {"name": "name", "poll": 19, "ttl": 19 }]}`)
+                       {"name": "name", "poll": 19 }]}`)
 	validateParseError(t, testJSON, []string{"`onChange`"})
 }
 

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -199,11 +199,11 @@ func TestMetricServiceCreation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing config: %v", err)
 	}
-	app, err := InitializeApp(config)
+	app, err := NewApp(config)
 	if err != nil {
 		t.Fatalf("Got unexpected error deserializing JSON config: %v", err)
 	}
-	if _, err := InitializeApp(config); err != nil {
+	if _, err := NewApp(config); err != nil {
 		t.Fatalf("Got error while initializing config: %v", err)
 	} else {
 		if len(app.Services) != 1 {
@@ -241,7 +241,7 @@ func validateParseError(t *testing.T, input []byte, matchStrings []string) {
 	if cfg, err := config.UnmarshalConfig([]byte(input)); err != nil {
 		t.Errorf("Unexpected error parsing config: %v", err)
 	} else {
-		if _, err := InitializeApp(cfg); err == nil {
+		if _, err := NewApp(cfg); err == nil {
 			t.Errorf("Expected error parsing config")
 		} else {
 			for _, match := range matchStrings {

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-
-	"github.com/joyent/containerpilot/config"
 )
 
 // ------------------------------------------
@@ -103,39 +101,39 @@ func TestValidConfigParse(t *testing.T) {
 
 func TestServiceConfigRequiredFields(t *testing.T) {
 	// Missing `name`
-	var testJSON = []byte(`{"consul": "consul:8500", "services": [
-                           {"name": "", "port": 8080, "poll": 30, "ttl": 19 }]}`)
+	var testJSON = `{"consul": "consul:8500", "services": [
+                           {"name": "", "port": 8080, "poll": 30, "ttl": 19 }]}`
 	validateParseError(t, testJSON, []string{"`name`"})
 
 	// Missing `poll`
-	testJSON = []byte(`{"consul": "consul:8500", "services": [
-                       {"name": "name", "port": 8080, "ttl": 19}]}`)
+	testJSON = `{"consul": "consul:8500", "services": [
+                       {"name": "name", "port": 8080, "ttl": 19}]}`
 	validateParseError(t, testJSON, []string{"`poll`"})
 
 	// Missing `ttl`
-	testJSON = []byte(`{"consul": "consul:8500", "services": [
-                       {"name": "name", "port": 8080, "poll": 19}]}`)
+	testJSON = `{"consul": "consul:8500", "services": [
+                       {"name": "name", "port": 8080, "poll": 19}]}`
 	validateParseError(t, testJSON, []string{"`ttl`"})
 
-	testJSON = []byte(`{"consul": "consul:8500", "services": [
-                       {"name": "name", "poll": 19, "ttl": 19}]}`)
+	testJSON = `{"consul": "consul:8500", "services": [
+                       {"name": "name", "poll": 19, "ttl": 19}]}`
 	validateParseError(t, testJSON, []string{"`port`"})
 }
 
 func TestBackendConfigRequiredFields(t *testing.T) {
 	// Missing `name`
-	var testJSON = []byte(`{"consul": "consul:8500", "backends": [
-                           {"name": "", "poll": 30, "onChange": "true"}]}`)
+	var testJSON = `{"consul": "consul:8500", "backends": [
+                           {"name": "", "poll": 30, "onChange": "true"}]}`
 	validateParseError(t, testJSON, []string{"`name`"})
 
 	// Missing `poll`
-	testJSON = []byte(`{"consul": "consul:8500", "backends": [
-                       {"name": "name", "onChange": "true"}]}`)
+	testJSON = `{"consul": "consul:8500", "backends": [
+                       {"name": "name", "onChange": "true"}]}`
 	validateParseError(t, testJSON, []string{"`poll`"})
 
 	// Missing `onChange`
-	testJSON = []byte(`{"consul": "consul:8500", "backends": [
-                       {"name": "name", "poll": 19 }]}`)
+	testJSON = `{"consul": "consul:8500", "backends": [
+                       {"name": "name", "poll": 19 }]}`
 	validateParseError(t, testJSON, []string{"`onChange`"})
 }
 
@@ -206,15 +204,7 @@ func TestMetricServiceCreation(t *testing.T) {
       "port": 9090
     }
   }`
-	config, err := config.ParseConfig(jsonFragment)
-	if err != nil {
-		t.Fatalf("Error parsing config: %v", err)
-	}
-	app, err := NewApp(config)
-	if err != nil {
-		t.Fatalf("Got unexpected error deserializing JSON config: %v", err)
-	}
-	if _, err := NewApp(config); err != nil {
+	if app, err := NewApp(jsonFragment); err != nil {
 		t.Fatalf("Got error while initializing config: %v", err)
 	} else {
 		if len(app.Services) != 1 {
@@ -248,17 +238,13 @@ func testParseExpectError(t *testing.T, testJSON string, expected string) {
 	}
 }
 
-func validateParseError(t *testing.T, input []byte, matchStrings []string) {
-	if cfg, err := config.UnmarshalConfig([]byte(input)); err != nil {
-		t.Errorf("Unexpected error parsing config: %v", err)
+func validateParseError(t *testing.T, testJSON string, matchStrings []string) {
+	if _, err := NewApp(testJSON); err == nil {
+		t.Errorf("Expected error parsing config")
 	} else {
-		if _, err := NewApp(cfg); err == nil {
-			t.Errorf("Expected error parsing config")
-		} else {
-			for _, match := range matchStrings {
-				if !strings.Contains(err.Error(), match) {
-					t.Errorf("Expected message does not contain %s: %s", match, err)
-				}
+		for _, match := range matchStrings {
+			if !strings.Contains(err.Error(), match) {
+				t.Errorf("Expected message does not contain %s: %s", match, err)
 			}
 		}
 	}

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -25,7 +25,7 @@ var testJSON = `{
 					"interfaces": "eth0",
 					"health": "/bin/to/healthcheck/for/service/A.sh",
 					"poll": 30,
-					"ttl": 19,
+					"ttl": "19",
 					"tags": ["tag1","tag2"]
 			},
 			{
@@ -78,6 +78,14 @@ func TestValidConfigParse(t *testing.T) {
 
 	if app.Services[1].Tags != nil {
 		t.Errorf("Expected no tags for serviceB, but got: %s", app.Services[1].Tags)
+	}
+
+	if app.Services[0].TTL != 19 {
+		t.Errorf("Expected ttl=19 for serviceA, but got: %d", app.Services[1].TTL)
+	}
+
+	if app.Services[1].TTL != 103 {
+		t.Errorf("Expected ttl=103 for serviceB, but got: %d", app.Services[1].TTL)
 	}
 
 	if app.Backends[0].Tag != "dev" {

--- a/core/poll_test.go
+++ b/core/poll_test.go
@@ -17,7 +17,7 @@ func (p DummyPollable) PollStop() {}
 // Verify we have no obvious crashing paths in the poll code and that we handle
 // a closed channel immediately as expected and gracefully.
 func TestPoll(t *testing.T) {
-	app := NewApp()
+	app := EmptyApp()
 	service := &DummyPollable{}
 	quit := app.poll(service)
 	close(quit)

--- a/core/poll_test.go
+++ b/core/poll_test.go
@@ -17,7 +17,8 @@ func (p DummyPollable) PollStop() {}
 // Verify we have no obvious crashing paths in the poll code and that we handle
 // a closed channel immediately as expected and gracefully.
 func TestPoll(t *testing.T) {
+	app := NewApp()
 	service := &DummyPollable{}
-	quit := poll(service)
+	quit := app.poll(service)
 	close(quit)
 }

--- a/core/signals.go
+++ b/core/signals.go
@@ -3,133 +3,29 @@ package core
 import (
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
-	"time"
-
-	log "github.com/Sirupsen/logrus"
-	"github.com/joyent/containerpilot/config"
-	"github.com/joyent/containerpilot/services"
-	"github.com/joyent/containerpilot/utils"
 )
 
-// globals are eeeeevil
-var paused bool
-var signalLock = sync.RWMutex{}
-var maintModeLock = sync.RWMutex{}
-
-// we wrap access to `paused` in a RLock so that if we're in the middle of
-// marking services for maintenance we don't get stale reads
-func inMaintenanceMode() bool {
-	maintModeLock.RLock()
-	defer maintModeLock.RUnlock()
-	return paused
-}
-
-func toggleMaintenanceMode(cfg *config.Config) {
-	maintModeLock.RLock()
-	signalLock.Lock()
-	defer signalLock.Unlock()
-	defer maintModeLock.RUnlock()
-	paused = !paused
-	if paused {
-		forAllServices(cfg, func(service *services.Service) {
-			log.Infof("Marking for maintenance: %s", service.Name)
-			service.MarkForMaintenance()
-		})
-	}
-}
-
-func terminate(cfg *config.Config) {
-	signalLock.Lock()
-	defer signalLock.Unlock()
-	stopPolling(cfg)
-	forAllServices(cfg, func(service *services.Service) {
-		log.Infof("Deregistering service: %s", service.Name)
-		service.Deregister()
-	})
-
-	// Run and wait for preStop command to exit
-	utils.RunWithFields(cfg.PreStopCmd, log.Fields{"process": "PreStop"})
-
-	cmd := cfg.Command
-	if cmd == nil || cmd.Process == nil {
-		// Not managing the process, so don't do anything
-		return
-	}
-	if cfg.StopTimeout > 0 {
-		if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			log.Warnf("Error sending SIGTERM to application: %s", err)
-		} else {
-			time.AfterFunc(time.Duration(cfg.StopTimeout)*time.Second, func() {
-				log.Infof("Killing Process %#v", cmd.Process)
-				cmd.Process.Kill()
-			})
-			return
-		}
-	}
-	log.Infof("Killing Process %#v", cfg.Command.Process)
-	cmd.Process.Kill()
-}
-
-func reloadConfig(cfg *config.Config) *config.Config {
-	signalLock.Lock()
-	defer signalLock.Unlock()
-	log.Infof("Reloading configuration.")
-	newConfig, err := config.ReloadConfig(cfg.ConfigFlag)
-	if err != nil {
-		log.Errorf("Could not reload config: %v", err)
-		return nil
-	}
-	// stop advertising the existing services so that we can
-	// make sure we update them if ports, etc. change.
-	stopPolling(cfg)
-	forAllServices(cfg, func(service *services.Service) {
-		log.Infof("Deregistering service: %s", service.Name)
-		service.Deregister()
-	})
-
-	signal.Reset()
-	HandleSignals(newConfig)
-	HandlePolling(newConfig)
-
-	return newConfig // return for debuggability
-}
-
-func stopPolling(cfg *config.Config) {
-	for _, quit := range cfg.QuitChannels {
-		quit <- true
-	}
-}
-
-type serviceFunc func(service *services.Service)
-
-func forAllServices(cfg *config.Config, fn serviceFunc) {
-	for _, service := range cfg.Services {
-		fn(service)
-	}
-}
-
-// Listen for and capture signals used for orchestration
-func HandleSignals(cfg *config.Config) {
+// HandleSignals listens for and captures signals used for orchestration
+func (a *App) HandleSignals() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGUSR1, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
 		for signal := range sig {
 			switch signal {
 			case syscall.SIGUSR1:
-				toggleMaintenanceMode(cfg)
+				a.ToggleMaintenanceMode()
 			case syscall.SIGTERM:
-				terminate(cfg)
+				a.Terminate()
 			case syscall.SIGHUP:
-				reloadConfig(cfg)
+				a.Reload()
 			}
 		}
 	}()
 }
 
-// on SIGCHLD send wait4() (ref http://linux.die.net/man/2/waitpid)
-// to clean up any potential zombies
+// ReapChildren cleans up zombies
+// - on SIGCHLD send wait4() (ref http://linux.die.net/man/2/waitpid)
 func ReapChildren() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGCHLD)

--- a/core/signals.go
+++ b/core/signals.go
@@ -7,7 +7,7 @@ import (
 )
 
 // HandleSignals listens for and captures signals used for orchestration
-func (a *App) HandleSignals() {
+func (a *App) handleSignals() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGUSR1, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
@@ -26,7 +26,7 @@ func (a *App) HandleSignals() {
 
 // ReapChildren cleans up zombies
 // - on SIGCHLD send wait4() (ref http://linux.die.net/man/2/waitpid)
-func ReapChildren() {
+func reapChildren() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGCHLD)
 	go func() {

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/joyent/containerpilot/config"
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/services"
 	"github.com/joyent/containerpilot/utils"
@@ -25,35 +24,35 @@ func (c *NoopDiscoveryService) CheckForUpstreamChanges(backend, tag string) bool
 func (c *NoopDiscoveryService) MarkForMaintenance(service *discovery.ServiceDefinition) {}
 func (c *NoopDiscoveryService) Deregister(service *discovery.ServiceDefinition)         {}
 
-func getSignalTestConfig() *config.Config {
+func getSignalTestConfig() *App {
 	service, _ := services.NewService(
 		"test-service", 1, 1, 1, nil, nil, &NoopDiscoveryService{})
-	cfg := &config.Config{
-		Command: utils.ArgsToCmd([]string{
-			"./testdata/test.sh",
-			"interruptSleep"}),
-		StopTimeout: 5,
-		Services:    []*services.Service{service},
-	}
-	return cfg
+	app := NewApp()
+	app.Command = utils.ArgsToCmd([]string{
+		"./testdata/test.sh",
+		"interruptSleep"})
+	app.StopTimeout = 5
+	app.Services = []*services.Service{service}
+	return app
 }
 
 // ------------------------------------------
 
 // Test handler for SIGUSR1
 func TestMaintenanceSignal(t *testing.T) {
-	config := getSignalTestConfig()
-	if inMaintenanceMode() {
+	app := getSignalTestConfig()
+
+	if app.InMaintenanceMode() {
 		t.Fatal("Should not be in maintenance mode by default")
 	}
 
-	toggleMaintenanceMode(config)
-	if !inMaintenanceMode() {
+	app.ToggleMaintenanceMode()
+	if !app.InMaintenanceMode() {
 		t.Fatal("Should be in maintenance mode after receiving SIGUSR1")
 	}
 
-	toggleMaintenanceMode(config)
-	if inMaintenanceMode() {
+	app.ToggleMaintenanceMode()
+	if app.InMaintenanceMode() {
 		t.Fatal("Should not be in maintenance mode after receiving second SIGUSR1")
 	}
 }
@@ -63,10 +62,10 @@ func TestMaintenanceSignal(t *testing.T) {
 // because they'll interfere with each other's state.
 func TestTerminateSignal(t *testing.T) {
 
-	config := getSignalTestConfig()
+	app := getSignalTestConfig()
 	startTime := time.Now()
 	go func() {
-		if exitCode, _ := utils.ExecuteAndWait(config.Command); exitCode != 2 {
+		if exitCode, _ := utils.ExecuteAndWait(app.Command); exitCode != 2 {
 			t.Fatalf("Expected exit code 2 but got %d", exitCode)
 		}
 	}()
@@ -74,23 +73,29 @@ func TestTerminateSignal(t *testing.T) {
 	runtime.Gosched()
 	time.Sleep(10 * time.Millisecond)
 
-	terminate(config)
+	app.Terminate()
 	elapsed := time.Since(startTime)
-	if elapsed.Seconds() > float64(config.StopTimeout) {
+	if elapsed.Seconds() > float64(app.StopTimeout) {
 		t.Fatalf("Expected elapsed time <= %d seconds, but was %.2f",
-			config.StopTimeout, elapsed.Seconds())
+			app.StopTimeout, elapsed.Seconds())
 	}
 }
 
 // Test handler for SIGHUP
 func TestReloadSignal(t *testing.T) {
-	oldConfig := getSignalTestConfig()
-	oldConfig.ConfigFlag = "invalid"
-	if badConfig := reloadConfig(oldConfig); badConfig != nil {
-		t.Errorf("Invalid configuration did not return nil")
+	app := getSignalTestConfig()
+	app.ConfigFlag = "invalid"
+	err := app.Reload()
+	if err == nil {
+		t.Errorf("Invalid configuration did not return error")
 	}
-	oldConfig.ConfigFlag = `{ "consul": "newconsul:8500" }`
-	if newConfig := reloadConfig(oldConfig); newConfig == nil || newConfig.Consul != "newconsul:8500" {
+	app.ConfigFlag = `{ "consul": "newconsul:8500" }`
+	err = app.Reload()
+	if err != nil {
+		t.Errorf("Valid configuration returned error: %v", err)
+	}
+	discSvc := app.DiscoveryService
+	if discSvc == nil {
 		t.Errorf("Configuration was not reloaded.")
 	}
 }
@@ -98,7 +103,8 @@ func TestReloadSignal(t *testing.T) {
 // Test that only ensures that we cover a straight-line run through
 // the handleSignals setup code
 func TestSignalWiring(t *testing.T) {
-	HandleSignals(&config.Config{})
+	app := NewApp()
+	app.HandleSignals()
 	sendAndWaitForSignal(t, syscall.SIGUSR1)
 	sendAndWaitForSignal(t, syscall.SIGTERM)
 	sendAndWaitForSignal(t, syscall.SIGCHLD)

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -27,7 +27,7 @@ func (c *NoopDiscoveryService) Deregister(service *discovery.ServiceDefinition) 
 func getSignalTestConfig() *App {
 	service, _ := services.NewService(
 		"test-service", 1, 1, 1, nil, nil, &NoopDiscoveryService{})
-	app := NewApp()
+	app := EmptyApp()
 	app.Command = utils.ArgsToCmd([]string{
 		"./testdata/test.sh",
 		"interruptSleep"})
@@ -103,8 +103,8 @@ func TestReloadSignal(t *testing.T) {
 // Test that only ensures that we cover a straight-line run through
 // the handleSignals setup code
 func TestSignalWiring(t *testing.T) {
-	app := NewApp()
-	app.HandleSignals()
+	app := EmptyApp()
+	app.handleSignals()
 	sendAndWaitForSignal(t, syscall.SIGUSR1)
 	sendAndWaitForSignal(t, syscall.SIGTERM)
 	sendAndWaitForSignal(t, syscall.SIGCHLD)

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -95,8 +95,8 @@ func TestReloadSignal(t *testing.T) {
 		t.Errorf("Valid configuration returned error: %v", err)
 	}
 	discSvc := app.DiscoveryService
-	if discSvc == nil {
-		t.Errorf("Configuration was not reloaded.")
+	if svc, ok := discSvc.(*discovery.Consul); !ok || svc == nil {
+		t.Errorf("Configuration was not reloaded: %v", discSvc)
 	}
 }
 

--- a/discovery/consul.go
+++ b/discovery/consul.go
@@ -8,7 +8,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	consul "github.com/hashicorp/consul/api"
-	"github.com/mitchellh/mapstructure"
+	"github.com/joyent/containerpilot/utils"
 )
 
 // Consul is a service discovery backend for Hashicorp Consul
@@ -40,27 +40,19 @@ func NewConsulConfig(config interface{}) (*Consul, error) {
 	return &Consul{*client}, nil
 }
 
-func configFromMap(m map[string]interface{}) (*consul.Config, error) {
-	result := &struct {
+func configFromMap(raw map[string]interface{}) (*consul.Config, error) {
+	config := &struct {
 		Address string `mapstructure:"address"`
 		Scheme  string `mapstructure:"scheme"`
 		Token   string `mapstructure:"token"`
 	}{}
-	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: false,
-		Result:      result,
-	})
-	if err != nil {
-		return nil, err
-	}
-	err = dec.Decode(m)
-	if err != nil {
+	if err := utils.DecodeRaw(raw, config); err != nil {
 		return nil, err
 	}
 	return &consul.Config{
-		Address: result.Address,
-		Scheme:  result.Scheme,
-		Token:   result.Token,
+		Address: config.Address,
+		Scheme:  config.Scheme,
+		Token:   config.Token,
 	}, nil
 }
 

--- a/discovery/consul.go
+++ b/discovery/consul.go
@@ -8,27 +8,68 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	consul "github.com/hashicorp/consul/api"
+	"github.com/mitchellh/mapstructure"
 )
 
 // Consul is a service discovery backend for Hashicorp Consul
 type Consul struct{ consul.Client }
 
 // NewConsulConfig creates a new service discovery backend for Consul
-func NewConsulConfig(uri string) Consul {
-
-	address, scheme := parseRawUri(uri)
-	defaultconfig := consul.Config{
-		Address: address,
-		Scheme:  scheme,
+func NewConsulConfig(config interface{}) (*Consul, error) {
+	var consulConfig *consul.Config
+	var err error
+	switch t := config.(type) {
+	case string:
+		consulConfig, err = configFromURI(t)
+	case map[string]interface{}:
+		consulConfig, err = configFromMap(t)
+	default:
+		return nil, fmt.Errorf("Unexpected Consul config structure. Expected a string or map")
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	if token := os.Getenv("CONSUL_HTTP_TOKEN"); token != "" {
-		defaultconfig.Token = token
+		consulConfig.Token = token
 	}
+	client, err := consul.NewClient(consulConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &Consul{*client}, nil
+}
 
-	client, _ := consul.NewClient(&defaultconfig)
-	config := &Consul{*client}
-	return *config
+func configFromMap(m map[string]interface{}) (*consul.Config, error) {
+	result := &struct {
+		Address string `mapstructure:"address"`
+		Scheme  string `mapstructure:"scheme"`
+		Token   string `mapstructure:"token"`
+	}{}
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: false,
+		Result:      result,
+	})
+	if err != nil {
+		return nil, err
+	}
+	err = dec.Decode(m)
+	if err != nil {
+		return nil, err
+	}
+	return &consul.Config{
+		Address: result.Address,
+		Scheme:  result.Scheme,
+		Token:   result.Token,
+	}, nil
+}
+
+func configFromURI(uri string) (*consul.Config, error) {
+	address, scheme := parseRawUri(uri)
+	return &consul.Config{
+		Address: address,
+		Scheme:  scheme,
+	}, nil
 }
 
 // Returns the uri broken into an address and scheme portion
@@ -48,12 +89,12 @@ func parseRawUri(raw string) (string, string) {
 }
 
 // Deregister removes the node from Consul.
-func (c Consul) Deregister(service *ServiceDefinition) {
+func (c *Consul) Deregister(service *ServiceDefinition) {
 	c.MarkForMaintenance(service)
 }
 
 // MarkForMaintenance removes the node from Consul.
-func (c Consul) MarkForMaintenance(service *ServiceDefinition) {
+func (c *Consul) MarkForMaintenance(service *ServiceDefinition) {
 	if err := c.Agent().ServiceDeregister(service.ID); err != nil {
 		log.Infof("Deregistering failed: %s", err)
 	}
@@ -62,7 +103,7 @@ func (c Consul) MarkForMaintenance(service *ServiceDefinition) {
 // SendHeartbeat writes a TTL check status=ok to the consul store.
 // If consul has never seen this service, we register the service and
 // its TTL check.
-func (c Consul) SendHeartbeat(service *ServiceDefinition) {
+func (c *Consul) SendHeartbeat(service *ServiceDefinition) {
 	if err := c.Agent().PassTTL(service.ID, "ok"); err != nil {
 		log.Infof("%v\nService not registered, registering...", err)
 		if err = c.registerService(*service); err != nil {

--- a/discovery/consul_test.go
+++ b/discovery/consul_test.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-func setupConsul(serviceName string) (Consul, *ServiceDefinition) {
-	consul := NewConsulConfig("consul:8500")
+func setupConsul(serviceName string) (*Consul, *ServiceDefinition) {
+	consul, _ := NewConsulConfig("consul:8500")
 	service := &ServiceDefinition{
 		ID:        serviceName,
 		Name:      serviceName,
@@ -15,6 +15,18 @@ func setupConsul(serviceName string) (Consul, *ServiceDefinition) {
 		Port:      9000,
 	}
 	return consul, service
+}
+
+func TestConsulObjectParse(t *testing.T) {
+	rawCfg := map[string]interface{}{
+		"address": "consul:8501",
+		"scheme":  "https",
+		"token":   "ec492475-7753-4ff0-bd65-2f056d68f78b",
+	}
+	_, err := NewConsulConfig(rawCfg)
+	if err != nil {
+		t.Fatalf("Unable to parse config: %v", err)
+	}
 }
 
 func TestConsulAddressParse(t *testing.T) {

--- a/discovery/etcd.go
+++ b/discovery/etcd.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/client"
+	"github.com/mitchellh/mapstructure"
 	"golang.org/x/net/context"
 )
 
@@ -28,13 +29,11 @@ type EtcdServiceNode struct {
 }
 
 type etcdRawConfig struct {
-	Endpoints json.RawMessage `json:"endpoints"`
-	Prefix    string          `json:"prefix"`
+	Endpoints interface{} `mapstructure:"endpoints"`
+	Prefix    string      `mapstructure:"prefix"`
 }
 
-func parseEndpoints(raw json.RawMessage) []string {
-	var endpoints interface{}
-	json.Unmarshal(raw, &endpoints)
+func parseEndpoints(endpoints interface{}) []string {
 	switch e := endpoints.(type) {
 	case string:
 		return []string{e}
@@ -54,15 +53,23 @@ func parseEndpoints(raw json.RawMessage) []string {
 }
 
 // NewEtcdConfig creates a new service discovery backend for etcd
-func NewEtcdConfig(config json.RawMessage) Etcd {
-	etcd := Etcd{
+func NewEtcdConfig(config interface{}) (*Etcd, error) {
+	etcd := &Etcd{
 		Prefix: "/containerpilot",
 	}
 	var rawConfig etcdRawConfig
 	etcdConfig := client.Config{}
-	err := json.Unmarshal(config, &rawConfig)
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused: false,
+		Result:      &rawConfig,
+		ZeroFields:  false,
+	})
 	if err != nil {
-		log.Fatalf("Unable to parse etcd config: %v", err)
+		return nil, err
+	}
+	err = dec.Decode(config)
+	if err != nil {
+		return nil, err
 	}
 	etcdConfig.Endpoints = parseEndpoints(rawConfig.Endpoints)
 	if rawConfig.Prefix != "" {
@@ -71,25 +78,25 @@ func NewEtcdConfig(config json.RawMessage) Etcd {
 
 	etcdClient, err := client.New(etcdConfig)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	etcd.Client = etcdClient
 	etcd.API = client.NewKeysAPI(etcdClient)
-	return etcd
+	return etcd, nil
 }
 
 // Deregister removes this instance from the registry
-func (c Etcd) Deregister(service *ServiceDefinition) {
+func (c *Etcd) Deregister(service *ServiceDefinition) {
 	c.deregisterService(service)
 }
 
 // MarkForMaintenance removes this instance from the registry
-func (c Etcd) MarkForMaintenance(service *ServiceDefinition) {
+func (c *Etcd) MarkForMaintenance(service *ServiceDefinition) {
 	c.deregisterService(service)
 }
 
 // SendHeartbeat refreshes the TTL of this associated etcd node
-func (c Etcd) SendHeartbeat(service *ServiceDefinition) {
+func (c *Etcd) SendHeartbeat(service *ServiceDefinition) {
 	if err := c.updateServiceTTL(service); err != nil {
 		log.Infof("Service not registered, registering...")
 		if err := c.registerService(service); err != nil {
@@ -98,18 +105,18 @@ func (c Etcd) SendHeartbeat(service *ServiceDefinition) {
 	}
 }
 
-func (c Etcd) getNodeKey(service *ServiceDefinition) string {
+func (c *Etcd) getNodeKey(service *ServiceDefinition) string {
 	return fmt.Sprintf("%s/%s/%s", c.Prefix, service.Name, service.ID)
 }
 
-func (c Etcd) getAppKey(appName string) string {
+func (c *Etcd) getAppKey(appName string) string {
 	return fmt.Sprintf("%s/%s", c.Prefix, appName)
 }
 
 var etcdUpstreams = make(map[string][]EtcdServiceNode)
 
 // CheckForUpstreamChanges checks another etcd node for changes
-func (c Etcd) CheckForUpstreamChanges(backendName, backendTag string) bool {
+func (c *Etcd) CheckForUpstreamChanges(backendName, backendTag string) bool {
 	// TODO: is there a way to filter by tag in etcd?
 	services, err := c.getServices(backendName)
 	if err != nil {
@@ -127,7 +134,7 @@ func (c Etcd) CheckForUpstreamChanges(backendName, backendTag string) bool {
 	return didChange
 }
 
-func (c Etcd) getServices(appName string) ([]EtcdServiceNode, error) {
+func (c *Etcd) getServices(appName string) ([]EtcdServiceNode, error) {
 	var services []EtcdServiceNode
 
 	key := c.getAppKey(appName)

--- a/discovery/etcd.go
+++ b/discovery/etcd.go
@@ -8,7 +8,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/client"
-	"github.com/mitchellh/mapstructure"
+	"github.com/joyent/containerpilot/utils"
 	"golang.org/x/net/context"
 )
 
@@ -53,27 +53,18 @@ func parseEndpoints(endpoints interface{}) []string {
 }
 
 // NewEtcdConfig creates a new service discovery backend for etcd
-func NewEtcdConfig(config interface{}) (*Etcd, error) {
+func NewEtcdConfig(raw interface{}) (*Etcd, error) {
 	etcd := &Etcd{
 		Prefix: "/containerpilot",
 	}
-	var rawConfig etcdRawConfig
+	var config etcdRawConfig
 	etcdConfig := client.Config{}
-	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ErrorUnused: false,
-		Result:      &rawConfig,
-		ZeroFields:  false,
-	})
-	if err != nil {
+	if err := utils.DecodeRaw(raw, &config); err != nil {
 		return nil, err
 	}
-	err = dec.Decode(config)
-	if err != nil {
-		return nil, err
-	}
-	etcdConfig.Endpoints = parseEndpoints(rawConfig.Endpoints)
-	if rawConfig.Prefix != "" {
-		etcd.Prefix = rawConfig.Prefix
+	etcdConfig.Endpoints = parseEndpoints(config.Endpoints)
+	if config.Prefix != "" {
+		etcd.Prefix = config.Prefix
 	}
 
 	etcdClient, err := client.New(etcdConfig)

--- a/discovery/etcd.go
+++ b/discovery/etcd.go
@@ -24,12 +24,12 @@ type EtcdServiceNode struct {
 	Name    string   `json:"name"`
 	Address string   `json:"address"`
 	Port    int      `json:"port"`
-	Tags    []string `json:"tags,omitempty"`
+	Tags    []string `json:"tags"`
 }
 
 type etcdRawConfig struct {
 	Endpoints json.RawMessage `json:"endpoints"`
-	Prefix    string          `json:"prefix,omitempty"`
+	Prefix    string          `json:"prefix"`
 }
 
 func parseEndpoints(raw json.RawMessage) []string {

--- a/discovery/etcd_test.go
+++ b/discovery/etcd_test.go
@@ -1,7 +1,6 @@
 package discovery
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -10,8 +9,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-func setupEtcd(serviceName string) (Etcd, *ServiceDefinition) {
-	etcd := NewEtcdConfig(json.RawMessage(`{"endpoints":["http://etcd:4001"]}`))
+func setupEtcd(serviceName string) (*Etcd, *ServiceDefinition) {
+	etcd, _ := NewEtcdConfig(map[string]interface{}{"endpoints": []string{"http://etcd:4001"}})
 	service := &ServiceDefinition{
 		ID:        serviceName,
 		Name:      serviceName,
@@ -23,7 +22,7 @@ func setupEtcd(serviceName string) (Etcd, *ServiceDefinition) {
 }
 
 func TestEtcdParseArrayEndpoints(t *testing.T) {
-	cfg := NewEtcdConfig(json.RawMessage(`{"endpoints":["http://etcd:4001"]}`))
+	cfg, _ := NewEtcdConfig(map[string]interface{}{"endpoints": []string{"http://etcd:4001"}})
 	expected := []string{"http://etcd:4001"}
 	actual := cfg.Client.Endpoints()
 	if !reflect.DeepEqual(expected, actual) {
@@ -32,7 +31,7 @@ func TestEtcdParseArrayEndpoints(t *testing.T) {
 }
 
 func TestEtcdParseStringEndpoints(t *testing.T) {
-	cfg := NewEtcdConfig(json.RawMessage(`{"endpoints":"http://etcd:4001"}`))
+	cfg, _ := NewEtcdConfig(map[string]interface{}{"endpoints": "http://etcd:4001"})
 	expected := []string{"http://etcd:4001"}
 	actual := cfg.Client.Endpoints()
 	if !reflect.DeepEqual(expected, actual) {
@@ -105,7 +104,7 @@ func TestEtcdCheckForChanges(t *testing.T) {
 	}
 }
 
-func checkServiceExists(etcd Etcd, service *ServiceDefinition) bool {
+func checkServiceExists(etcd *Etcd, service *ServiceDefinition) bool {
 	key := etcd.getNodeKey(service)
 	if _, err := etcd.API.Get(context.Background(), key, nil); err != nil {
 		if etcdErr, ok := err.(client.Error); ok {

--- a/main.go
+++ b/main.go
@@ -1,14 +1,11 @@
 package main // import "github.com/joyent/containerpilot"
 
 import (
-	"flag"
-	"os"
 	"runtime"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/joyent/containerpilot/config"
 	"github.com/joyent/containerpilot/core"
-	"github.com/joyent/containerpilot/utils"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // Main executes the containerpilot CLI
@@ -17,44 +14,9 @@ func main() {
 	// contention on the main application
 	runtime.GOMAXPROCS(1)
 
-	cfg, configErr := config.LoadConfig()
+	app, configErr := core.LoadApp()
 	if configErr != nil {
 		log.Fatal(configErr)
 	}
-
-	// Run the preStart handler, if any, and exit if it returns an error
-	if preStartCode, err := utils.RunWithFields(cfg.PreStartCmd, log.Fields{"process": "PreStart"}); err != nil {
-		os.Exit(preStartCode)
-	}
-
-	// Set up handlers for polling and to accept signal interrupts
-	if 1 == os.Getpid() {
-		core.ReapChildren()
-	}
-	core.HandleSignals(cfg)
-	core.HandlePolling(cfg)
-
-	if len(flag.Args()) != 0 {
-		// Run our main application and capture its stdout/stderr.
-		// This will block until the main application exits and then os.Exit
-		// with the exit code of that application.
-		cfg.Command = utils.ArgsToCmd(flag.Args())
-
-		// Command output directly to stdout/stderr
-		cfg.Command.Stdout = os.Stdout
-		cfg.Command.Stderr = os.Stderr
-		code, err := utils.ExecuteAndWait(cfg.Command)
-		if err != nil {
-			log.Println(err)
-		}
-		// Run the PostStop handler, if any, and exit if it returns an error
-		if postStopCode, err := utils.RunWithFields(config.GetConfig().PostStopCmd, log.Fields{"process": "PostStop"}); err != nil {
-			os.Exit(postStopCode)
-		}
-		os.Exit(code)
-	}
-
-	// block forever, as we're polling in the two polling functions and
-	// did not os.Exit by waiting on an external application.
-	select {}
+	app.Run() // Blocks forever
 }

--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@ SHELL := /bin/bash
 
 IMPORT_PATH := github.com/joyent/containerpilot
 VERSION ?= dev-build-not-for-release
-LDFLAGS := -X ${IMPORT_PATH}/config.GitHash='$(shell git rev-parse --short HEAD)' -X ${IMPORT_PATH}/config.Version='${VERSION}'
+LDFLAGS := -X ${IMPORT_PATH}/core.GitHash='$(shell git rev-parse --short HEAD)' -X ${IMPORT_PATH}/core.Version='${VERSION}'
 
 ROOT := $(shell pwd)
 

--- a/makefile
+++ b/makefile
@@ -71,7 +71,7 @@ add-dep: build/containerpilot_build
 		-v ${ROOT}:/cp/src/${IMPORT_PATH} \
 		-w /cp/src/${IMPORT_PATH} \
 		containerpilot_build \
-		bash ./scripts/add_dep.sh DEP=$(DEP)
+		bash -c "DEP=$(DEP) ./scripts/add_dep.sh"
 
 # ----------------------------------------------
 # develop and test

--- a/services/services.go
+++ b/services/services.go
@@ -21,7 +21,7 @@ type Service struct {
 	Port             int             `json:"port"`
 	TTL              int             `json:"ttl"`
 	Interfaces       json.RawMessage `json:"interfaces"`
-	Tags             []string        `json:"tags,omitempty"`
+	Tags             []string        `json:"tags"`
 	ipAddress        string
 	healthCheckCmd   *exec.Cmd
 	discoveryService discovery.DiscoveryService

--- a/services/services.go
+++ b/services/services.go
@@ -17,7 +17,7 @@ type Service struct {
 	ID               string
 	Name             string          `json:"name"`
 	Poll             int             `json:"poll"` // time in seconds
-	HealthCheckExec  json.RawMessage `json:"health"`
+	HealthCheckExec  interface{}     `json:"health"`
 	Port             int             `json:"port"`
 	TTL              int             `json:"ttl"`
 	Interfaces       json.RawMessage `json:"interfaces"`

--- a/services/services.go
+++ b/services/services.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,25 +14,25 @@ import (
 // Service configures the service, discovery data, and health checks
 type Service struct {
 	ID               string
-	Name             string          `json:"name"`
-	Poll             int             `json:"poll"` // time in seconds
-	HealthCheckExec  interface{}     `json:"health"`
-	Port             int             `json:"port"`
-	TTL              int             `json:"ttl"`
-	Interfaces       json.RawMessage `json:"interfaces"`
-	Tags             []string        `json:"tags"`
+	Name             string      `mapstructure:"name"`
+	Poll             int         `mapstructure:"poll"` // time in seconds
+	HealthCheckExec  interface{} `mapstructure:"health"`
+	Port             int         `mapstructure:"port"`
+	TTL              int         `mapstructure:"ttl"`
+	Interfaces       interface{} `mapstructure:"interfaces"`
+	Tags             []string    `mapstructure:"tags"`
 	ipAddress        string
 	healthCheckCmd   *exec.Cmd
 	discoveryService discovery.DiscoveryService
 	definition       *discovery.ServiceDefinition
 }
 
-func NewServices(raw json.RawMessage, disc discovery.DiscoveryService) ([]*Service, error) {
+func NewServices(raw []interface{}, disc discovery.DiscoveryService) ([]*Service, error) {
 	if raw == nil {
 		return []*Service{}, nil
 	}
-	services := make([]*Service, 0)
-	if err := json.Unmarshal(raw, &services); err != nil {
+	var services []*Service
+	if err := utils.DecodeRaw(raw, &services); err != nil {
 		return nil, fmt.Errorf("Service configuration error: %v", err)
 	}
 	for _, s := range services {
@@ -44,7 +43,7 @@ func NewServices(raw json.RawMessage, disc discovery.DiscoveryService) ([]*Servi
 	return services, nil
 }
 
-func NewService(name string, poll, port, ttl int, interfaces json.RawMessage,
+func NewService(name string, poll, port, ttl int, interfaces interface{},
 	tags []string, disc discovery.DiscoveryService) (*Service, error) {
 	service := &Service{
 		Name:       name,
@@ -85,7 +84,7 @@ func parseService(s *Service, disc discovery.DiscoveryService) error {
 		s.healthCheckCmd = cmd
 	}
 
-	interfaces, ifaceErr := utils.ParseInterfaces(s.Interfaces)
+	interfaces, ifaceErr := utils.ToStringArray(s.Interfaces)
 	if ifaceErr != nil {
 		return ifaceErr
 	}

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"encoding/json"
 	"os/exec"
 	"reflect"
 	"testing"
@@ -46,7 +47,7 @@ func TestServiceParse(t *testing.T) {
   "ttl": 103
 }
 ]`)
-	if services, err := NewServices(jsonFragment, nil); err != nil {
+	if services, err := NewServices(decodeJSONRawService(t, jsonFragment), nil); err != nil {
 		t.Fatalf("Could not parse service JSON: %s", err)
 	} else {
 		validateCommandParsed(t, "health", services[0].healthCheckCmd,
@@ -58,6 +59,14 @@ func TestServiceParse(t *testing.T) {
 
 // ------------------------------------------
 // test helpers
+
+func decodeJSONRawService(t *testing.T, testJSON json.RawMessage) []interface{} {
+	var raw []interface{}
+	if err := json.Unmarshal(testJSON, &raw); err != nil {
+		t.Fatalf("Unexpected error decoding JSON:\n%s\n%v", testJSON, err)
+	}
+	return raw
+}
 
 func validateCommandParsed(t *testing.T, name string, parsed *exec.Cmd, expected []string) {
 	if expected == nil {

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -17,7 +17,7 @@ type Task struct {
 	Name      string   `json:"name"`
 	Args      []string `json:"command"`
 	Frequency string   `json:"frequency"`
-	Timeout   string   `json:"timeout,omitempty"`
+	Timeout   string   `json:"timeout"`
 
 	freqDuration    time.Duration
 	timeoutDuration time.Duration

--- a/tasks/tasks_test.go
+++ b/tasks/tasks_test.go
@@ -57,7 +57,7 @@ func expectDuration(t *testing.T, actual time.Duration, expectedString string) {
 
 func TestTaskParseDuration(t *testing.T) {
 	task := &Task{
-		Args:      []string{"/usr/bin/true"},
+		Command:   []string{"/usr/bin/true"},
 		Frequency: "1ms",
 	}
 	expectNoParseError(t, task)
@@ -65,7 +65,7 @@ func TestTaskParseDuration(t *testing.T) {
 	expectDuration(t, task.timeoutDuration, "1ms")
 
 	task = &Task{
-		Args:      []string{"/usr/bin/true"},
+		Command:   []string{"/usr/bin/true"},
 		Frequency: "10s",
 		Timeout:   "10",
 	}
@@ -74,7 +74,7 @@ func TestTaskParseDuration(t *testing.T) {
 	expectDuration(t, task.timeoutDuration, "10s")
 
 	task = &Task{
-		Args:      []string{"/usr/bin/true"},
+		Command:   []string{"/usr/bin/true"},
 		Frequency: "10",
 		Timeout:   "1s",
 	}
@@ -106,7 +106,7 @@ func TestTask(t *testing.T) {
 		t.Fatalf("Unexpeced error: %v", err)
 	}
 	task := &Task{
-		Args:      []string{"testdata/test.sh", "echoOut", ".", tmpf.Name()},
+		Command:   []string{"testdata/test.sh", "echoOut", ".", tmpf.Name()},
 		Frequency: "100ms",
 	}
 	err = parseTask(task)
@@ -143,7 +143,7 @@ func TestScheduledTaskTimeoutConfig(t *testing.T) {
 		t.Fatalf("Unexpeced error: %v", err)
 	}
 	task := &Task{
-		Args:      []string{"testdata/test.sh", "printDots", tmpf.Name()},
+		Command:   []string{"testdata/test.sh", "printDots", tmpf.Name()},
 		Frequency: "400ms",
 		Timeout:   "200ms",
 	}

--- a/telemetry/sensors.go
+++ b/telemetry/sensors.go
@@ -1,8 +1,6 @@
 package telemetry
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,13 +15,13 @@ import (
 
 // A Sensor is a single measurement of the application.
 type Sensor struct {
-	Namespace string      `json:"namespace"`
-	Subsystem string      `json:"subsystem"`
-	Name      string      `json:"name"`
-	Help      string      `json:"help"` // help string returned by API
-	Type      string      `json:"type"`
-	Poll      int         `json:"poll"` // time in seconds
-	CheckExec interface{} `json:"check"`
+	Namespace string      `mapstructure:"namespace"`
+	Subsystem string      `mapstructure:"subsystem"`
+	Name      string      `mapstructure:"name"`
+	Help      string      `mapstructure:"help"` // help string returned by API
+	Type      string      `mapstructure:"type"`
+	Poll      int         `mapstructure:"poll"` // time in seconds
+	CheckExec interface{} `mapstructure:"check"`
 	checkCmd  *exec.Cmd
 	collector prometheus.Collector
 }
@@ -89,10 +87,10 @@ func (s Sensor) record(metricValue string) {
 	}
 }
 
-func NewSensors(raw json.RawMessage) ([]*Sensor, error) {
+func NewSensors(raw []interface{}) ([]*Sensor, error) {
 	sensors := make([]*Sensor, 0)
-	if err := json.Unmarshal(raw, &sensors); err != nil {
-		return nil, errors.New("Sensor configuration error: %v, err")
+	if err := utils.DecodeRaw(raw, &sensors); err != nil {
+		return nil, fmt.Errorf("Sensor configuration error: %v", err)
 	}
 	for _, s := range sensors {
 		if check, err := utils.ParseCommandArgs(s.CheckExec); err != nil {

--- a/telemetry/sensors.go
+++ b/telemetry/sensors.go
@@ -17,13 +17,13 @@ import (
 
 // A Sensor is a single measurement of the application.
 type Sensor struct {
-	Namespace string          `json:"namespace"`
-	Subsystem string          `json:"subsystem"`
-	Name      string          `json:"name"`
-	Help      string          `json:"help"` // help string returned by API
-	Type      string          `json:"type"`
-	Poll      int             `json:"poll"` // time in seconds
-	CheckExec json.RawMessage `json:"check"`
+	Namespace string      `json:"namespace"`
+	Subsystem string      `json:"subsystem"`
+	Name      string      `json:"name"`
+	Help      string      `json:"help"` // help string returned by API
+	Type      string      `json:"type"`
+	Poll      int         `json:"poll"` // time in seconds
+	CheckExec interface{} `json:"check"`
 	checkCmd  *exec.Cmd
 	collector prometheus.Collector
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -16,9 +16,9 @@ import (
 // endpoint, and the collection of Sensors.
 type Telemetry struct {
 	Port          int             `json:"port"`
-	Interfaces    json.RawMessage `json:"interfaces,omitempty"` // optional override
-	Tags          []string        `json:"tags,omitempty"`
-	SensorConfigs json.RawMessage `json:"sensors,omitempty"`
+	Interfaces    json.RawMessage `json:"interfaces"` // optional override
+	Tags          []string        `json:"tags"`
+	SensorConfigs json.RawMessage `json:"sensors"`
 	Sensors       []*Sensor
 	ServiceName   string
 	URL           string

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -3,7 +3,7 @@ package telemetry
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
+	"net"
 	"net/http"
 	"sync"
 
@@ -20,62 +20,77 @@ type Telemetry struct {
 	Tags          []string        `json:"tags,omitempty"`
 	SensorConfigs json.RawMessage `json:"sensors,omitempty"`
 	Sensors       []*Sensor
-	IpAddress     string
 	ServiceName   string
-	Url           string
+	URL           string
 	TTL           int
 	Poll          int
+	mux           *http.ServeMux
+	lock          sync.RWMutex
+	listen        net.Listener
+	addr          net.TCPAddr
+	listening     bool
 }
 
+// NewTelemetry configures a new prometheus Telemetry server
 func NewTelemetry(raw json.RawMessage) (*Telemetry, error) {
 	t := &Telemetry{
 		Port:        9090,
 		ServiceName: "containerpilot",
-		Url:         "/metrics",
+		URL:         "/metrics",
 		TTL:         15,
 		Poll:        5,
+		lock:        sync.RWMutex{},
 	}
 	if err := json.Unmarshal(raw, t); err != nil {
 		return nil, errors.New("Telemetry configuration error: %v, err")
 	}
-	if ipAddress, err := utils.IpFromInterfaces(t.Interfaces); err != nil {
+	ipAddress, err := utils.IpFromInterfaces(t.Interfaces)
+	if err != nil {
 		return nil, err
-	} else {
-		t.IpAddress = ipAddress
 	}
+	ip := net.ParseIP(ipAddress)
+	t.addr = net.TCPAddr{IP: ip, Port: t.Port}
+	t.mux = http.NewServeMux()
+	t.mux.Handle(t.URL, prometheus.Handler())
 	// note that we don't return an error if there are no sensors
 	// because the prometheus handler will still pick up metrics
 	// internal to ContainerPilot (i.e. the golang runtime)
 	if t.SensorConfigs != nil {
-		if sensors, err := NewSensors(t.SensorConfigs); err != nil {
+		sensors, err := NewSensors(t.SensorConfigs)
+		if err != nil {
 			return nil, err
-		} else {
-			t.Sensors = sensors
 		}
+		t.Sensors = sensors
 	}
 	return t, nil
 }
 
-var server *http.Server
-var serverLock = sync.RWMutex{}
-
+// Serve starts serving the telemetry service
 func (t *Telemetry) Serve() {
-	serverLock.Lock()
-	serverLock.Unlock()
-	if server != nil {
-		// no-op if we've created the server previously
-		// otherwise we'll panic when we try to reregister
-		// the HTTP handlers
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.listening {
 		return
 	}
+	ln, err := net.Listen(t.addr.Network(), t.addr.String())
+	if err != nil {
+		log.Errorf("Error serving telemetry on %s: %v", t.addr.String(), err)
+	}
+	t.listen = ln
+	t.listening = true
 	go func() {
-		http.Handle(t.Url, prometheus.Handler())
-		address := fmt.Sprintf("%s:%v", t.IpAddress, t.Port)
-		log.Debugf("Telemetry listening on %v\n", address)
-
-		server = &http.Server{
-			Addr: address,
-		}
-		log.Fatal(server.ListenAndServe())
+		log.Debugf("telemetry: Listening on %s\n", t.addr.String())
+		log.Fatal(http.Serve(t.listen, t.mux))
+		log.Debugf("telemetry: Stopped listening on %s\n", t.addr.String())
 	}()
+}
+
+// Shutdown shuts down the telemetry service
+func (t *Telemetry) Shutdown() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if t.listening {
+		t.listen.Close()
+		t.listening = false
+	}
 }

--- a/utils/ips.go
+++ b/utils/ips.go
@@ -2,8 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -14,35 +12,18 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
-func IpFromInterfaces(raw json.RawMessage) (string, error) {
-	interfaces, ifaceErr := ParseInterfaces(raw)
+// IPFromInterfaces ...
+func IPFromInterfaces(raw interface{}) (string, error) {
+	interfaces, ifaceErr := ToStringArray(raw)
 	if ifaceErr != nil {
 		return "", ifaceErr
 	}
 
-	if ipAddress, err := GetIP(interfaces); err != nil {
+	ipAddress, err := GetIP(interfaces)
+	if err != nil {
 		return "", err
-	} else {
-		return ipAddress, nil
 	}
-}
-
-func ParseInterfaces(raw json.RawMessage) ([]string, error) {
-	if raw == nil {
-		return []string{}, nil
-	}
-	// Parse as a string
-	var jsonString string
-	if err := json.Unmarshal(raw, &jsonString); err == nil {
-		return []string{jsonString}, nil
-	}
-
-	var jsonArray []string
-	if err := json.Unmarshal(raw, &jsonArray); err == nil {
-		return jsonArray, nil
-	}
-
-	return []string{}, errors.New("interfaces must be a string or an array")
+	return ipAddress, nil
 }
 
 // GetIP determines the IP address of the container
@@ -131,7 +112,7 @@ type inetInterfaceSpec struct {
 type staticInterfaceSpec struct {
 	Spec string
 	Name string
-	IP net.IP
+	IP   net.IP
 }
 
 func (s staticInterfaceSpec) Match(index int, iip interfaceIP) bool {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,29 +1,58 @@
 package utils
 
 import (
-	"encoding/json"
-	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 )
 
-func ParseCommandArgs(raw json.RawMessage) (*exec.Cmd, error) {
+// ParseCommandArgs tries to parse a command from the supported types
+func ParseCommandArgs(raw interface{}) (*exec.Cmd, error) {
+	strArray, err := ToStringArray(raw)
+	if err != nil {
+		return nil, err
+	}
+	return ArgsToCmd(strArray), nil
+}
+
+// ToStringArray converts the given interface to a []string if possible
+func ToStringArray(raw interface{}) ([]string, error) {
 	if raw == nil {
 		return nil, nil
 	}
-	// Parse as a string
-	var stringCmd string
-	if err := json.Unmarshal(raw, &stringCmd); err == nil {
-		return StrToCmd(stringCmd), nil
+	switch t := raw.(type) {
+	case string:
+		return []string{t}, nil
+	case []string:
+		return t, nil
+	case []interface{}:
+		return interfaceToStringArray(t), nil
+	default:
+		return nil, fmt.Errorf("Unexpected argument type: %T", t)
 	}
-
-	var arrayCmd []string
-	if err := json.Unmarshal(raw, &arrayCmd); err == nil {
-		return ArgsToCmd(arrayCmd), nil
-	}
-	return nil, errors.New("Command argument must be a string or an array")
 }
 
+func interfaceToString(raw interface{}) string {
+	switch t := raw.(type) {
+	case string:
+		return t
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+func interfaceToStringArray(rawArray []interface{}) []string {
+	if rawArray == nil || len(rawArray) == 0 {
+		return nil
+	}
+	var stringArray []string
+	for _, raw := range rawArray {
+		stringArray = append(stringArray, interfaceToString(raw))
+	}
+	return stringArray
+}
+
+// ArgsToCmd creates a command from a list of arguments
 func ArgsToCmd(args []string) *exec.Cmd {
 	if len(args) == 0 {
 		return nil
@@ -34,6 +63,7 @@ func ArgsToCmd(args []string) *exec.Cmd {
 	return exec.Command(args[0])
 }
 
+// StrToCmd creates a command from a string, triming whitespace
 func StrToCmd(command string) *exec.Cmd {
 	if command != "" {
 		return ArgsToCmd(strings.Split(strings.TrimSpace(command), " "))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,10 +4,29 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"github.com/mitchellh/mapstructure"
 )
+
+// DecodeRaw decodes a raw interface into the target structure
+func DecodeRaw(raw interface{}, result interface{}) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		ErrorUnused:      true,
+		WeaklyTypedInput: true,
+		Result:           result,
+	})
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(raw)
+}
 
 // ParseCommandArgs tries to parse a command from the supported types
 func ParseCommandArgs(raw interface{}) (*exec.Cmd, error) {
+	switch t := raw.(type) {
+	case string:
+		return StrToCmd(t), nil
+	}
 	strArray, err := ToStringArray(raw)
 	if err != nil {
 		return nil, err

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -15,23 +15,26 @@ func TestParseCommandArgs(t *testing.T) {
 	}
 
 	expected := []string{"/testdata/test.sh", "arg1"}
-	json1 := json.RawMessage(`"/testdata/test.sh arg1"`)
-	if cmd, err := ParseCommandArgs(json1); err == nil {
-		validateCommandParsed(t, "json1", cmd, expected)
+	if cmd, err := ParseCommandArgs("/testdata/test.sh arg1"); err == nil {
+		validateCommandParsed(t, "string", cmd, expected)
 	} else {
-		t.Errorf("Unexpected parse error json1: %s", err.Error())
+		t.Errorf("Unexpected parse error string: %s", err.Error())
 	}
 
-	json2 := json.RawMessage(`["/testdata/test.sh","arg1"]`)
-	if cmd, err := ParseCommandArgs(json2); err == nil {
-		validateCommandParsed(t, "json2", cmd, expected)
+	if cmd, err := ParseCommandArgs([]string{"/testdata/test.sh", "arg1"}); err == nil {
+		validateCommandParsed(t, "[]string", cmd, expected)
 	} else {
-		t.Errorf("Unexpected parse error json2: %s", err.Error())
+		t.Errorf("Unexpected parse error []string: %s", err.Error())
 	}
 
-	json3 := json.RawMessage(`{ "a": true }`)
-	if _, err := ParseCommandArgs(json3); err == nil {
-		t.Errorf("Expected parse error for json3")
+	if cmd, err := ParseCommandArgs([]interface{}{"/testdata/test.sh", "arg1"}); err == nil {
+		validateCommandParsed(t, "[]interface{}", cmd, expected)
+	} else {
+		t.Errorf("Unexpected parse error []interface{}: %s", err.Error())
+	}
+
+	if _, err := ParseCommandArgs(map[string]bool{"a": true}); err == nil {
+		t.Errorf("Expected parse error for invalid")
 	}
 
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"encoding/json"
 	"os/exec"
 	"reflect"
 	"testing"
@@ -57,31 +56,31 @@ func validateCommandParsed(t *testing.T, name string, parsed *exec.Cmd, expected
 	}
 }
 
-func TestParseInterfaces(t *testing.T) {
-	if interfaces, err := ParseInterfaces(nil); err != nil {
+func TestToStringArray(t *testing.T) {
+	if interfaces, err := ToStringArray(nil); err != nil {
 		t.Errorf("Unexpected parse error: %s", err.Error())
 	} else if len(interfaces) > 0 {
-		t.Errorf("Expected no interfaces, but got %s", interfaces)
+		t.Errorf("Expected no strings, but got %s", interfaces)
 	}
 
-	json1 := json.RawMessage(`"eth0"`)
-	expected1 := []string{"eth0"}
-	if interfaces, err := ParseInterfaces(json1); err != nil {
+	test1 := "eth0"
+	expected1 := []string{test1}
+	if interfaces, err := ToStringArray(test1); err != nil {
 		t.Errorf("Unexpected parse error: %s", err.Error())
 	} else if !reflect.DeepEqual(interfaces, expected1) {
 		t.Errorf("Expected %s, got: %s", expected1, interfaces)
 	}
 
-	json2 := json.RawMessage(`["ethwe","eth0"]`)
+	test2 := []interface{}{"ethwe", "eth0"}
 	expected2 := []string{"ethwe", "eth0"}
-	if interfaces, err := ParseInterfaces(json2); err != nil {
+	if interfaces, err := ToStringArray(test2); err != nil {
 		t.Errorf("Unexpected parse error: %s", err.Error())
 	} else if !reflect.DeepEqual(interfaces, expected2) {
 		t.Errorf("Expected %s, got: %s", expected2, interfaces)
 	}
 
-	json3 := json.RawMessage(`{ "a": true }`)
-	if _, err := ParseInterfaces(json3); err == nil {
+	test3 := map[string]interface{}{"a": true}
+	if _, err := ToStringArray(test3); err == nil {
 		t.Errorf("Expected parse error for json3")
 	}
 }


### PR DESCRIPTION
For #128

This is an initial stab at factoring out the application state from configuration.  One cool thing about this is that many (all?) of the global variables go away.

I also added support for telemetry reload (hopefully, I have not tested this extensively)

I thought I'd get this out in the open so that everyone can poke some holes in it.

cc: @tgross 

## Work in progress

One thing I'm not too happy about is the proliferation of methods that I implemented on the `Config` struct. I think the next step would probably be to push that logic into the packages themselves.  I've had some success implementing configs as some high-level structure containing mostly maps and using [github.com/mitchellh/mapstructure](https://github.com/mitchellh/mapstructure) - since it supports weak typing which would be good for things like #122 
