### PR TITLE
Send quit to timeout when RunWithTimeout command exits non-zero

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -194,6 +194,9 @@ func (c *Command) waitForTimeout() error {
 				return
 			}
 		}()
+		// if we send on this when we haven't set up the receiver
+		// we'll deadlock
+		defer func() { quit <- 0 }()
 	}
 	log.Debugf("%s.run waiting for PID %d: ", c.Name, cmd.Process.Pid)
 	state, err := cmd.Process.Wait()
@@ -209,12 +212,6 @@ func (c *Command) waitForTimeout() error {
 		return fmt.Errorf("%s exited with error", c.Name)
 	}
 
-	if doTimeout {
-		// if we send on this when we haven't set up the receiver
-		// we'll deadlock
-		log.Debugf("%s.run sent timeout quit", c.Name)
-		quit <- 0
-	}
 	log.Debugf("%s.run complete", c.Name)
 	return nil
 }


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/233

When the command executed with `RunWithTimeout` failed and exited with a non-zero exit code, we returned early and didn't send on the timeout's quit channel. This `defers` the send on that channel right after we set up the timeout goroutine so that we don't miss any code paths where it needs to be sent.

In [my comment](https://github.com/joyent/containerpilot/issues/233#issuecomment-255102350) in the original issue I mentioned this was hard to test for because we don't communicate with the quit channel. This is probably something we should consider fixing in the long term (perhaps in 3.x) but in the meantime I've modified the test so that we wait for the capture the debug log output and then I'm just parsing that for the timeout message. The failing test (without the changes I've made here to `commands.go`) looks like this:

```
=== RUN   TestRunWithTimeoutFailed
time="2016-10-20T14:36:31Z" level=warning msg="killing command at pid: 458"
--- FAIL: TestRunWithTimeoutFailed (0.22s)
        commands_test.go:107: RunWithTimeout failed to cancel timeout after failure: time="2016-10-20T14:36:31Z" level=debug msg="./testdata/test.sh.RunWithTimeout start"
                time="2016-10-20T14:36:31Z" level=debug msg="./testdata/test.sh.Cmd.Start"
                time="2016-10-20T14:36:31Z" level=debug msg="./testdata/test.sh.run waiting for PID 462: "
                time="2016-10-20T14:36:31Z" level=info msg="Running failStuff with args: --debug" process=test
                time="2016-10-20T14:36:31Z" level=debug msg="./testdata/test.sh.RunWithTimeout end"
                time="2016-10-20T14:36:31Z" level=warning msg="./testdata/test.sh timeout after 100ms: '[failStuff --debug]'"
                time="2016-10-20T14:36:31Z" level=debug msg="./testdata/test.sh.kill"
                time="2016-10-20T14:36:31Z" level=warning msg="killing command at pid: 462"
                time="2016-10-20T14:36:31Z" level=error msg="error killing command: os: process already finished"
```

cc @commarla @jasonpincin @justenwalker @misterbisson 