### PR TITLE
Remove deprecated features

### DIFF
--- a/config/commands.go
+++ b/config/commands.go
@@ -3,21 +3,10 @@ package config
 import (
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/commands"
 )
 
 func (cfg *rawConfig) parsePreStart() (*commands.Command, error) {
-	// onStart has been deprecated for preStart. Remove in 2.0
-	if cfg.preStart != nil && cfg.onStart != nil {
-		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use only the preStart option provided")
-	}
-
-	// alias the onStart behavior to preStart
-	if cfg.preStart == nil && cfg.onStart != nil {
-		log.Warnf("The onStart option has been deprecated in favor of preStart. ContainerPilot will use the onStart option as a preStart")
-		cfg.preStart = cfg.onStart
-	}
 	return parseCommand("preStart", cfg.preStart)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,6 @@ import (
 
 type rawConfig struct {
 	logConfig         *LogConfig
-	onStart           interface{}
 	preStart          interface{}
 	preStop           interface{}
 	postStop          interface{}
@@ -382,7 +381,6 @@ func decodeConfig(configMap map[string]interface{}, result *rawConfig) error {
 	}
 	result.stopTimeout = stopTimeout
 	result.logConfig = &logConfig
-	result.onStart = configMap["onStart"]
 	result.preStart = configMap["preStart"]
 	result.preStop = configMap["preStop"]
 	result.postStop = configMap["postStop"]
@@ -393,7 +391,6 @@ func decodeConfig(configMap map[string]interface{}, result *rawConfig) error {
 	result.telemetryConfig = configMap["telemetry"]
 
 	delete(configMap, "logging")
-	delete(configMap, "onStart")
 	delete(configMap, "preStart")
 	delete(configMap, "preStop")
 	delete(configMap, "postStop")

--- a/utils/names.go
+++ b/utils/names.go
@@ -3,8 +3,6 @@ package utils
 import (
 	"fmt"
 	"regexp"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 var validName = regexp.MustCompile(`^[a-z][a-zA-Z0-9\-]+$`)
@@ -17,7 +15,7 @@ func ValidateServiceName(name string) error {
 		return fmt.Errorf("`name` must not be blank")
 	}
 	if ok := validName.MatchString(name); !ok {
-		log.Warnf("Deprecation warning: service names must be alpha-numeric with dashes. In a future version of ContainerPilot this will be an error.")
+		return fmt.Errorf("service names must be alphanumeric with dashes to comply with service discovery")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR removes two features that were no longer in use and that issue deprecation warnings:
- Remove support for `onStart`, which was changed to `preStart` in #115
- Remove support for invalid characters from service names (ref #177)

~(This PR currently contains commits from #281, #282 but will be rebased once those are merged.)~