### PR TITLE
Expose service IP address as environment variable

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -31,8 +31,8 @@ func NewBackends(raw []interface{}, disc discovery.ServiceBackend) ([]*Backend, 
 		return nil, fmt.Errorf("Backend configuration error: %v", err)
 	}
 	for _, b := range backends {
-		if b.Name == "" {
-			return nil, fmt.Errorf("backend must have a `name`")
+		if err := utils.ValidateServiceName(b.Name); err != nil {
+			return nil, err
 		}
 		cmd, err := utils.ParseCommandArgs(b.OnChangeExec)
 		if err != nil {

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -230,6 +230,12 @@ func TestMetricServiceCreation(t *testing.T) {
 			if service.Name != "containerpilot" {
 				t.Errorf("Got incorrect service back: %v", service)
 			}
+			for _, envVar := range os.Environ() {
+				if strings.HasPrefix(envVar, "CONTAINERPILOT_CONTAINERPILOT_IP") {
+					return
+				}
+			}
+			t.Errorf("Did not find CONTAINERPILOT_CONTAINERPILOT_IP env var")
 		}
 	}
 }

--- a/integration_tests/tests/test_envvars/containerpilot.json
+++ b/integration_tests/tests/test_envvars/containerpilot.json
@@ -1,0 +1,15 @@
+{
+  "etcd": {
+    "endpoints": ["http://127.0.0.1:4001"],
+    "prefix": "/containerpilot"
+  },
+  "services": [
+    {
+      "name": "etcd",
+      "port": 4001,
+      "health": "curl --fail -o /dev/null http://127.0.0.1:2379/health",
+      "poll": 10,
+      "ttl": 25
+    }
+  ]
+}

--- a/integration_tests/tests/test_envvars/docker-compose.yml
+++ b/integration_tests/tests/test_envvars/docker-compose.yml
@@ -1,0 +1,23 @@
+etcd:
+    image: "cpfix_etcd"
+    mem_limit: 128m
+    hostname: etcd
+    ports:
+      - 4001:4001
+      - 2379:2379
+    environment:
+      - CONTAINERPILOT=file:///etc/containerpilot.json
+    volumes:
+      - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
+      - './containerpilot.json:/etc/containerpilot.json'
+    entrypoint: >-
+      /bin/containerpilot
+      /etcd
+      -name etcd0
+      -advertise-client-urls http://etcd:2379,http://etcd:4001
+      -listen-client-urls 'http://{{ .CONTAINERPILOT_ETCD_IP }}:2379,http://{{ .CONTAINERPILOT_ETCD_IP }}:4001'
+      -initial-advertise-peer-urls http://etcd:2380
+      -listen-peer-urls 'http://{{ .CONTAINERPILOT_ETCD_IP }}:2380'
+      -initial-cluster-token etcd-cluster-1
+      -initial-cluster etcd0=http://etcd:2380
+      -initial-cluster-state new

--- a/integration_tests/tests/test_envvars/run.sh
+++ b/integration_tests/tests/test_envvars/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+docker-compose up -d etcd
+
+# give the instance enough time to self-elect
+sleep 2
+curl --fail -s http://${DOCKER_HOST:-localhost}:2379/health

--- a/services/services.go
+++ b/services/services.go
@@ -21,7 +21,7 @@ type Service struct {
 	TTL              int         `mapstructure:"ttl"`
 	Interfaces       interface{} `mapstructure:"interfaces"`
 	Tags             []string    `mapstructure:"tags"`
-	ipAddress        string
+	IPAddress        string
 	healthCheckCmd   *exec.Cmd
 	discoveryService discovery.ServiceBackend
 	definition       *discovery.ServiceDefinition
@@ -62,8 +62,8 @@ func NewService(name string, poll, port, ttl int, interfaces interface{},
 }
 
 func parseService(s *Service, disc discovery.ServiceBackend) error {
-	if s.Name == "" {
-		return fmt.Errorf("service must have a `name`")
+	if err := utils.ValidateServiceName(s.Name); err != nil {
+		return err
 	}
 	hostname, _ := os.Hostname()
 	s.ID = fmt.Sprintf("%s-%s", s.Name, hostname)
@@ -95,7 +95,7 @@ func parseService(s *Service, disc discovery.ServiceBackend) error {
 	if err != nil {
 		return err
 	}
-	s.ipAddress = ipAddress
+	s.IPAddress = ipAddress
 
 	s.definition = &discovery.ServiceDefinition{
 		ID:        s.ID,
@@ -103,7 +103,7 @@ func parseService(s *Service, disc discovery.ServiceBackend) error {
 		Port:      s.Port,
 		TTL:       s.TTL,
 		Tags:      s.Tags,
-		IPAddress: s.ipAddress,
+		IPAddress: s.IPAddress,
 	}
 	return nil
 }

--- a/utils/names.go
+++ b/utils/names.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var validName = regexp.MustCompile(`^[a-z][a-zA-Z0-9\-]+$`)
+
+// ValidateServiceName checks if the service name passed as an argument
+// is is alpha-numeric with dashes. This ensures compliance with both DNS
+// and discovery backends.
+func ValidateServiceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("`name` must not be blank")
+	}
+	if ok := validName.MatchString(name); !ok {
+		log.Warnf("Deprecation warning: service names must be alpha-numeric with dashes. In a future version of ContainerPilot this will be an error.")
+	}
+	return nil
+}

--- a/utils/names_test.go
+++ b/utils/names_test.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestValidateServiceName(t *testing.T) {
+
+	var validNames = []string{
+		"myService",
+		"my-service",
+		"my-service-123",
+	}
+	for _, name := range validNames {
+		if err := ValidateServiceName(name); err != nil {
+			t.Errorf("Expected no error for name `%v` but got %v", name, err)
+		}
+	}
+
+	// TODO: in a future version of ContainerPilot invalid service names
+	//       will be an error rather than a warning. When that happens,
+	//       uncomment this test.
+	//
+	// var invalidNames = []string{
+	// 	"my_service",
+	// 	"-my-service",
+	// 	"my%service",
+	// }
+	// for _, name := range invalidNames {
+	// 	if err := ValidateServiceName(name); err == nil {
+	// 		t.Errorf("Expected error for name `%v` but got nil", name)
+	// 	}
+	// }
+}


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/171

For each service, create an environment variable that has the name `CONTAINERPILOT_<SERVICE>_IP` and the value of the IP address where we're advertising that service.

@justenwalker @dekobon I'd like to do an integration test before this gets merged just to make sure it works out ok in practice, but this is good for review of the approach I think.