### PR TITLE
Interpolate variables in command args

### DIFF
--- a/core/app_test.go
+++ b/core/app_test.go
@@ -197,6 +197,21 @@ func TestParseTrailingComma(t *testing.T) {
 	}`, "Do you have an extra comma somewhere?")
 }
 
+func TestRenderArgs(t *testing.T) {
+	flags := []string{"-name", "{{ .HOSTNAME }}"}
+	expected, _ := os.Hostname()
+	if got := getArgs(flags)[1]; got != expected {
+		t.Errorf("Expected %v but got %v for rendered hostname", expected, got)
+	}
+
+	// invalid template should just be returned unchanged
+	flags = []string{"-name", "{{ .HOSTNAME }"}
+	expected = "{{ .HOSTNAME }"
+	if got := getArgs(flags)[1]; got != expected {
+		t.Errorf("Expected %v but got %v for unrendered hostname", expected, got)
+	}
+}
+
 func TestMetricServiceCreation(t *testing.T) {
 
 	jsonFragment := `{

--- a/documentation/12-configuration/README.md
+++ b/documentation/12-configuration/README.md
@@ -252,9 +252,9 @@ All executable fields, including `services/health`, `preStart`, `preStop`, `post
 
 ### Template configuration
 
-ContainerPilot configuration has template support. If you have an environment variable such as `FOO=BAR` then you can use `{{.FOO}}` in your configuration file and it will be substituted with `BAR`.
+ContainerPilot configuration has template support. If you have an environment variable such as `FOO=BAR` then you can use `{{.FOO}}` in your configuration file or in your command arguments and it will be substituted with `BAR`.
 
-**Example usage**
+**Example usage in a config file**
 
 ```json
 {
@@ -262,5 +262,17 @@ ContainerPilot configuration has template support. If you have an environment va
   "preStart": "/usr/local/bin/preStart-script.sh {{.URL_TO_SERVICE}} {{.API_KEY}}",
 }
 ```
+
+**Example usage in a Dockerfile**
+
+```
+ENV APP_PORT=8000
+CMD [ "/usr/local/bin/containerpilot", \
+      "node",\
+      "/usr/local/bin/http-server",\
+      "-p",\
+      "{{ .APP_PORT }}"]
+```
+
 
 **Note**:  If you need more than just variable interpolation, check out the [Go text/template Docs](https://golang.org/pkg/text/template/).

--- a/integration_tests/fixtures/app/Dockerfile
+++ b/integration_tests/fixtures/app/Dockerfile
@@ -21,6 +21,10 @@ COPY task.sh /task.sh
 # by default use app-consul.json, allows for override in docker-compose
 ENV CONTAINERPILOT=file:///app-with-consul.json
 
+# default port, allows us to override in docker-compose and also test
+# env var interpolation in the command args
+ENV APP_PORT=8000
+
 ENTRYPOINT [ "/bin/containerpilot", \
              "/usr/local/bin/node", \
-             "/usr/local/bin/http-server", "/srv", "-p", "8000"]
+             "/usr/local/bin/http-server", "/srv", "-p", "{{ .APP_PORT }}"]


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/145

Use the same template rendering process for the command line as we do in the config file. This allows us to pass environment variables at runtime into the shimmed application's own flags.

I've hopped on this sooner rather than later because I'm working on https://github.com/autopilotpattern/etcd and finding that the etcd configuration simply can't be updated in the `preStart` hooks because they support *only* config flags or env vars, which means we can't do things like set the etcd node name to the hostname otherwise.

cc @misterbisson @justenwalker @dekobon 