### PR TITLE
Fixes debug logging field for onChange

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -44,7 +44,7 @@ func NewBackends(raw []interface{}, disc discovery.ServiceBackend) ([]*Backend, 
 			return nil, fmt.Errorf("Could not parse `onChange` in backend %s: %s",
 				b.Name, err)
 		}
-		cmd.Name = fmt.Sprintf("%s.health", b.Name)
+		cmd.Name = fmt.Sprintf("%s.onChange", b.Name)
 		b.onChangeCmd = cmd
 
 		if b.Poll < 1 {


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/263.
This fixes a copy-and-paste error in the logging fields for `onChange` handlers in DEBUG mode.