### PR TITLE
Fix null-pointer exception in error handling of RunAndWait

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -31,14 +31,16 @@ func BenchmarkRunAndWaitSuccess(b *testing.B) {
 }
 
 func TestRunAndWaitFailed(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			t.Errorf("Expected panic but did not.")
-		}
-	}()
 	cmd, _ := NewCommand("./testdata/test.sh failStuff --debug", "0")
 	if exitCode, _ := RunAndWait(cmd, nil); exitCode != 255 {
 		t.Errorf("Expected exit code 255 but got %d", exitCode)
+	}
+}
+
+func TestRunAndWaitInvalidCommand(t *testing.T) {
+	cmd, _ := NewCommand("./testdata/invalidCommand", "0")
+	if exitCode, _ := RunAndWait(cmd, nil); exitCode != 127 {
+		t.Errorf("Expected exit code 127 but got %d", exitCode)
 	}
 }
 
@@ -107,6 +109,14 @@ func TestRunWithTimeoutFailed(t *testing.T) {
 
 	if strings.Contains(logs, "timeout after") {
 		t.Fatalf("RunWithTimeout failed to cancel timeout after failure: %v", logs)
+	}
+}
+
+func TestRunWithTimeoutInvalidCommand(t *testing.T) {
+	cmd, _ := NewCommand("./testdata/invalidCommand", "100ms")
+	fields := log.Fields{"process": "test"}
+	if err := RunWithTimeout(cmd, fields); err == nil {
+		t.Errorf("Expected error but got nil")
 	}
 }
 


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/255

`Cmd.Process.Wait` does not guarantee that the `ProcessState` struct it returns is non-nil if the error it returns is non-nil, because we might have an invalid PID or a `waitpid` syscall error (ECHILD or EINTR).

We'll check ProcessState struct first b/c it might have the process error code and this is going to be the common case, but if not then we'll bubble-up the error. Expanded test coverage for invalid and pruned an unused error handling branch.

cc @jasonpincin @misterbisson 