### PR TITLE
Set GOEXPERIMENT for go1.6 framepointer support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM golang
+FROM golang:1.6
 
 RUN  go get github.com/golang/lint/golint \
   && go get github.com/tools/godep
 
 ENV CGO_ENABLED 0
 ENV GO15VENDOREXPERIMENT 1
+ENV GOEXPERIMENT framepointer
 ENV GOPATH /go:/cp


### PR DESCRIPTION
In the upcoming golang 1.7, framepointers will be [enabled by default](https://github.com/golang/go/issues/15840). But after reading that GH issue I've realized that in the meantime, we can get this behavior today by pinning our go toolchain version -- which we should have been doing all along -- and adding an environment variable to our build container.

cc @pfmooney @misterbisson 