### PR TITLE
Add split and join to templates

### DIFF
--- a/config/template.go
+++ b/config/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 )
@@ -26,6 +27,22 @@ func join(sep string, s []string) (string, error) {
 		return "", nil
 	}
 	return strings.Join(s, sep), nil
+}
+
+// replace replaces all occurrences of a value in a string with the given
+// replacement value.
+func replace(from, to, s string) (string, error) {
+	return strings.Replace(s, from, to, -1), nil
+}
+
+// regexRplace replaces all occurrences of a regex in a string with the given
+// replacement value.
+func regexReplace(re, to, s string) (string, error) {
+	compiled, err := regexp.Compile(re)
+	if err != nil {
+		return "", err
+	}
+	return compiled.ReplaceAllString(s, to), nil
 }
 
 func parseEnvironment(environ []string) Environment {
@@ -65,9 +82,12 @@ func defaultValue(defaultValue, templateValue interface{}) string {
 func NewTemplate(config []byte) (*Template, error) {
 	env := parseEnvironment(os.Environ())
 	tmpl, err := template.New("").Funcs(template.FuncMap{
-		"default": defaultValue,
-		"split":   split,
-		"join":    join,
+		"default":       defaultValue,
+		"split":         split,
+		"join":          join,
+		"replace":       replace,
+		"regexReplace":  regexReplace,
+		"regexpReplace": regexReplace,
 	}).Option("missingkey=zero").Parse(string(config))
 	if err != nil {
 		return nil, err

--- a/config/template.go
+++ b/config/template.go
@@ -11,6 +11,23 @@ import (
 // Environment is a map of environment variables to their values
 type Environment map[string]string
 
+// split is a version of strings.Split that can be piped
+func split(sep, s string) ([]string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return []string{}, nil
+	}
+	return strings.Split(s, sep), nil
+}
+
+// join is a version of strings.Join that can be piped
+func join(sep string, s []string) (string, error) {
+	if len(s) == 0 {
+		return "", nil
+	}
+	return strings.Join(s, sep), nil
+}
+
 func parseEnvironment(environ []string) Environment {
 	env := make(Environment)
 	if len(environ) == 0 {
@@ -49,6 +66,8 @@ func NewTemplate(config []byte) (*Template, error) {
 	env := parseEnvironment(os.Environ())
 	tmpl, err := template.New("").Funcs(template.FuncMap{
 		"default": defaultValue,
+		"split":   split,
+		"join":    join,
 	}).Option("missingkey=zero").Parse(string(config))
 	if err != nil {
 		return nil, err

--- a/config/template.go
+++ b/config/template.go
@@ -29,15 +29,15 @@ func join(sep string, s []string) (string, error) {
 	return strings.Join(s, sep), nil
 }
 
-// replace replaces all occurrences of a value in a string with the given
+// replaceAll replaces all occurrences of a value in a string with the given
 // replacement value.
-func replace(from, to, s string) (string, error) {
+func replaceAll(from, to, s string) (string, error) {
 	return strings.Replace(s, from, to, -1), nil
 }
 
-// regexRplace replaces all occurrences of a regex in a string with the given
+// regexReplaceAll replaces all occurrences of a regex in a string with the given
 // replacement value.
-func regexReplace(re, to, s string) (string, error) {
+func regexReplaceAll(re, to, s string) (string, error) {
 	compiled, err := regexp.Compile(re)
 	if err != nil {
 		return "", err
@@ -82,12 +82,11 @@ func defaultValue(defaultValue, templateValue interface{}) string {
 func NewTemplate(config []byte) (*Template, error) {
 	env := parseEnvironment(os.Environ())
 	tmpl, err := template.New("").Funcs(template.FuncMap{
-		"default":       defaultValue,
-		"split":         split,
-		"join":          join,
-		"replace":       replace,
-		"regexReplace":  regexReplace,
-		"regexpReplace": regexReplace,
+		"default":         defaultValue,
+		"split":           split,
+		"join":            join,
+		"replaceAll":      replaceAll,
+		"regexReplaceAll": regexReplaceAll,
 	}).Option("missingkey=zero").Parse(string(config))
 	if err != nil {
 		return nil, err

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -24,9 +24,8 @@ func TestTemplate(t *testing.T) {
 	validateTemplate(t, "Default", `Hello, {{.NONAME | default 100 }}!`, env, "Hello, 100!")
 	validateTemplate(t, "Default", `Hello, {{.NONAME | default 10.1 }}!`, env, "Hello, 10.1!")
 	validateTemplate(t, "Split and Join", `Hello, {{.PARTS | split ":" | join "." }}!`, env, "Hello, a.b.c!")
-	validateTemplate(t, "Replace", `Hello, {{.NAME | replace "e" "_" }}!`, env, "Hello, T_mplat_!")
-	validateTemplate(t, "Regex Replace", `Hello, {{.NAME | regexReplace "[epa]+" "_" }}!`, env, "Hello, T_m_l_t_!")
-	validateTemplate(t, "Regexp Replace", `Hello, {{.NAME | regexpReplace "[epa]+" "_" }}!`, env, "Hello, T_m_l_t_!")
+	validateTemplate(t, "Replace All", `Hello, {{.NAME | replaceAll "e" "_" }}!`, env, "Hello, T_mplat_!")
+	validateTemplate(t, "Regex Replace All", `Hello, {{.NAME | regexReplaceAll "[epa]+" "_" }}!`, env, "Hello, T_m_l_t_!")
 }
 
 // Helper Functions

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -24,6 +24,9 @@ func TestTemplate(t *testing.T) {
 	validateTemplate(t, "Default", `Hello, {{.NONAME | default 100 }}!`, env, "Hello, 100!")
 	validateTemplate(t, "Default", `Hello, {{.NONAME | default 10.1 }}!`, env, "Hello, 10.1!")
 	validateTemplate(t, "Split and Join", `Hello, {{.PARTS | split ":" | join "." }}!`, env, "Hello, a.b.c!")
+	validateTemplate(t, "Replace", `Hello, {{.NAME | replace "e" "_" }}!`, env, "Hello, T_mplat_!")
+	validateTemplate(t, "Regex Replace", `Hello, {{.NAME | regexReplace "[epa]+" "_" }}!`, env, "Hello, T_m_l_t_!")
+	validateTemplate(t, "Regexp Replace", `Hello, {{.NAME | regexpReplace "[epa]+" "_" }}!`, env, "Hello, T_m_l_t_!")
 }
 
 // Helper Functions

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -17,12 +17,13 @@ func TestParseEnvironment(t *testing.T) {
 }
 
 func TestTemplate(t *testing.T) {
-	env := parseEnvironment([]string{"NAME=Template", "USER=pilot"})
+	env := parseEnvironment([]string{"NAME=Template", "USER=pilot", "PARTS=a:b:c"})
 	validateTemplate(t, "One var", `Hello, {{.NAME}}!`, env, "Hello, Template!")
 	validateTemplate(t, "Var undefined", `Hello, {{.NONAME}}!`, env, "Hello, !")
 	validateTemplate(t, "Default", `Hello, {{.NONAME | default "World" }}!`, env, "Hello, World!")
 	validateTemplate(t, "Default", `Hello, {{.NONAME | default 100 }}!`, env, "Hello, 100!")
 	validateTemplate(t, "Default", `Hello, {{.NONAME | default 10.1 }}!`, env, "Hello, 10.1!")
+	validateTemplate(t, "Split and Join", `Hello, {{.PARTS | split ":" | join "." }}!`, env, "Hello, a.b.c!")
 }
 
 // Helper Functions


### PR DESCRIPTION
I will try to add the `replace*` ones after, but here is a good start. Obviously includes a test line as well. I like how I just tested both in one line. :-)

Per the request for PR from @tgross at https://github.com/joyent/containerpilot/issues/261#issuecomment-270125563