### PR TITLE
Upgrade toolchain to golang 1.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.8
 
 RUN  go get github.com/golang/lint/golint \
   && curl -Lo /tmp/glide.tgz https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz \
@@ -6,6 +6,4 @@ RUN  go get github.com/golang/lint/golint \
 
 
 ENV CGO_ENABLED 0
-ENV GO15VENDOREXPERIMENT 1
-ENV GOEXPERIMENT framepointer
 ENV GOPATH /go:/cp

--- a/integration_tests/fixtures/test_probe/Dockerfile
+++ b/integration_tests/fixtures/test_probe/Dockerfile
@@ -1,5 +1,4 @@
-FROM golang:latest
-ENV GO15VENDOREXPERIMENT 1
+FROM golang:1.8
 
 RUN go get github.com/tools/godep
 

--- a/makefile
+++ b/makefile
@@ -20,7 +20,6 @@ dockerTest := docker run --rm -e LDFLAGS="${LDFLAGS}" -e CONSUL="consul:8500" --
 GOOS := $(shell uname -s | tr A-Z a-iz)
 GOARCH := amd64
 CGO_ENABLED := 0
-GO15VENDOREXPERIMENT := 1
 GOEXPERIMENT := framepointer
 
 
@@ -96,7 +95,7 @@ dep-add: build/containerpilot_build
 
 ## set up local dev environment
 tools:
-	@go version | grep 1.7 || (echo 'go1.7 not installed'; exit 1)
+	@go version | grep 1.8 || (echo 'go1.8 not installed'; exit 1)
 	@$(if $(value GOPATH),, $(error 'GOPATH not set'))
 	go get github.com/golang/lint/golint
 	curl --fail -Lso glide.tgz "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-$(OS)-amd64.tar.gz"


### PR DESCRIPTION
Upgrades our golang toolchain to 1.8 so we can take advantage of improvements in the HTTP server (graceful restarts) as well as `Context` (ref https://github.com/joyent/containerpilot/issues/266)

~This PR includes all commits in https://github.com/joyent/containerpilot/pull/282 and will be rebased on top of master once that's been merged in. 5330bb3 is the only commit unique to this PR.~