### PR TITLE
Remove vendor from .PHONY block in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -euc
 .DEFAULT_GOAL := build
 
-.PHONY: clean test integration consul etcd run-consul run-etcd example example-consul example-etcd ship dockerfile docker cover lint vendor
+.PHONY: clean test integration consul etcd run-consul run-etcd example example-consul example-etcd ship dockerfile docker cover lint
 
 IMPORT_PATH := github.com/joyent/containerpilot
 VERSION ?= dev-build-not-for-release


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/185

This makes sure that we don't re-run the `vendor` target with its expensive and Internet-connecting `godep restore` on every unit test run under local development. Updating the vendor directory should be done by `make clean vendor`.