### PR TITLE
Remove stopTimeout from configMap before checking unknown keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -349,6 +349,7 @@ func decodeConfig(configMap map[string]interface{}, result *rawConfig) error {
 	delete(configMap, "preStart")
 	delete(configMap, "preStop")
 	delete(configMap, "postStop")
+	delete(configMap, "stopTimeout")
 	delete(configMap, "services")
 	delete(configMap, "backends")
 	delete(configMap, "tasks")

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -16,6 +16,7 @@ var testJSON = `{
 	"preStart": "/bin/to/preStart.sh arg1 arg2",
 	"preStop": ["/bin/to/preStop.sh","arg1","arg2"],
 	"postStop": ["/bin/to/postStop.sh"],
+	"stopTimeout": 5,
 	"services": [
 			{
 					"name": "serviceA",

--- a/integration_tests/fixtures/nginx/Dockerfile
+++ b/integration_tests/fixtures/nginx/Dockerfile
@@ -9,8 +9,8 @@ RUN apk update && apk add \
     && rm -rf /var/cache/apk/*
 
 # we use consul-template to re-write our Nginx virtualhost config
-RUN curl -Lo /tmp/consul_template_0.11.0_linux_amd64.zip https://github.com/hashicorp/consul-template/releases/download/v0.11.0/consul_template_0.11.0_linux_amd64.zip && \
-    unzip /tmp/consul_template_0.11.0_linux_amd64.zip && \
+RUN curl -Lo /tmp/consul_template_0.14.0_linux_amd64.zip https://releases.hashicorp.com/consul-template/0.14.0/consul-template_0.14.0_linux_amd64.zip && \
+    unzip /tmp/consul_template_0.14.0_linux_amd64.zip && \
     mv consul-template /bin
 
 # Add confd to re-write our Nginx config from etcd


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/149. When we parse the configuration we remove all the expected keys from the `map[string]interface{}` and then verify that there are no remaining keys. Any remaining keys will fire an error `Unknown config keys`. The `stopTimeout` configuration was accidentally left off when we did the refactor in https://github.com/joyent/containerpilot/pull/144, so this fixes that.

I can confirm that if I make only the change to the test config that the test fails as expected:
```
=== RUN   TestValidConfigParse
--- FAIL: TestValidConfigParse (0.00s)
        app_test.go:62: Unexpected error in LoadApp: Unknown config keys: [stopTimeout]
```

cc @mterron @justenwalker @misterbisson 