### PR TITLE
Add integration test to verify telemetry service (de)registration

### DIFF
--- a/integration_tests/tests/test_telemetry/run.sh
+++ b/integration_tests/tests/test_telemetry/run.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+set -e
+
+function finish {
+    result=$?
+    docker-compose rm -f
+    exit $result
+}
+trap finish EXIT
+
 
 # start up consul and app
 docker-compose up -d consul
@@ -8,14 +17,26 @@ docker-compose up -d app
 APP_ID="$(docker-compose ps -q app)"
 IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${APP_ID})
 
-# this interface takes a while to converge
+# This interface takes a while to converge
+set +e
 for i in {20..1}; do
-    sleep 1
-    docker exec -it ${APP_ID} curl -v -s --fail ${IP}:9090/metrics | grep 'containerpilot_app_some_counter 42' && break
+    sleep 1 # sleep has to be before b/c we want exit code
+    docker exec -it ${APP_ID} curl -s ${IP}:9090/metrics | grep 'containerpilot_app_some_counter 42' && break
 done
-
 result=$?
+set -e
+if [ $result -ne 0 ]; then exit $result; fi
 
-# cleanup
-docker-compose rm -f
-exit $result
+# Make we register and tear down telemetry service in Consul
+CONSUL_ID="$(docker-compose ps -q consul)"
+set +e
+for i in {5..1}; do
+    sleep 1
+    docker exec -it ${CONSUL_ID} curl -s --fail localhost:8500/v1/catalog/service/containerpilot | grep 'containerpilot' && break
+done
+result=$?
+set -e
+if [ $result -ne 0 ]; then exit $result; fi
+
+docker-compose stop app
+docker exec -it ${CONSUL_ID} curl -s --fail localhost:8500/v1/catalog/service/containerpilot | grep -v 'containerpilot'


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/135

This integration test verifies that we're registering the telemetry service (`containerpilot`) in the service catalog and that we're deregistering it when we stop the container.

cc @misterbisson @adamlc