### PR TITLE
Add config support for health, onChange, sensor timeouts

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -16,6 +16,7 @@ type Backend struct {
 	Poll             int         `mapstructure:"poll"` // time in seconds
 	OnChangeExec     interface{} `mapstructure:"onChange"`
 	Tag              string      `mapstructure:"tag"`
+	Timeout          string      `mapstructure:"timeout"`
 	discoveryService discovery.ServiceBackend
 	lastState        interface{}
 	onChangeCmd      *commands.Command
@@ -38,9 +39,7 @@ func NewBackends(raw []interface{}, disc discovery.ServiceBackend) ([]*Backend, 
 			return nil, fmt.Errorf("`onChange` is required in backend %s",
 				b.Name)
 		}
-
-		// TODO: add field to Backend to pass to timeout here
-		cmd, err := commands.NewCommand(b.OnChangeExec, "0")
+		cmd, err := commands.NewCommand(b.OnChangeExec, b.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("Could not parse `onChange` in backend %s: %s",
 				b.Name, err)

--- a/backends/backends_test.go
+++ b/backends/backends_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOnChangeCmd(t *testing.T) {
-	cmd1, _ := commands.NewCommand("./testdata/test.sh doStuff --debug", "")
+	cmd1, _ := commands.NewCommand("./testdata/test.sh doStuff --debug", "1s")
 	backend := &Backend{
 		onChangeCmd: cmd1,
 	}

--- a/backends/backends_test.go
+++ b/backends/backends_test.go
@@ -58,6 +58,27 @@ func TestBackendsParse(t *testing.T) {
 	}
 }
 
+func TestBackendsConfigError(t *testing.T) {
+	var raw []interface{}
+	json.Unmarshal([]byte(`[{"name": ""}]`), &raw)
+	_, err := NewBackends(raw, nil)
+	validateBackendConfigError(t, err, "`name` must not be blank")
+	raw = nil
+
+	json.Unmarshal([]byte(`[{"name": "myName"}]`), &raw)
+	_, err = NewBackends(raw, nil)
+	validateBackendConfigError(t, err, "`onChange` is required in backend myName")
+
+	json.Unmarshal([]byte(`[{"name": "myName", "onChange": "/bin/true", "timeout": "xx"}]`), &raw)
+	_, err = NewBackends(raw, nil)
+	validateBackendConfigError(t, err,
+		"Could not parse `onChange` in backend myName: time: invalid duration xx")
+
+	json.Unmarshal([]byte(`[{"name": "myName", "onChange": "/bin/true", "timeout": ""}]`), &raw)
+	_, err = NewBackends(raw, nil)
+	validateBackendConfigError(t, err, "`poll` must be > 0 in backend myName")
+}
+
 // ------------------------------------------
 // test helpers
 
@@ -71,5 +92,20 @@ func validateCommandParsed(t *testing.T, name string, parsed *commands.Command,
 	}
 	if !reflect.DeepEqual(parsed.Args, expectedArgs) {
 		t.Errorf("%s arguments not configured: %s != %s", name, parsed.Args, expectedArgs)
+	}
+}
+
+func validateBackendConfigError(t *testing.T, err error, expected string) {
+	if expected == "" {
+		if err != nil {
+			t.Fatalf("Expected no error but got %s", err)
+		}
+	} else {
+		if err == nil {
+			t.Fatalf("Expected %s but got nil error", expected)
+		}
+		if err.Error() != expected {
+			t.Fatalf("Expected %s but got %s", expected, err.Error())
+		}
 	}
 }

--- a/documentation/12-configuration/README.md
+++ b/documentation/12-configuration/README.md
@@ -122,7 +122,7 @@ The format of the JSON file configuration is as follows:
 - `poll` is the time in seconds between polling for health checks.
 - `ttl` is the time-to-live of a successful health check. This should be longer than the polling rate so that the polling process and the TTL aren't racing; otherwise Consul will mark the service as unhealthy.
 - `tags` is an optional array of tags. If the discovery service supports it (Consul does), the service will register itself with these tags.
-- `timeout` an optional value to wait before forcibly killing the health check. Health checks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This means that a heartbeat will not be sent. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the health check.
+- `timeout` an optional value to wait before forcibly killing the health check. Health checks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This means that a heartbeat will not be sent. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the health check. *Deprecation warning:* in ContainerPilot 3.0 this will default to the `poll` time.
 
 
 ### `backends`
@@ -130,7 +130,7 @@ The format of the JSON file configuration is as follows:
 - `name` is the name of a backend service that this container depends on, as it will appear in Consul.
 - `poll` is the time in seconds between polling for changes.
 - `onChange` is the executable (and its arguments) that is called when there is a change in the list of IPs and ports for this backend.
-- `timeout` an optional value to wait before forcibly killing the `onChange` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the `onChange` handler.
+- `timeout` an optional value to wait before forcibly killing the `onChange` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the `onChange` handler. *Deprecation warning:* in ContainerPilot 3.0 this will default to the `poll` time.
 
 ### Service catalog
 

--- a/documentation/12-configuration/README.md
+++ b/documentation/12-configuration/README.md
@@ -50,7 +50,7 @@ The format of the JSON file configuration is as follows:
         "--fail",
         "-s",
         "http://localhost/app"
-      ],
+        ],
       "interfaces": [
         "eth0",
         "eth1[1]",
@@ -63,6 +63,7 @@ The format of the JSON file configuration is as follows:
       ],
       "poll": 10,
       "ttl": 30,
