### PR TITLE
SIGINT Termination and Co-Process Restart Suspension

### DIFF
--- a/coprocesses/coprocess.go
+++ b/coprocesses/coprocess.go
@@ -146,6 +146,10 @@ func (coprocess *Coprocess) Start() {
 	}
 }
 
+func (coprocess *Coprocess) SuspendRestart() {
+	coprocess.restart = false
+} 
+
 // Stop kills a running coprocess
 func (coprocess *Coprocess) Stop() {
 	log.Debugf("coprocess[%s].Stop", coprocess.Name)

--- a/coprocesses/coprocess.go
+++ b/coprocesses/coprocess.go
@@ -146,6 +146,7 @@ func (coprocess *Coprocess) Start() {
 	}
 }
 
+// Stops the coprocess from being restarted if it dies
 func (coprocess *Coprocess) SuspendRestart() {
 	coprocess.restart = false
 } 

--- a/coprocesses/coprocess.go
+++ b/coprocesses/coprocess.go
@@ -146,7 +146,7 @@ func (coprocess *Coprocess) Start() {
 	}
 }
 
-// Sets whether a process from being restarted if it dies ignoring restart count
+// ShouldRestart sets whether a process from being restarted if it dies ignoring restart count
 func (coprocess *Coprocess) ShouldRestart(shouldRestart bool) {
 	coprocess.restart = shouldRestart
 } 

--- a/coprocesses/coprocess.go
+++ b/coprocesses/coprocess.go
@@ -146,9 +146,9 @@ func (coprocess *Coprocess) Start() {
 	}
 }
 
-// Stops the coprocess from being restarted if it dies
-func (coprocess *Coprocess) SuspendRestart() {
-	coprocess.restart = false
+// Sets whether a process from being restarted if it dies ignoring restart count
+func (coprocess *Coprocess) ShouldRestart(shouldRestart bool) {
+	coprocess.restart = shouldRestart
 } 
 
 // Stop kills a running coprocess

--- a/core/app.go
+++ b/core/app.go
@@ -210,6 +210,9 @@ func (a *App) Terminate() {
 	defer a.signalLock.Unlock()
 	a.stopPolling()
 	a.forAllServices(deregisterService)
+	for _, coprocess := range a.Coprocesses {
+		coprocess.SuspendRestart()
+	}
 
 	// Run and wait for preStop command to exit
 	utils.RunWithFields(a.PreStopCmd, log.Fields{"process": "PreStop"})

--- a/core/app.go
+++ b/core/app.go
@@ -211,7 +211,7 @@ func (a *App) Terminate() {
 	a.stopPolling()
 	a.forAllServices(deregisterService)
 	for _, coprocess := range a.Coprocesses {
-		coprocess.SuspendRestart()
+		coprocess.ShouldRestart(false)
 	}
 
 	// Run and wait for preStop command to exit

--- a/core/signals.go
+++ b/core/signals.go
@@ -9,13 +9,15 @@ import (
 // HandleSignals listens for and captures signals used for orchestration
 func (a *App) handleSignals() {
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGUSR1, syscall.SIGTERM, syscall.SIGHUP)
+	signal.Notify(sig, syscall.SIGUSR1, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGINT)
 	go func() {
 		for signal := range sig {
 			switch signal {
 			case syscall.SIGUSR1:
 				a.ToggleMaintenanceMode()
 			case syscall.SIGTERM:
+				a.Terminate()
+			case syscall.SIGINT:
 				a.Terminate()
 			case syscall.SIGHUP:
 				a.Reload()


### PR DESCRIPTION
Not sure what the wider repercussions would be on enabling this so completely open to feedback. 

SIGINT Termination:
Because of the issues around service registration with multiple instances of Consul being available behind a single DNS hostname (where the same service could potentially become registered multiple times), we have installed Consul into our container image via co-processes. We use the same image for development purposes locally (typically through `docker run -it`) and one would typically Ctrl-C or otherwise issue a SIGINT to break out of this. Containerpilot at the moment will only listen for/forward on SIGTERM. This change causes it to perform the same action for SIGINT as well. 

If it isn't acceptable to make this a hard-coded setting, perhaps an option can be added into the configuration file such as `{"extraTermSigs": ["SIGINT"]}` to control the behaviour

Co-Process Restart Suspension:
One issue that we also observed given we were embedding Consul into the container is the rather large list of failed Consul nodes that would amass over time. In an attempt to have the Consul agent 'leave' the cluster, it would shut itself down only to be restarted by ContainerPilot and re-join the cluster, even while CP was in the process of terminating. I've simply added a method that suspends the automated restarting of co-processes if ContainerPilot is in the process of terminating.
