### PR TITLE
Attach stdout/stderr in RunAndWait

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -66,6 +66,10 @@ func RunAndWait(c *Command, fields log.Fields) (int, error) {
 	}
 	log.Debugf("%s.RunAndWait start", c.Name)
 	c.setUpCmd(fields)
+	if fields == nil {
+		c.Cmd.Stdout = os.Stdout
+		c.Cmd.Stderr = os.Stderr
+	}
 	log.Debugf("%s.Cmd.Run", c.Name)
 	if err := c.Cmd.Run(); err != nil {
 		if exiterr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/207.

#184 caused a bug where stdout/stderr of the main application were no longer being captured. We need to attach stdout/stderr for a command whenever we don't have logging fields set. But we can't do this in `setUpCmd` because it breaks the case of `RunAndWaitForOutput` so I've added it to `RunAndWait` directly.

I've run unit and integration tests on this PR as well as added the build output to a build of autopilotpattern/nginx to [verify the behavior for log capture of the Nginx logs is correct](https://gist.github.com/tgross/fb8e41d7b8f2a6cae135a7a90464fd45).

cc @fitz123 @misterbisson @justenwalker 