### PR TITLE
Create a sha1 file when we make a release

### DIFF
--- a/makefile
+++ b/makefile
@@ -119,5 +119,6 @@ release: build
 	git push joyent --tags
 	cd build && tar -czf ../release/containerpilot-$(VERSION).tar.gz containerpilot
 	@echo
-	@echo Upload this file to Github release:
-	@sha1sum release/containerpilot-$(VERSION).tar.gz
+	@cd release && sha1sum containerpilot-$(VERSION).tar.gz
+	@cd release && sha1sum containerpilot-$(VERSION).tar.gz > containerpilot-$(VERSION).sha1.txt
+	@echo Upload files in release/ directory to GitHub release.


### PR DESCRIPTION
Per @mterron's suggestion in https://github.com/autopilotpattern/consul/issues/13#issuecomment-217754796, this adds a file with the SHA1 file to facilitate automated checking.

[Release 2.1.1](https://github.com/joyent/containerpilot/releases/tag/2.1.1) has an example of the output.

cc @misterbisson @mterron