### PR TITLE
Refactor of config and discovery registration

### DIFF
--- a/config/commands.go
+++ b/config/commands.go
@@ -8,29 +8,26 @@ import (
 	"github.com/joyent/containerpilot/utils"
 )
 
-// ParsePreStart ...
-func (cfg *Config) ParsePreStart() (*exec.Cmd, error) {
+func (cfg *rawConfig) parsePreStart() (*exec.Cmd, error) {
 	// onStart has been deprecated for preStart. Remove in 2.0
-	if cfg.PreStart != nil && cfg.OnStart != nil {
+	if cfg.preStart != nil && cfg.onStart != nil {
 		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use only the preStart option provided")
 	}
 
 	// alias the onStart behavior to preStart
-	if cfg.PreStart == nil && cfg.OnStart != nil {
+	if cfg.preStart == nil && cfg.onStart != nil {
 		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use the onStart option as a preStart")
-		cfg.PreStart = cfg.OnStart
+		cfg.preStart = cfg.onStart
 	}
-	return parseCommand("preStart", cfg.PreStart)
+	return parseCommand("preStart", cfg.preStart)
 }
 
-// ParsePreStop ...
-func (cfg *Config) ParsePreStop() (*exec.Cmd, error) {
-	return parseCommand("preStop", cfg.PreStop)
+func (cfg *rawConfig) parsePreStop() (*exec.Cmd, error) {
+	return parseCommand("preStop", cfg.preStop)
 }
 
-// ParsePostStop ...
-func (cfg *Config) ParsePostStop() (*exec.Cmd, error) {
-	return parseCommand("postStop", cfg.PostStop)
+func (cfg *rawConfig) parsePostStop() (*exec.Cmd, error) {
+	return parseCommand("postStop", cfg.postStop)
 }
 
 func parseCommand(name string, args interface{}) (*exec.Cmd, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -7,33 +7,44 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os/exec"
+	"reflect"
 	"strings"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/backends"
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/services"
 	"github.com/joyent/containerpilot/tasks"
 	"github.com/joyent/containerpilot/telemetry"
-	"github.com/prometheus/common/log"
+	"github.com/joyent/containerpilot/utils"
 )
 
-// Config is the top-level ContainerPilot Configuration
-type Config struct {
-	Consul          interface{}   `json:"consul"`
-	Etcd            interface{}   `json:"etcd"`
-	LogConfig       *LogConfig    `json:"logging"`
-	OnStart         interface{}   `json:"onStart"`
-	PreStart        interface{}   `json:"preStart"`
-	PreStop         interface{}   `json:"preStop"`
-	PostStop        interface{}   `json:"postStop"`
-	StopTimeout     int           `json:"stopTimeout"`
-	ServicesConfig  []interface{} `json:"services"`
-	BackendsConfig  []interface{} `json:"backends"`
-	TasksConfig     []interface{} `json:"tasks"`
-	TelemetryConfig interface{}   `json:"telemetry"`
+type rawConfig struct {
+	logConfig       *LogConfig
+	onStart         interface{}
+	preStart        interface{}
+	preStop         interface{}
+	postStop        interface{}
+	stopTimeout     int
+	servicesConfig  []interface{}
+	backendsConfig  []interface{}
+	tasksConfig     []interface{}
+	telemetryConfig interface{}
+}
 
-	RawConfig  map[string]interface{}
-	ConfigFlag string
+// Config contains the parsed config elements
+type Config struct {
+	DiscoveryService discovery.DiscoveryService
+	LogConfig        *LogConfig
+	PreStart         *exec.Cmd
+	PreStop          *exec.Cmd
+	PostStop         *exec.Cmd
+	StopTimeout      int
+	Services         []*services.Service
+	Backends         []*backends.Backend
+	Tasks            []*tasks.Task
+	Telemetry        *telemetry.Telemetry
 }
 
 const (
@@ -41,15 +52,14 @@ const (
 	defaultStopTimeout int = 5
 )
 
-// ParseDiscoveryService ...
-func (cfg *Config) ParseDiscoveryService() (discovery.DiscoveryService, error) {
+func parseDiscoveryService(rawCfg map[string]interface{}) (discovery.DiscoveryService, error) {
 	var discoveryService discovery.DiscoveryService
 	var err error
 	discoveryCount := 0
 	for _, key := range discovery.GetBackends() {
 		handler := discovery.GetConfigHook(key)
 		if handler != nil {
-			if rawCfg, ok := cfg.RawConfig[key]; ok {
+			if rawCfg, ok := rawCfg[key]; ok {
 				discoveryService, err = handler(rawCfg)
 				if err != nil {
 					return nil, err
@@ -57,6 +67,7 @@ func (cfg *Config) ParseDiscoveryService() (discovery.DiscoveryService, error) {
 				log.Debugf("parsed service discovery backend: %s", key)
 				discoveryCount++
 			}
+			delete(rawCfg, key)
 		}
 	}
 	if discoveryCount == 0 {
@@ -67,7 +78,7 @@ func (cfg *Config) ParseDiscoveryService() (discovery.DiscoveryService, error) {
 	return discoveryService, nil
 }
 
-// InitLogging ...
+// InitLogging configure logrus with the new log config if available
 func (cfg *Config) InitLogging() error {
 	if cfg.LogConfig != nil {
 		return cfg.LogConfig.init()
@@ -75,46 +86,45 @@ func (cfg *Config) InitLogging() error {
 	return nil
 }
 
-// ParseBackends ...
-func (cfg *Config) ParseBackends(discoveryService discovery.DiscoveryService) ([]*backends.Backend, error) {
-	backends, err := backends.NewBackends(cfg.BackendsConfig, discoveryService)
+func (cfg *rawConfig) parseBackends(discoveryService discovery.DiscoveryService) ([]*backends.Backend, error) {
+	backends, err := backends.NewBackends(cfg.backendsConfig, discoveryService)
 	if err != nil {
 		return nil, err
 	}
 	return backends, nil
 }
 
-// ParseServices ...
-func (cfg *Config) ParseServices(discoveryService discovery.DiscoveryService) ([]*services.Service, error) {
-	services, err := services.NewServices(cfg.ServicesConfig, discoveryService)
+func (cfg *rawConfig) parseServices(discoveryService discovery.DiscoveryService) ([]*services.Service, error) {
+	services, err := services.NewServices(cfg.servicesConfig, discoveryService)
 	if err != nil {
 		return nil, err
 	}
 	return services, nil
 }
 
-// ParseStopTimeout ...
-func (cfg *Config) ParseStopTimeout() (int, error) {
-	if cfg.StopTimeout == 0 {
+// parseStopTimeout ...
+func (cfg *rawConfig) parseStopTimeout() (int, error) {
+	if cfg.stopTimeout == 0 {
 		return defaultStopTimeout, nil
 	}
-	return cfg.StopTimeout, nil
+	return cfg.stopTimeout, nil
 }
 
-// ParseTelemetry ...
-func (cfg *Config) ParseTelemetry() (*telemetry.Telemetry, error) {
-	if cfg.TelemetryConfig == nil {
+// parseTelemetry ...
+func (cfg *rawConfig) parseTelemetry() (*telemetry.Telemetry, error) {
+
+	if cfg.telemetryConfig == nil {
 		return nil, nil
 	}
-	t, err := telemetry.NewTelemetry(cfg.TelemetryConfig)
+	t, err := telemetry.NewTelemetry(cfg.telemetryConfig)
 	if err != nil {
 		return nil, err
 	}
 	return t, nil
 }
 
-// CreateTelemetryService ...
-func CreateTelemetryService(t *telemetry.Telemetry, discoveryService discovery.DiscoveryService) (*services.Service, error) {
+// createTelemetryService ...
+func createTelemetryService(t *telemetry.Telemetry, discoveryService discovery.DiscoveryService) (*services.Service, error) {
 	// create a new service for Telemetry
 	svc, err := services.NewService(
 		t.ServiceName,
@@ -130,19 +140,18 @@ func CreateTelemetryService(t *telemetry.Telemetry, discoveryService discovery.D
 	return svc, nil
 }
 
-// ParseTasks ...
-func (cfg *Config) ParseTasks() ([]*tasks.Task, error) {
-	if cfg.TasksConfig == nil {
+func (cfg *rawConfig) parseTasks() ([]*tasks.Task, error) {
+	if cfg.tasksConfig == nil {
 		return nil, nil
 	}
-	tasks, err := tasks.NewTasks(cfg.TasksConfig)
+	tasks, err := tasks.NewTasks(cfg.tasksConfig)
 	if err != nil {
 		return nil, err
 	}
 	return tasks, nil
 }
 
-// ParseConfig ...
+// ParseConfig parses a raw config flag
 func ParseConfig(configFlag string) (*Config, error) {
 	if configFlag == "" {
 		return nil, errors.New("-config flag is required")
@@ -162,19 +171,89 @@ func ParseConfig(configFlag string) (*Config, error) {
 	template, err := ApplyTemplate(data)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"Could not apply template to config: %s", err)
+			"Could not apply template to config: %v", err)
 	}
-	cfg, err := UnmarshalConfig(template)
-	if cfg != nil {
-		// store so we can reload
-		cfg.ConfigFlag = configFlag
+	configMap, err := unmarshalConfig(template)
+	if err != nil {
+		return nil, err
 	}
-	return cfg, err
+	discoveryService, err := parseDiscoveryService(configMap)
+	if err != nil {
+		return nil, err
+	}
+	// Delete discovery backend keys
+	for _, backend := range discovery.GetBackends() {
+		delete(configMap, backend)
+	}
+	raw := &rawConfig{}
+	if err = decodeConfig(configMap, raw); err != nil {
+		return nil, err
+	}
+	cfg := &Config{}
+	cfg.DiscoveryService = discoveryService
+	cfg.LogConfig = raw.logConfig
+
+	preStartCmd, err := raw.parsePreStart()
+	if err != nil {
+		return nil, err
+	}
+	cfg.PreStart = preStartCmd
+
+	preStopCmd, err := raw.parsePreStop()
+	if err != nil {
+		return nil, err
+	}
+	cfg.PreStop = preStopCmd
+
+	postStopCmd, err := raw.parsePostStop()
+	if err != nil {
+		return nil, err
+	}
+	cfg.PostStop = postStopCmd
+
+	stopTimeout, err := raw.parseStopTimeout()
+	if err != nil {
+		return nil, err
+	}
+	cfg.StopTimeout = stopTimeout
+
+	services, err := raw.parseServices(discoveryService)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse services: %v", err)
+	}
+	cfg.Services = services
+
+	backends, err := raw.parseBackends(discoveryService)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to parse backends: %v", err)
+	}
+	cfg.Backends = backends
+
+	telemetry, err := raw.parseTelemetry()
+	if err != nil {
+		return nil, err
+	}
+
+	if telemetry != nil {
+		telemetryService, err2 := createTelemetryService(telemetry, discoveryService)
+		if err2 != nil {
+			return nil, err2
+		}
+		cfg.Telemetry = telemetry
+		cfg.Services = append(cfg.Services, telemetryService)
+	}
+
+	tasks, err := raw.parseTasks()
+	if err != nil {
+		return nil, err
+	}
+	cfg.Tasks = tasks
+
+	return cfg, nil
 }
 
-// UnmarshalConfig unmarshalls the raw config bytes into a Config struct
-func UnmarshalConfig(data []byte) (*Config, error) {
-	config := &Config{}
+func unmarshalConfig(data []byte) (map[string]interface{}, error) {
+	var config map[string]interface{}
 	if err := json.Unmarshal(data, &config); err != nil {
 		syntax, ok := err.(*json.SyntaxError)
 		if !ok {
@@ -182,17 +261,12 @@ func UnmarshalConfig(data []byte) (*Config, error) {
 				"Could not parse configuration: %s",
 				err)
 		}
-		return nil, newJSONParseError(data, syntax)
+		return nil, newJSONparseError(data, syntax)
 	}
-	var rawCfg map[string]interface{}
-	if err := json.Unmarshal(data, &rawCfg); err != nil {
-		return nil, err
-	}
-	config.RawConfig = rawCfg
 	return config, nil
 }
 
-func newJSONParseError(js []byte, syntax *json.SyntaxError) error {
+func newJSONparseError(js []byte, syntax *json.SyntaxError) error {
 	line, col, err := highlightError(js, syntax.Offset)
 	return fmt.Errorf("Parse error at line:col [%d:%d]: %s\n%s", line, col, syntax, err)
 }
@@ -226,4 +300,65 @@ func highlightError(data []byte, pos int64) (int, int, string) {
 		highlight = "Do you have an extra comma somewhere?"
 	}
 	return line, int(col), fmt.Sprintf("%s%s%s", prevLine, thisLine, highlight)
+}
+
+func decodeArray(raw interface{}) []interface{} {
+	if raw == nil {
+		return nil
+	}
+	var arr []interface{}
+	switch reflect.TypeOf(raw).Kind() {
+	case reflect.Slice:
+		s := reflect.ValueOf(raw)
+		for i := 0; i < s.Len(); i++ {
+			v := s.Index(i)
+			if !v.IsNil() {
+				arr = append(arr, v.Interface())
+			}
+		}
+		return arr
+	}
+	return nil
+}
+
+// We can't use mapstructure to decode our config map since we want the values
+// to also be raw interface{} types. mapstructure can only decode
+// into concrete structs and primitives
+func decodeConfig(configMap map[string]interface{}, result *rawConfig) error {
+	var logConfig LogConfig
+	var stopTimeout int
+	if err := utils.DecodeRaw(configMap["logging"], &logConfig); err != nil {
+		return err
+	}
+	if err := utils.DecodeRaw(configMap["stopTimeout"], &stopTimeout); err != nil {
+		return err
+	}
+	result.stopTimeout = stopTimeout
+	result.logConfig = &logConfig
+	result.onStart = configMap["onStart"]
+	result.preStart = configMap["preStart"]
+	result.preStop = configMap["preStop"]
+	result.postStop = configMap["postStop"]
+	result.servicesConfig = decodeArray(configMap["services"])
+	result.backendsConfig = decodeArray(configMap["backends"])
+	result.tasksConfig = decodeArray(configMap["tasks"])
+	result.telemetryConfig = configMap["telemetry"]
+
+	delete(configMap, "logging")
+	delete(configMap, "onStart")
+	delete(configMap, "preStart")
+	delete(configMap, "preStop")
+	delete(configMap, "postStop")
+	delete(configMap, "services")
+	delete(configMap, "backends")
+	delete(configMap, "tasks")
+	delete(configMap, "telemetry")
+	var unused []string
+	for key := range configMap {
+		unused = append(unused, key)
+	}
+	if len(unused) > 0 {
+		return fmt.Errorf("Unknown config keys: %v", unused)
+	}
+	return nil
 }

--- a/core/app.go
+++ b/core/app.go
@@ -90,80 +90,18 @@ func NewApp(configFlag string) (*App, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// onStart has been deprecated for preStart. Remove in 2.0
-	if cfg.PreStart != nil && cfg.OnStart != nil {
-		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use only the preStart option provided")
-	}
-
-	// alias the onStart behavior to preStart
-	if cfg.PreStart == nil && cfg.OnStart != nil {
-		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use the onStart option as a preStart")
-		cfg.PreStart = cfg.OnStart
-	}
-
-	preStartCmd, err := cfg.ParsePreStart()
-	if err != nil {
+	if err = cfg.InitLogging(); err != nil {
 		return nil, err
 	}
-	a.PreStartCmd = preStartCmd
-
-	preStopCmd, err := cfg.ParsePreStop()
-	if err != nil {
-		return nil, err
-	}
-	a.PreStopCmd = preStopCmd
-
-	postStopCmd, err := cfg.ParsePostStop()
-	if err != nil {
-		return nil, err
-	}
-	a.PostStopCmd = postStopCmd
-
-	stopTimeout, err := cfg.ParseStopTimeout()
-	if err != nil {
-		return nil, err
-	}
-	a.StopTimeout = stopTimeout
-
-	discoveryService, err := cfg.ParseDiscoveryService()
-	if err != nil {
-		return nil, err
-	}
-	a.DiscoveryService = discoveryService
-
-	backends, err := cfg.ParseBackends(discoveryService)
-	if err != nil {
-		return nil, err
-	}
-	a.Backends = backends
-
-	services, err := cfg.ParseServices(discoveryService)
-	if err != nil {
-		return nil, err
-	}
-	a.Services = services
-
-	telemetry, err := cfg.ParseTelemetry()
-	if err != nil {
-		return nil, err
-	}
-
-	if telemetry != nil {
-		telemetryService, err2 := config.CreateTelemetryService(telemetry, discoveryService)
-		if err2 != nil {
-			return nil, err2
-		}
-		a.Telemetry = telemetry
-		a.Services = append(a.Services, telemetryService)
-	}
-
-	tasks, err := cfg.ParseTasks()
-	if err != nil {
-		return nil, err
-	}
-	a.Tasks = tasks
-
+	a.PreStartCmd = cfg.PreStart
+	a.PreStopCmd = cfg.PreStop
+	a.PostStopCmd = cfg.PostStop
+	a.StopTimeout = cfg.StopTimeout
+	a.DiscoveryService = cfg.DiscoveryService
+	a.Services = cfg.Services
+	a.Backends = cfg.Backends
+	a.Tasks = cfg.Tasks
+	a.Telemetry = cfg.Telemetry
 	return a, nil
 }
 

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -62,7 +62,7 @@ func TestValidConfigParse(t *testing.T) {
 	}
 
 	if len(app.Backends) != 2 || len(app.Services) != 2 {
-		t.Errorf("Expected 2 backends and 2 services but got: %v", app)
+		t.Fatalf("Expected 2 backends and 2 services but got: len(backends)=%d, len(services)=%d", len(app.Backends), len(app.Services))
 	}
 	args := flag.Args()
 	if len(args) != 3 || args[0] != "/testdata/test.sh" {

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/joyent/containerpilot/discovery"
+	"github.com/joyent/containerpilot/discovery/consul"
 	"github.com/joyent/containerpilot/services"
 	"github.com/joyent/containerpilot/utils"
 )
@@ -95,7 +96,7 @@ func TestReloadSignal(t *testing.T) {
 		t.Errorf("Valid configuration returned error: %v", err)
 	}
 	discSvc := app.DiscoveryService
-	if svc, ok := discSvc.(*discovery.Consul); !ok || svc == nil {
+	if svc, ok := discSvc.(*consul.Consul); !ok || svc == nil {
 		t.Errorf("Configuration was not reloaded: %v", discSvc)
 	}
 }

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -1,0 +1,68 @@
+# Service Discovery
+
+ContainerPilot can support multiple, "pluggable" backends for service discovery. If you want to implement a new backend, you are awesome and we'd love to see it!
+
+Here are the steps you'll need to take:
+
+## Create your discovery package
+
+Create a new package under this folder named after your service discovery backend. For example: If you are implementing ZooKeeper, you'd make a folder called `zookeeper`. Also name the `.go` files after the backend as well:
+
+```
++ discovery/
+|-+ zookeeper/
+  |-- zookeeper.go
+  |-- zookeeper_test.go
+```
+
+## Implement `discovery.Service` interface
+
+Create a struct that represents your backend and make sure that it defines all the required functions to be considered a `discovery.Service`.
+
+Create a function which accepts a raw `interface{}` and returns either your service discovery struct, or an error if there was a parsing problem. Check the other backends `consul` and `etcd` for an example. Also look at `utils.DecodeRaw` for a utility that can transform this raw value into a concrete type or struct.
+
+Include unit and integration tests so that we can verify the implementation easily and detect breaking changes.
+
+So far, we've seen two types of discovery backends:
+
+### 1. Service Registry
+
+A service registry will have first-class support for services. It allows registering the IP/Port of a service by name and most likely supports health checking, and DNS or other means of listing the healthy services. Consul is one such service registry.  If you are implementing a backend like this, look at `consul` as an example.
+
+### 2. Coordinated Filesystem
+
+A coordinated filesystem is less of a service discovery mechanism and more of a primitive on which you can build a service discovery protocol. Ideally, we would like to keep the ContainerPilot implementation consistent across these types of backends, so look at the `etcd` backend and try to mirror the implementation used there: the paths (eg: `/containerpilot/{serviceName}/{serviceID}`), and the document body (`etcd.ServiceNode`).
+
+## Register the backend with `discovery.RegisterBackend`
+
+You'll need to register the backend name and a config function so that it can be identified and handed-off to your backend creation function by `config.go`.
+
+There are two steps involved with this:
+
+First, create an init function to register the name of your backend and a `ServiceDiscoveryConfigHook`function for parsing the configuration object. Here is an example for ZooKeeper:
+
+```go
+// init registers your backend name and  function
+func init() {
+	discovery.RegisterBackend("zookeeper", ConfigHook)
+}
+
+// ConfigHook simply implements the correct function signature
+func ConfigHook(raw interface{}) (discovery.DiscoveryService, error) {
+	return NewZookeeper(raw)
+}
+
+// NewZookeeper creates a new service discovery backend for ZooKeeper
+func NewZookeeper(config interface{}) (*ZooKeeper, error) {
+ // ...
+}
+```
+
+Then, import your service discovery package in `main.go`:
+
+```go
+  // Import backends so that they initialize
+_ "github.com/joyent/containerpilot/discovery/consul"
+_ "github.com/joyent/containerpilot/discovery/etcd"
+_ "github.com/joyent/containerpilot/discovery/zookeeper"
+```

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -1,13 +1,15 @@
-package discovery
+package consul
 
 import (
 	"testing"
 	"time"
+
+	"github.com/joyent/containerpilot/discovery"
 )
 
-func setupConsul(serviceName string) (*Consul, *ServiceDefinition) {
+func setupConsul(serviceName string) (*Consul, *discovery.ServiceDefinition) {
 	consul, _ := NewConsulConfig("consul:8500")
-	service := &ServiceDefinition{
+	service := &discovery.ServiceDefinition{
 		ID:        serviceName,
 		Name:      serviceName,
 		IpAddress: "192.168.1.1",
@@ -46,7 +48,7 @@ func TestConsulAddressParse(t *testing.T) {
 
 func runParseTest(t *testing.T, uri, expectedAddress, expectedScheme string) {
 
-	address, scheme := parseRawUri(uri)
+	address, scheme := parseRawURI(uri)
 	if address != expectedAddress || scheme != expectedScheme {
 		t.Fatalf("Expected %s over %s but got %s over %s",
 			expectedAddress, expectedScheme, address, scheme)

--- a/discovery/etcd/etcd_test.go
+++ b/discovery/etcd/etcd_test.go
@@ -1,4 +1,4 @@
-package discovery
+package etcd
 
 import (
 	"reflect"
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/client"
+	"github.com/joyent/containerpilot/discovery"
 	"golang.org/x/net/context"
 )
 
-func setupEtcd(serviceName string) (*Etcd, *ServiceDefinition) {
+func setupEtcd(serviceName string) (*Etcd, *discovery.ServiceDefinition) {
 	etcd, _ := NewEtcdConfig(map[string]interface{}{"endpoints": []string{"http://etcd:4001"}})
-	service := &ServiceDefinition{
+	service := &discovery.ServiceDefinition{
 		ID:        serviceName,
 		Name:      serviceName,
 		IpAddress: "192.168.1.1",
@@ -104,7 +105,7 @@ func TestEtcdCheckForChanges(t *testing.T) {
 	}
 }
 
-func checkServiceExists(etcd *Etcd, service *ServiceDefinition) bool {
+func checkServiceExists(etcd *Etcd, service *discovery.ServiceDefinition) bool {
 	key := etcd.getNodeKey(service)
 	if _, err := etcd.API.Get(context.Background(), key, nil); err != nil {
 		if etcdErr, ok := err.(client.Error); ok {

--- a/main.go
+++ b/main.go
@@ -6,6 +6,10 @@ import (
 	"github.com/joyent/containerpilot/core"
 
 	log "github.com/Sirupsen/logrus"
+
+	// Import backends so that they initialize
+	_ "github.com/joyent/containerpilot/discovery/consul"
+	_ "github.com/joyent/containerpilot/discovery/etcd"
 )
 
 // Main executes the containerpilot CLI

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 result=0
 for pkg in $(go list ./... | grep -v '/vendor/\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerpilot+'); do
-  if golint $pkg; then
+  if ! golint -set_exit_status $pkg; then
     result=1
   fi
 done


### PR DESCRIPTION
For #143 

- Decoupled the service discovery backends from `config.go`
- Added README for creating new discovery backends
- Refactored config parser to allow for pluggable config sections (for now just discovery backends)
- Fixed the return code in `lint.sh` script
- Fixed some lint warnings/errors

