### PR TITLE
Fixing broken blog link reported on Twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We've published a number of example applications demonstrating how ContainerPilo
 - [Consul, running as an HA raft](https://github.com/autopilotpattern/consul)
 - [Couchbase](https://github.com/autopilotpattern/couchbase)
 - [Mesos on Joyent Triton](https://www.joyent.com/blog/mesos-by-the-pound)
-- [Nginx with dynamic upstreams](https://www.joyent.com/blog/dynamic-nginx-upstreams-with-containerpilot)
+- [Nginx with dynamic upstreams](https://www.joyent.com/blog/dynamic-nginx-upstreams-with-containerbuddy)
 
 ## Contributing
 


### PR DESCRIPTION
Per tweet: https://twitter.com/flyinprogrammer/status/755779542560583680