### PR TITLE
Fix syntax highlighting in installation docs

### DIFF
--- a/documentation/11-installation/README.md
+++ b/documentation/11-installation/README.md
@@ -42,7 +42,7 @@ RUN apt-get update \
         bc \
         curl \
         unzip \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/∗
 
 # Add Consul template
 # Releases at https://releases.hashicorp.com/consul-template/


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/228. I've swapped out the `*` for a `u+2217` (ASTERISK OPERATOR) which looks close-enough visually but isn't interpreted by Kirby as an instruction that breaks syntax highlighting. Tested locally:

![screen shot 2016-11-07 at 10 14 38 am](https://cloud.githubusercontent.com/assets/1409219/20062859/3c0902bc-a4d3-11e6-8355-d37711ee69ae.png)

cc @fitzage for review please