### PR TITLE
Improve development environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,8 @@ sudo: required
 services:
   - docker
 
-## Need docker-compose 1.5.x for Variable Interpolation
 env:
-  DOCKER_COMPOSE_VERSION: 1.5.2
+  DOCKER_COMPOSE_VERSION: 1.11.2
   GO15VENDOREXPERIMENT: 1
 
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.6
 
 RUN  go get github.com/golang/lint/golint \
-  && curl -Lo /tmp/glide.tgz https://github.com/Masterminds/glide/releases/download/v0.11.1/glide-v0.11.1-linux-amd64.tar.gz \
+  && curl -Lo /tmp/glide.tgz https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz \
   && tar -C /usr/bin -xzf /tmp/glide.tgz --strip=1 linux-amd64/glide
 
 

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -22,7 +22,7 @@ var testJSON = `{
 			{
 					"name": "serviceA",
 					"port": 8080,
-					"interfaces": "eth0",
+					"interfaces": "inet",
 					"health": "/bin/to/healthcheck/for/service/A.sh",
 					"poll": 30,
 					"ttl": "19",
@@ -31,7 +31,7 @@ var testJSON = `{
 			{
 					"name": "serviceB",
 					"port": 5000,
-					"interfaces": ["ethwe","eth0"],
+					"interfaces": ["ethwe","eth0", "inet"],
 					"health": "/bin/to/healthcheck/for/service/B.sh",
 					"poll": 30,
 					"ttl": 103
@@ -203,7 +203,13 @@ func TestParseTrailingComma(t *testing.T) {
 
 func TestRenderArgs(t *testing.T) {
 	flags := []string{"-name", "{{ .HOSTNAME }}"}
-	expected, _ := os.Hostname()
+	expected := os.Getenv("HOSTNAME")
+	if expected == "" {
+		// not all environments use this variable as a hostname but
+		// we really just want to make sure it's being rendered
+		expected, _ = os.Hostname()
+		os.Setenv("HOSTNAME", expected)
+	}
 	if got := getArgs(flags)[1]; got != expected {
 		t.Errorf("Expected %v but got %v for rendered hostname", expected, got)
 	}
@@ -221,6 +227,7 @@ func TestMetricServiceCreation(t *testing.T) {
 	jsonFragment := `{
     "consul": "consul:8500",
     "telemetry": {
+      "interfaces": ["inet"],
       "port": 9090
     }
   }`

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -1,14 +1,25 @@
 package consul
 
 import (
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/joyent/containerpilot/discovery"
 )
 
+func getTestConsulAddress() string {
+	addr := os.Getenv("CONSUL")
+	if addr == "" {
+		addr = "localhost:8500"
+	}
+	fmt.Println(addr)
+	return addr
+}
+
 func setupConsul(serviceName string) (*Consul, *discovery.ServiceDefinition) {
-	consul, _ := NewConsulConfig("consul:8500")
+	consul, _ := NewConsulConfig(getTestConsulAddress())
 	service := &discovery.ServiceDefinition{
 		ID:        serviceName,
 		Name:      serviceName,
@@ -139,7 +150,7 @@ func TestConsulCheckForChanges(t *testing.T) {
 
 func TestConsulEnableTagOverride(t *testing.T) {
 	backend := "service-TestConsulEnableTagOverride"
-	consul, _ := NewConsulConfig("consul:8500")
+	consul, _ := NewConsulConfig(getTestConsulAddress())
 	if err := setupWaitForLeader(consul); err != nil {
 		t.Errorf("Consul leader could not be elected.")
 	}

--- a/integration_tests/fixtures/nginx/etc/nginx-with-consul.json
+++ b/integration_tests/fixtures/nginx/etc/nginx-with-consul.json
@@ -1,7 +1,11 @@
 {
   "consul": "consul:8500",
+  "logging": {
+    "level": "DEBUG",
+    "format": "text"
+  },
   "preStart": [
-    "consul-template", "-once", "-retry", "30s", "-consul", "consul:8500", "-template",
+    "consul-template", "-once", "-retry", "3s", "-consul", "consul:8500", "-template",
     "/etc/nginx-consul.ctmpl:/etc/nginx/nginx.conf"
   ],
   "services": [

--- a/integration_tests/tests/test_coprocess/docker-compose.yml
+++ b/integration_tests/tests/test_coprocess/docker-compose.yml
@@ -1,9 +1,12 @@
-consul:
+version: "2.1"
+
+services:
+  consul:
     image: "cpfix_consul"
     mem_limit: 128m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_app"
     mem_limit: 128m
     links:
@@ -15,7 +18,7 @@ app:
       - './containerpilot.json:/etc/containerpilot.json'
       - './coprocess.sh:/bin/coprocess.sh'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_discovery_consul/docker-compose.yml
+++ b/integration_tests/tests/test_discovery_consul/docker-compose.yml
@@ -1,9 +1,12 @@
-consul:
+version: "2.1"
+
+services:
+  consul:
     image: "cpfix_consul"
     mem_limit: 128m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_app"
     mem_limit: 128m
     links:
@@ -11,7 +14,7 @@ app:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-nginx:
+  nginx:
     image: "cpfix_nginx"
     mem_limit: 128m
     links:
@@ -19,7 +22,7 @@ nginx:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_envvars/containerpilot.json
+++ b/integration_tests/tests/test_envvars/containerpilot.json
@@ -2,7 +2,7 @@
   "consul": "127.0.0.1:8500",
   "services": [
     {
-      "name": "consul",
+      "name": "testenvvar",
       "port": 8500,
       "health": "true",
       "poll": 10,

--- a/integration_tests/tests/test_envvars/docker-compose.yml
+++ b/integration_tests/tests/test_envvars/docker-compose.yml
@@ -1,4 +1,4 @@
-consul:
+test:
   image: cpfix_consul
   environment:
     - CONTAINERPILOT=file:///etc/containerpilot.json
@@ -7,7 +7,5 @@ consul:
     - './containerpilot.json:/etc/containerpilot.json'
   command: >
     /bin/containerpilot
-    /bin/consul agent -dev -client '{{ .CONTAINERPILOT_CONSUL_IP }}' -bind '{{ .CONTAINERPILOT_CONSUL_IP }}'
+    echo '{{ .CONTAINERPILOT_TESTENVVAR_IP | default "FAIL" }}'
   mem_limit: 128m
-  ports:
-    - "8500:8500"

--- a/integration_tests/tests/test_envvars/run.sh
+++ b/integration_tests/tests/test_envvars/run.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 set -e
 
-# stand up Consul
-docker-compose up -d consul
-
-# give the instance enough time to self-elect
-n=0
-while true
-do
-    if [ $n == 15 ]; then
-        echo 'Timed out waiting for Consul.'
-        exit 1;
-    fi
-    curl -Ls --fail "http://${DOCKER_HOST:-localhost}:8500/v1/status/leader" | grep 8300 >/dev/null 2>&1 && break
-    n=$((n+1))
-    sleep 1
-done
+# run and check that we didn't get the default environment value of "FAIL"
+docker-compose run --rm test | grep -v FAIL

--- a/integration_tests/tests/test_logging/docker-compose.yml
+++ b/integration_tests/tests/test_logging/docker-compose.yml
@@ -1,9 +1,13 @@
-consul:
+version: "2.1"
+
+services:
+
+  consul:
     image: "cpfix_consul"
     mem_limit: 128m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_app"
     mem_limit: 128m
     links:
@@ -13,7 +17,7 @@ app:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_reap_zombies/docker-compose.yml
+++ b/integration_tests/tests/test_reap_zombies/docker-compose.yml
@@ -1,9 +1,12 @@
-consul:
+version: "2.1"
+
+services:
+  consul:
     image: "cpfix_consul"
     mem_limit: 256m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_zombie_maker"
     mem_limit: 512m
     links:
@@ -11,7 +14,7 @@ app:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_sighup_deadlock/docker-compose.yml
+++ b/integration_tests/tests/test_sighup_deadlock/docker-compose.yml
@@ -1,9 +1,13 @@
-consul:
+version: "2.1"
+
+services:
+
+  consul:
     image: "cpfix_consul"
     mem_limit: 256m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_app"
     mem_limit: 512m
     links:
@@ -11,7 +15,7 @@ app:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_sighup_prestart/docker-compose.yml
+++ b/integration_tests/tests/test_sighup_prestart/docker-compose.yml
@@ -1,9 +1,13 @@
-consul:
+version: "2.1"
+
+services:
+
+  consul:
     image: "cpfix_consul"
     mem_limit: 256m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_app"
     environment:
       - CONTAINERPILOT=file:///app-with-consul-prestart-sighup.json
@@ -13,7 +17,7 @@ app:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_sigterm/docker-compose.yml
+++ b/integration_tests/tests/test_sigterm/docker-compose.yml
@@ -1,9 +1,13 @@
-consul:
+version: "2.1"
+
+services:
+
+  consul:
     image: "cpfix_consul"
     mem_limit: 256m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_app"
     mem_limit: 512m
     links:
@@ -11,7 +15,7 @@ app:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_tasks/docker-compose.yml
+++ b/integration_tests/tests/test_tasks/docker-compose.yml
@@ -1,9 +1,13 @@
-consul:
+version: "2.1"
+
+services:
+
+  consul:
     image: "cpfix_consul"
     mem_limit: 128m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_app"
     mem_limit: 128m
     links:
@@ -13,7 +17,7 @@ app:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_telemetry/docker-compose.yml
+++ b/integration_tests/tests/test_telemetry/docker-compose.yml
@@ -1,9 +1,13 @@
-consul:
+version: "2.1"
+
+services:
+
+  consul:
     image: "cpfix_consul"
     mem_limit: 128m
     hostname: consul
 
-app:
+  app:
     image: "cpfix_app"
     mem_limit: 128m
     links:
@@ -13,7 +17,7 @@ app:
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
-test:
+  test:
     image: "cpfix_test_probe"
     mem_limit: 128m
     links:

--- a/integration_tests/tests/test_telemetry/run.sh
+++ b/integration_tests/tests/test_telemetry/run.sh
@@ -19,13 +19,13 @@ if [ ! $? -eq 0 ] ; then exit 1 ; fi
 docker-compose up -d app
 
 APP_ID="$(docker-compose ps -q app)"
-IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' ${APP_ID})
+IP=$(docker inspect -f '{{ .NetworkSettings.Networks.testtelemetry_default.IPAddress }}' "${APP_ID}")
 
 # This interface takes a while to converge
 set +e
 for i in {20..1}; do
     sleep 1 # sleep has to be before b/c we want exit code
-    docker exec -it ${APP_ID} curl -s ${IP}:9090/metrics | grep 'containerpilot_app_some_counter 42' && break
+    docker exec -it "${APP_ID}" curl -s "${IP}:9090/metrics" | grep 'containerpilot_app_some_counter 42' && break
 done
 result=$?
 set -e
@@ -36,11 +36,11 @@ CONSUL_ID="$(docker-compose ps -q consul)"
 set +e
 for i in {5..1}; do
     sleep 1
-    docker exec -it ${CONSUL_ID} curl -s --fail localhost:8500/v1/catalog/service/containerpilot | grep 'containerpilot' && break
+    docker exec -it "${CONSUL_ID}" curl -s --fail localhost:8500/v1/catalog/service/containerpilot | grep 'containerpilot' && break
 done
 result=$?
 set -e
 if [ $result -ne 0 ]; then exit $result; fi
 
 docker-compose stop app
-docker exec -it ${CONSUL_ID} curl -s --fail localhost:8500/v1/catalog/service/containerpilot | grep -v 'containerpilot'
+docker exec -it "${CONSUL_ID}" curl -s --fail localhost:8500/v1/catalog/service/containerpilot | grep -v 'containerpilot'

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ RUNNER := -v ${ROOT}:/go/src/${IMPORT_PATH} -w /go/src/${IMPORT_PATH} containerp
 docker := docker run --rm -e LDFLAGS="${LDFLAGS}" $(RUNNER)
 
 # TODO: remove once we've mocked-out Consul in unit tests
-dockerTest := docker run --rm -e LDFLAGS="${LDFLAGS}" --link containerpilot_consul:consul $(RUNNER)
+dockerTest := docker run --rm -e LDFLAGS="${LDFLAGS}" -e CONSUL="consul:8500" --link containerpilot_consul:consul $(RUNNER)
 
 # flags for local development
 GOOS := $(shell uname -s | tr A-Z a-iz)
@@ -152,5 +152,5 @@ integration: build
 ## stand up a Consul server in development mode in Docker
 consul:
 	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
-	docker run -d -m 256m --name containerpilot_consul \
+	docker run -d -m 256m -p 8500:8500 --name containerpilot_consul \
 		consul:latest agent -dev -client 0.0.0.0 -bind=0.0.0.0

--- a/makefile
+++ b/makefile
@@ -3,42 +3,46 @@ SHELL := /bin/bash
 .SHELLFLAGS := -o pipefail -euc
 .DEFAULT_GOAL := build
 
-.PHONY: clean test integration consul ship dockerfile docker cover lint
+.PHONY: clean test integration consul ship dockerfile docker cover lint local vendor dep-* tools
 
 IMPORT_PATH := github.com/joyent/containerpilot
 VERSION ?= dev-build-not-for-release
 LDFLAGS := -X ${IMPORT_PATH}/core.GitHash='$(shell git rev-parse --short HEAD)' -X ${IMPORT_PATH}/core.Version='${VERSION}'
 
 ROOT := $(shell pwd)
+RUNNER := -v ${ROOT}:/go/src/${IMPORT_PATH} -w /go/src/${IMPORT_PATH} containerpilot_build
+docker := docker run --rm -e LDFLAGS="${LDFLAGS}" $(RUNNER)
 
-DOCKERRUN := docker run --rm \
-	--link containerpilot_consul:consul \
-	-v ${ROOT}/vendor:/go/src \
-	-v ${ROOT}:/cp/src/${IMPORT_PATH} \
-	-w /cp/src/${IMPORT_PATH} \
-	containerpilot_build
+# TODO: remove once we've mocked-out Consul in unit tests
+dockerTest := docker run --rm -e LDFLAGS="${LDFLAGS}" --link containerpilot_consul:consul $(RUNNER)
 
-DOCKERBUILD := docker run --rm \
-	-e LDFLAGS="${LDFLAGS}" \
-	-v ${ROOT}/vendor:/go/src \
-	-v ${ROOT}:/cp/src/${IMPORT_PATH} \
-	-w /cp/src/${IMPORT_PATH} \
-	containerpilot_build
+# flags for local development
+GOOS := $(shell uname -s | tr A-Z a-iz)
+GOARCH := amd64
+CGO_ENABLED := 0
+GO15VENDOREXPERIMENT := 1
+GOEXPERIMENT := framepointer
 
-clean:
-	rm -rf build release cover vendor
-	docker rmi -f containerpilot_build > /dev/null 2>&1 || true
-	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
-	./scripts/test.sh clean
+
+## display this help message
+help:
+	@echo -e "\033[32m"
+	@echo "Targets in this Makefile build and test ContainerPilot in a build container in"
+	@echo "Docker. For testing (only), use the 'local' prefix target to run targets directly"
+	@echo "on your workstation (ex. 'make local test'). You will need to have its GOPATH set"
+	@echo "and have already run 'make tools'. Set GOOS=linux to build binaries for Docker."
+	@echo "Do not use 'make local' for building binaries for public release!"
+	@echo
+	@awk '/^##.*$$/,/[a-zA-Z_-]+:/' $(MAKEFILE_LIST) | awk '!(NR%2){print $$0p}{p=$$0}' | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-16s\033[0m %s\n", $$1, $$2}' | sort
+
 
 # ----------------------------------------------
-# docker build
+# building
 
-# default top-level target
+## build the ContainerPilot binary
 build: build/containerpilot
-
-build/containerpilot:  build/containerpilot_build */*.go vendor
-	${DOCKERBUILD} go build -o build/containerpilot -ldflags "$(LDFLAGS)"
+build/containerpilot:  build/containerpilot_build build/glide-installed */*.go *.go
+	$(docker) go build -o build/containerpilot -ldflags "$(LDFLAGS)"
 	@rm -rf src || true
 
 # builds the builder container
@@ -48,53 +52,8 @@ build/containerpilot_build:
 	docker build -t containerpilot_build ${ROOT}
 	docker inspect -f "{{ .ID }}" containerpilot_build > build/containerpilot_build
 
-# shortcut target for other targets: asserts a
-# working test environment
-docker: build/containerpilot_build consul
-
-# top-level target for vendoring our packages: glide install requires
-# being in the package directory so we have to run this for each package
-vendor: build/containerpilot_build
-	${DOCKERBUILD} glide install
-
-# fetch a dependency via go get, vendor it, and then save into the parent
-# package's glide.yml
-# usage DEP=github.com/owner/package make add-dep
-add-dep: build/containerpilot_build
-	docker run --rm \
-		-e LDFLAGS="${LDFLAGS}" \
-		-v ${ROOT}:/cp/src/${IMPORT_PATH} \
-		-w /cp/src/${IMPORT_PATH} \
-		containerpilot_build \
-		bash -c "DEP=$(DEP) ./scripts/add_dep.sh"
-
-# ----------------------------------------------
-# develop and test
-
-lint: vendor
-	${DOCKERBUILD} bash ./scripts/lint.sh
-
-# run unit tests and write out test coverage
-test: docker vendor
-	${DOCKERRUN} bash ./scripts/unit_test.sh
-
-cover: docker
-	mkdir -p cover
-	${DOCKERRUN} bash ./scripts/cover.sh
-
-# run integration tests
-TEST ?= "all"
-integration: build
-	./scripts/test.sh test $(TEST)
-
-# ------ Backends
-
-# Consul Backend
-consul:
-	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
-	docker run -d -m 256m --name containerpilot_consul \
-		consul:latest agent -dev -client 0.0.0.0 -bind=0.0.0.0
-
+# Before packaging always `make clean build test integration`!
+## tag and package ContainerPilot for release; `VERSION=make release`
 release: build
 	mkdir -p release
 	git tag $(VERSION)
@@ -104,3 +63,94 @@ release: build
 	@cd release && sha1sum containerpilot-$(VERSION).tar.gz
 	@cd release && sha1sum containerpilot-$(VERSION).tar.gz > containerpilot-$(VERSION).sha1.txt
 	@echo Upload files in release/ directory to GitHub release.
+
+## remove build/test artifacts, test fixtures, and vendor directories
+clean:
+	rm -rf build release cover vendor
+	docker rmi -f containerpilot_build > /dev/null 2>&1 || true
+	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
+	./scripts/test.sh clean
+
+# ----------------------------------------------
+# dependencies
+# NOTE: glide will be replaced with `dep` when its production-ready
+# ref https://github.com/golang/dep
+
+## install any changed packages in the glide.yaml
+vendor: build/glide-installed
+build/glide-installed: build/containerpilot_build glide.yaml
+	$(docker) glide install
+	mkdir -p vendor
+	@echo date > build/glide-installed
+
+## install all vendored packages in the glide.yaml
+dep-install:
+	mkdir -p vendor
+	$(docker) glide install
+	@echo date > build/glide-installed
+
+# usage DEP=github.com/owner/package make dep-add
+## fetch a dependency and vendor it via `glide`
+dep-add: build/containerpilot_build
+	$(docker) bash -c "DEP=$(DEP) ./scripts/add_dep.sh"
+
+## set up local dev environment
+tools:
+	@go version | grep 1.7 || (echo 'go1.7 not installed'; exit 1)
+	@$(if $(value GOPATH),, $(error 'GOPATH not set'))
+	go get github.com/golang/lint/golint
+	curl --fail -Lso glide.tgz "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-$(OS)-amd64.tar.gz"
+	tar -C "$(GOPATH)/bin" -xzf glide.tgz --strip=1 $(OS)-amd64/glide
+	rm glide.tgz
+
+
+# ----------------------------------------------
+# develop and test
+
+## print environment info about this dev environment
+debug:
+	@$(if $(value DOCKER_HOST), echo "DOCKER_HOST=$(DOCKER_HOST)", echo 'DOCKER_HOST not set')
+	@echo IMPORT_PATH=$(IMPORT_PATH)
+	@echo VERSION=$(VERSION)
+	@echo ROOT=$(ROOT)
+	@echo GOPATH=$(GOPATH)
+	@echo GOOS=$(GOOS)
+	@echo GOARCH=$(GOARCH)
+	@echo CGO_ENABLED=$(CGO_ENABLED)
+	@echo GO15VENDOREXPERIMENT=$(GO15VENDOREXPERIMENT)
+	@echo GOEXPERIMENT=$(GOEXPERIMENT)
+	@echo LDFLAGS="$(LDFLAGS)"
+	@echo
+	@echo docker commands run as:
+	@echo $(docker)
+
+## prefix before other make targets to run in your local dev environment
+local: | quiet
+	@$(eval docker= )
+	@$(eval dockerTest= )
+quiet: # this is silly but shuts up 'Nothing to be done for `local`'
+	@:
+
+## run `go lint` and other code quality tools
+lint:
+	$(docker) bash ./scripts/lint.sh
+
+## run unit tests
+test: build/containerpilot_build consul
+	$(dockerTest) bash ./scripts/unit_test.sh
+
+## run unit tests and write out HTML file of test coverage
+cover: build/containerpilot_build consul
+	mkdir -p cover
+	$(dockerTest) bash ./scripts/cover.sh
+
+TEST ?= "all"
+## run integration tests; filter with `TEST=testname make integration`
+integration: build
+	./scripts/test.sh test $(TEST)
+
+## stand up a Consul server in development mode in Docker
+consul:
+	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
+	docker run -d -m 256m --name containerpilot_consul \
+		consul:latest agent -dev -client 0.0.0.0 -bind=0.0.0.0

--- a/services/services_test.go
+++ b/services/services_test.go
@@ -41,7 +41,7 @@ func TestServiceParse(t *testing.T) {
 {
   "name": "serviceA",
   "port": 8080,
-  "interfaces": "eth0",
+  "interfaces": "inet",
   "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
   "poll": 30,
   "ttl": 19,
@@ -51,7 +51,7 @@ func TestServiceParse(t *testing.T) {
 {
   "name": "serviceB",
   "port": 5000,
-  "interfaces": ["ethwe","eth0"],
+  "interfaces": ["ethwe","eth0", "inet"],
   "health": "/bin/to/healthcheck/for/service/B.sh B1 B2",
   "poll": 30,
   "ttl": 103
@@ -91,7 +91,7 @@ func TestServicesConfigError(t *testing.T) {
 	validateServiceConfigError(t, err, "`port` must be > 0 in service myName")
 
 	// no health check shouldn't return an error
-	json.Unmarshal([]byte(`[{"name": "myName", "poll": 1, "ttl": 1, "port": 80}]`), &raw)
+	json.Unmarshal([]byte(`[{"name": "myName", "poll": 1, "ttl": 1, "port": 80, "interfaces": "inet"}]`), &raw)
 	_, err = NewServices(raw, nil)
 	validateServiceConfigError(t, err, "")
 
@@ -106,7 +106,7 @@ func TestServicesConsulConfigEnableTagOverride(t *testing.T) {
 {
   "name": "serviceA",
   "port": 8080,
-  "interfaces": "eth0",
+  "interfaces": "inet",
   "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
   "poll": 30,
   "ttl": 19,
@@ -132,7 +132,7 @@ func TestInvalidServicesConsulConfigEnableTagOverride(t *testing.T) {
 {
   "name": "serviceA",
   "port": 8080,
-  "interfaces": "eth0",
+  "interfaces": "inet",
   "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
   "poll": 30,
   "ttl": 19,
@@ -154,7 +154,7 @@ func TestServicesConsulConfigDeregisterCriticalServiceAfter(t *testing.T) {
 {
   "name": "serviceA",
   "port": 8080,
-  "interfaces": "eth0",
+  "interfaces": "inet",
   "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
   "poll": 30,
   "ttl": 19,
@@ -180,7 +180,7 @@ func TestInvalidServicesConsulConfigDeregisterCriticalServiceAfter(t *testing.T)
 {
   "name": "serviceA",
   "port": 8080,
-  "interfaces": "eth0",
+  "interfaces": "inet",
   "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
   "poll": 30,
   "ttl": 19,

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -12,7 +12,7 @@ import (
 
 var jsonFragment = []byte(`{
 	"port": 8000,
-	"interfaces": ["eth0"],
+	"interfaces": ["inet"],
 	"sensors": [
        {
 		"namespace": "telemetry",
@@ -41,7 +41,7 @@ func TestTelemetryParse(t *testing.T) {
 }
 
 func TestTelemetryParseBadSensor(t *testing.T) {
-	jsonFragment := []byte(`{"sensors": [{"check": "true"}]}`)
+	jsonFragment := []byte(`{"sensors": [{"check": "true"}], "interfaces": ["inet"]}`)
 	if _, err := NewTelemetry(decodeJSONRawTelemetry(t, jsonFragment)); err == nil {
 		t.Fatalf("Expected error from bad sensor but got nil.")
 	} else if ok := strings.HasPrefix(err.Error(), "invalid sensor type"); !ok {

--- a/utils/ips.go
+++ b/utils/ips.go
@@ -31,7 +31,7 @@ func GetIP(specList []string) (string, error) {
 
 	if specList == nil || len(specList) == 0 {
 		// Use a sane default
-		specList = []string{"eth0:inet"}
+		specList = []string{"eth0:inet", "inet"}
 	}
 
 	specs, err := parseInterfaceSpecs(specList)


### PR DESCRIPTION
The existing development environment only works in Docker. This lengthens compile and test cycles for those of us with a working golang development environment. While we want our CI environment to be based on Docker for consistency, this PR will make it feasible to develop ContainerPilot locally as well.

~~This PR is still work-in-progress because there are a few places in the unit tests where we've assumed that we're running in a Docker container.~~ fixed

~(This PR also contains the commits in https://github.com/joyent/containerpilot/pull/281 and will be rebased on master once that's been merged.)~