+      "timeout": "10s"
       "tags": ["tag1"]
     }
   ],
@@ -70,12 +71,14 @@ The format of the JSON file configuration is as follows:
     {
       "name": "nginx",
       "poll": 30,
-      "onChange": "/usr/local/bin/reload-app.sh"
+      "onChange": "/usr/local/bin/reload-app.sh",
+      "timeout": "30s"
     },
     {
       "name": "app",
       "poll": 10,
-      "onChange": "/usr/local/bin/reload-app.sh"
+      "onChange": "/usr/local/bin/reload-app.sh",
+      "timeout": "10s"
     }
   ],
   "telemetry": {
@@ -119,6 +122,7 @@ The format of the JSON file configuration is as follows:
 - `poll` is the time in seconds between polling for health checks.
 - `ttl` is the time-to-live of a successful health check. This should be longer than the polling rate so that the polling process and the TTL aren't racing; otherwise Consul will mark the service as unhealthy.
 - `tags` is an optional array of tags. If the discovery service supports it (Consul does), the service will register itself with these tags.
+- `timeout` an optional value to wait before forcibly killing the health check. Health checks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This means that a heartbeat will not be sent. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the health check.
 
 
 ### `backends`
@@ -126,6 +130,7 @@ The format of the JSON file configuration is as follows:
 - `name` is the name of a backend service that this container depends on, as it will appear in Consul.
 - `poll` is the time in seconds between polling for changes.
 - `onChange` is the executable (and its arguments) that is called when there is a change in the list of IPs and ports for this backend.
+- `timeout` an optional value to wait before forcibly killing the `onChange` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the `onChange` handler.
 
 ### Service catalog
 

--- a/documentation/19-telemetry/README.md
+++ b/documentation/19-telemetry/README.md
@@ -55,7 +55,7 @@ The fields for a sensor are as follows:
 - `type` is the type of collector Prometheus will use (one of `counter`, `gauge`, `histogram` or `summary`). See [below](#Collector_types) for details.
 - `poll` is the time in seconds between running the `check`.
 - `check` is the executable (and its arguments) that is called when it is time to perform a telemetry collection.
-- `timeout` an optional value to wait before forcibly killing the `check` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the `check` handler.
+- `timeout` an optional value to wait before forcibly killing the `check` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the `check` handler. *Deprecation warning:* in ContainerPilot 3.0 this will default to the `poll` time.
 
 The check executable is expected to return via stdout a value that can be parsed as a single 64-bit float number. Whitespace will be trimmed, but any other text in the stdout of the executable will cause the metric to be dropped. If you need to return additional information for logging, you should return this via stderr (which ContainerPilot will pass along to the Docker engine).
 

--- a/documentation/19-telemetry/README.md
+++ b/documentation/19-telemetry/README.md
@@ -27,7 +27,8 @@ A minimal configuration for ContainerPilot including telemetry might look like t
         "help": "help text",
         "type": "counter",
         "poll": 5,
-        "check": ["/bin/sensor.sh"]
+        "check": ["/bin/sensor.sh"],
+        "timeout": "5s"
       }
     ]
   }
