### PR TITLE
Ensure coprocesses do not restart once stopped

### DIFF
--- a/coprocesses/coprocess.go
+++ b/coprocesses/coprocess.go
@@ -139,5 +139,7 @@ func (c *Coprocess) Start() {
 func (c *Coprocess) Stop() {
 	log.Debugf("coprocess[%s].Stop", c.Name)
 	c.restartsRemain = haltRestarts
+	c.restartLimit = haltRestarts
+	c.restart = false
 	c.cmd.Kill()
 }

--- a/core/app.go
+++ b/core/app.go
@@ -335,6 +335,6 @@ func (a *App) handleCoprocesses() {
 
 func (a *App) stopCoprocesses() {
 	for _, coprocess := range a.Coprocesses {
-		go coprocess.Stop()
+		coprocess.Stop()
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/joyent/containerpilot/issues/201

- send SIGKILL synchronously to coprocess
- set `restartLimit` and `restart` flag to prevent a Coprocess that's
  received `Stop()` from restarting.

cc @misterbisson @justenwalker 
I've run the unit and integration tests and given this a try on autopilotpattern/nginx and my work on https://github.com/autopilotpattern/mysql/issues/43 as well.