### PR TITLE
Not registerd App.ConfigFlag value for reload

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -102,6 +102,7 @@ func NewApp(configFlag string) (*App, error) {
 	a.Backends = cfg.Backends
 	a.Tasks = cfg.Tasks
 	a.Telemetry = cfg.Telemetry
+	a.ConfigFlag = configFlag
 	return a, nil
 }
 


### PR DESCRIPTION
SIGHUP signal doesn't work because the app instance doesn't have ConfigFlag.