### PR TITLE
Eliminate test log spam from BenchmarkRunAndWaitSuccess

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -17,7 +17,7 @@ func TestRunAndWaitSuccess(t *testing.T) {
 }
 
 func BenchmarkRunAndWaitSuccess(b *testing.B) {
-	cmd, _ := NewCommand("./testdata/test.sh doStuff --debug", "0")
+	cmd, _ := NewCommand("./testdata/test.sh doNothing", "0")
 	for i := 0; i < b.N; i++ {
 		RunAndWait(cmd, nil)
 	}


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/221

The hook we're testing echos to stdout, which we can't eliminate from the log configuration. The benchmark is for fork/exec so there's no need to keep this echo anyways. This is a pretty minor thing but its annoying when you're trying to fix something to have your terminal filled with log spam.

cc @jasonpincin @justenwalker @misterbisson 