@@ -54,6 +55,7 @@ The fields for a sensor are as follows:
 - `type` is the type of collector Prometheus will use (one of `counter`, `gauge`, `histogram` or `summary`). See [below](#Collector_types) for details.
 - `poll` is the time in seconds between running the `check`.
 - `check` is the executable (and its arguments) that is called when it is time to perform a telemetry collection.
+- `timeout` an optional value to wait before forcibly killing the `check` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the `check` handler.
 
 The check executable is expected to return via stdout a value that can be parsed as a single 64-bit float number. Whitespace will be trimmed, but any other text in the stdout of the executable will cause the metric to be dropped. If you need to return additional information for logging, you should return this via stderr (which ContainerPilot will pass along to the Docker engine).
 

--- a/services/services.go
+++ b/services/services.go
@@ -21,6 +21,7 @@ type Service struct {
 	TTL              int         `mapstructure:"ttl"`
 	Interfaces       interface{} `mapstructure:"interfaces"`
 	Tags             []string    `mapstructure:"tags"`
+	Timeout          string      `mapstructure:"timeout"`
 	IPAddress        string
 	healthCheckCmd   *commands.Command
 	discoveryService discovery.ServiceBackend
@@ -81,8 +82,7 @@ func parseService(s *Service, disc discovery.ServiceBackend) error {
 	// if the HealthCheckExec is nil then we'll have no health check
 	// command; this is useful for the telemetry service
 	if s.HealthCheckExec != nil {
-		// TODO: add field to Services to pass to timeout here
-		cmd, err := commands.NewCommand(s.HealthCheckExec, "0")
+		cmd, err := commands.NewCommand(s.HealthCheckExec, s.Timeout)
 		if err != nil {
 			return fmt.Errorf("Could not parse `health` in service %s: %s", s.Name, err)
 		}

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHealthCheck(t *testing.T) {
-	cmd1, _ := commands.NewCommand("./testdata/test.sh doStuff --debug", "")
+	cmd1, _ := commands.NewCommand("./testdata/test.sh doStuff --debug", "1s")
 	service := &Service{
 		healthCheckCmd: cmd1,
 	}
@@ -35,6 +35,7 @@ func TestServiceParse(t *testing.T) {
   "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
   "poll": 30,
   "ttl": 19,
+  "timeout": "1ms",
   "tags": ["tag1","tag2"]
 },
 {

--- a/telemetry/sensors.go
+++ b/telemetry/sensors.go
@@ -21,6 +21,7 @@ type Sensor struct {
 	Type      string      `mapstructure:"type"`
 	Poll      int         `mapstructure:"poll"` // time in seconds
 	CheckExec interface{} `mapstructure:"check"`
+	Timeout   string      `mapstructure:"timeout"`
 	checkCmd  *commands.Command
 	collector prometheus.Collector
 }
@@ -81,8 +82,7 @@ func NewSensors(raw []interface{}) ([]*Sensor, error) {
 		return nil, fmt.Errorf("Sensor configuration error: %v", err)
 	}
 	for _, s := range sensors {
-		// TODO: add field to Sensors to pass to timeout here
-		check, err := commands.NewCommand(s.CheckExec, "0")
+		check, err := commands.NewCommand(s.CheckExec, s.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse check in sensor %s: %s", s.Name, err)
 		}

--- a/telemetry/sensors_test.go
+++ b/telemetry/sensors_test.go
@@ -216,7 +216,7 @@ func getFromTestServer(t *testing.T, testServer *httptest.Server) string {
 
 func TestSensorObserve(t *testing.T) {
 
-	cmd1, _ := commands.NewCommand("./testdata/test.sh doStuff --debug", "0")
+	cmd1, _ := commands.NewCommand("./testdata/test.sh doStuff --debug", "1s")
 	sensor := &Sensor{checkCmd: cmd1}
 	if val, err := sensor.observe(); err != nil {
 		t.Fatalf("Unexpected error from sensor check: %s", err)


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/139

This PR provides configuration options for the `health`, `onChange`, and `sensor` handlers to take advantage of the timeout option provided by PR #184.

~~TODO:~~ *Done*
- [x] verify that I haven't reduced test coverage; the timeout options themselves have been well-tested previously so I just need to make sure the extra config is covered
- [x] figure out what's going on in https://github.com/joyent/containerpilot/issues/139#issuecomment-237226335, which I haven't been able to reproduce locally.

cc @misterbisson @justenwalker 