### PR TITLE
Retry heartbeat after initial service registration

### DIFF
--- a/discovery/consul/consul.go
+++ b/discovery/consul/consul.go
@@ -110,9 +110,16 @@ func (c *Consul) SendHeartbeat(service *discovery.ServiceDefinition) {
 		log.Infof("%v\nService not registered, registering...", err)
 		if err = c.registerService(*service); err != nil {
 			log.Warnf("Service registration failed: %s", err)
+			return
 		}
 		if err = c.registerCheck(*service); err != nil {
 			log.Warnf("Check registration failed: %s", err)
+			return
+		}
+		// now that we're ensured we're registered, we can push the
+		// heartbeat again
+		if err := c.Agent().PassTTL(service.ID, "ok"); err != nil {
+			log.Errorf("Failed to write heartbeat: %s", err)
 		}
 	}
 }

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -59,16 +59,9 @@ func TestConsulTTLPass(t *testing.T) {
 	consul, service := setupConsul("service-TestConsulTTLPass")
 	id := service.ID
 
-	consul.SendHeartbeat(service) // force registration
+	consul.SendHeartbeat(service) // force registration and 1st heartbeat
 	checks, _ := consul.Agent().Checks()
 	check := checks[id]
-	if check.Status != "critical" {
-		t.Fatalf("status of check %s should be 'critical' but is %s", id, check.Status)
-	}
-
-	consul.SendHeartbeat(service) // write TTL and verify
-	checks, _ = consul.Agent().Checks()
-	check = checks[id]
 	if check.Status != "passing" {
 		t.Fatalf("status of check %s should be 'passing' but is %s", id, check.Status)
 	}

--- a/discovery/etcd/etcd.go
+++ b/discovery/etcd/etcd.go
@@ -103,6 +103,12 @@ func (c *Etcd) SendHeartbeat(service *discovery.ServiceDefinition) {
 		log.Infof("Service not registered, registering...")
 		if err := c.registerService(service); err != nil {
 			log.Warnf("Error registering service %s: %s", service.Name, err)
+			return
+		}
+		// now that we're ensured we're registered, we can push the
+		// heartbeat again
+		if err := c.updateServiceTTL(service); err != nil {
+			log.Errorf("Failed to write heartbeat: %s", err)
 		}
 	}
 }


### PR DESCRIPTION
For #225 

Sending a heartbeat to a not-yet registered service fails on both the `discovery/consul` and `discovery/etcd` backends. Previously we'd catch the error, register the service, and return so that we'd send a passing heartbeat on the next health check poll. This change retries the heartbeat on the newly registered service so that we become healthy more quickly.

cc @misterbisson @jasonpincin @justenwalker