### PR TITLE
Expose PIDs of ContainerPilot and hooks as environment variables

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -14,8 +14,12 @@ import (
 
 func TestRunAndWaitSuccess(t *testing.T) {
 	cmd, _ := NewCommand("./testdata/test.sh doStuff --debug", "0")
+	cmd.Name = "APP"
 	if exitCode, _ := RunAndWait(cmd, nil); exitCode != 0 {
 		t.Errorf("Expected exit code 0 but got %d", exitCode)
+	}
+	if pid := os.Getenv("CONTAINERPILOT_APP_PID"); pid == "" {
+		t.Errorf("Expected CONTAINERPILOT_APP_PID to be set")
 	}
 }
 

--- a/core/app.go
+++ b/core/app.go
@@ -77,6 +77,7 @@ func LoadApp() (*App, error) {
 		configFlag = os.Getenv("CONTAINERPILOT")
 	}
 
+	os.Setenv("CONTAINERPILOT_PID", fmt.Sprintf("%v", os.Getpid()))
 	app, err := NewApp(configFlag)
 	if err != nil {
 		return nil, err
@@ -135,6 +136,7 @@ func (a *App) Run() {
 	if err != nil {
 		log.Errorf("Unable to parse command arguments: %v", err)
 	}
+	cmd.Name = "APP"
 	a.Command = cmd
 
 	a.handleSignals()

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -244,6 +244,17 @@ func TestMetricServiceCreation(t *testing.T) {
 	}
 }
 
+func TestPidEnvVar(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	os.Args = []string{"this", "-config", "{}", "/testdata/test.sh"}
+	if _, err := LoadApp(); err == nil {
+		t.Fatalf("Expected error in LoadApp but got none")
+	}
+	if pid := os.Getenv("CONTAINERPILOT_PID"); pid == "" {
+		t.Errorf("Expected CONTAINERPILOT_PID to be set even on error")
+	}
+}
+
 // ----------------------------------------------------
 // test helpers
 

--- a/documentation/12-configuration/README.md
+++ b/documentation/12-configuration/README.md
@@ -273,6 +273,18 @@ All executable fields, including `services/health`, `preStart`, `preStop`, `post
 ]
 ```
 
+### Environment Variables
+
+ContainerPilot will set the following environment variables.
+
+- `CONTAINERPILOT_{SERVICE_NAME}_IP`: the IP address of every service advertised by ContainerPilot. This is available to the command arguments of each hook but not to the ContainerPilot configuration file (see below).
+- `CONTAINERPILOT_PID`: the PID of ContainerPilot itself. This is available to all hooks and to the main application.
+- `CONTAINERPILOT_APP_PID`: the PID of the main shimmed application. This is available to all hooks except for the `preStart`. It is not available to the shimmed application itself (we need to start the application first to get its PID).
+- `CONTAINERPILOT_PRESTART_PID`: the PID of the `preStart` hook while it runs.
+- `CONTAINERPILOT_PRESTOP_PID`: the PID of the `preStop` hook while it runs.
+- `CONTAINERPILOT_POSTSTOP_PID`: the PID of the `postStop` hook while it runs.
+- `CONTAINERPILOT_{COPROCESS_NAME}_PID`: the PID of a `coprocess` hook while it runs.
+
 ### Template configuration
 
 ContainerPilot configuration has template support. If you have an environment variable such as `FOO=BAR` then you can use `{{.FOO}}` in your configuration file or in your command arguments and it will be substituted with `BAR`. The `CONTAINERPILOT_{SERVICE_NAME}_IP` environment variable that is set by the services configuration is available to the command arguments but not to the configuration file.


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/229

This adds the following environment variables by grabbing the PID right after we start a process but before we block waiting for it to finish. This PID is set as an env var available to all _subsequently started_ processes.

- `CONTAINERPILOT_PID`: the PID of ContainerPilot itself. This is available to all hooks and to the main application.
- `CONTAINERPILOT_APP_PID`: the PID of the main shimmed application. This is available to all hooks except for the `preStart`. It is not available to the shimmed application itself (we need to start the application first to get its PID).
- `CONTAINERPILOT_PRESTART_PID`: the PID of the `preStart` hook while it runs.
- `CONTAINERPILOT_PRESTOP_PID`: the PID of the `preStop` hook while it runs.
- `CONTAINERPILOT_POSTSTOP_PID`: the PID of the `postStop` hook while it runs.
- `CONTAINERPILOT_{COPROCESS_NAME}_PID`: the PID of a `coprocess` hook while it runs.

cc @jasonpincin @misterbisson 