### PR TITLE
Fix exit codes not being respected by RunWithTimeout

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -77,6 +77,14 @@ func TestRunWithTimeout(t *testing.T) {
 	}
 }
 
+func TestRunWithTimeoutFailed(t *testing.T) {
+	cmd, _ := NewCommand("./testdata/test.sh failStuff --debug", "0")
+	fields := log.Fields{"process": "test"}
+	if err := RunWithTimeout(cmd, fields); err == nil {
+		t.Errorf("Expected error but got nil")
+	}
+}
+
 func TestEmptyCommand(t *testing.T) {
 	if cmd, err := NewCommand("", "0"); cmd != nil || err == nil {
 		t.Errorf("Expected exit (nil, err) but got %s, %s", cmd, err)

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -22,6 +22,16 @@ func TestHealthCheck(t *testing.T) {
 	}
 }
 
+func TestHealthCheckBad(t *testing.T) {
+	cmd1, _ := commands.NewCommand("./testdata/test.sh failStuff", "")
+	service := &Service{
+		healthCheckCmd: cmd1,
+	}
+	if err := service.CheckHealth(); err == nil {
+		t.Errorf("Expected error from CheckHealth but got nil")
+	}
+}
+
 type TestFragmentServices struct {
 	Services []Service
 }


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/223

We're assuming that `Process.Wait()` returns an error if the process exits with an error code. `Cmd.Wait()` returns with an error value on a non-zero exit code but `Process.Wait()` returns an error on OS-specific details (like if the process isn't a child process) and instead we should be checking the value of the `ProcessState.Success()` method.

It looks like this got introduced to most of the pollables during the refactoring to support timeouts for health checks (#184); the logic was lifted from the original tasks implementation but was totally safe there because we didn't really care about the exit codes. I've added two tests that ensure we don't miss this again.

cc @misterbisson @nickwales @justenwalker 