### PR TITLE
Use Hashicorp testutil for testing vs Consul API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:1.8
 
-RUN  go get github.com/golang/lint/golint \
-  && curl -Lo /tmp/glide.tgz https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz \
-  && tar -C /usr/bin -xzf /tmp/glide.tgz --strip=1 linux-amd64/glide
-
+RUN  apt-get update \
+     && apt-get install -y unzip \
+     && go get github.com/golang/lint/golint \
+     && curl -Lo /tmp/glide.tgz "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz" \
+     && tar -C /usr/bin -xzf /tmp/glide.tgz --strip=1 linux-amd64/glide \
+     && curl --fail -Lso consul.zip              "https://releases.hashicorp.com/consul/0.7.5/consul_0.7.5_linux_amd64.zip" \
+     && unzip consul.zip -d /usr/bin
 
 ENV CGO_ENABLED 0
 ENV GOPATH /go:/cp

--- a/discovery/consul/consul_test.go
+++ b/discovery/consul/consul_test.go
@@ -2,50 +2,11 @@ package consul
 
 import (
 	"fmt"
-	"os"
 	"testing"
-	"time"
 
+	"github.com/hashicorp/consul/testutil"
 	"github.com/joyent/containerpilot/discovery"
 )
-
-func getTestConsulAddress() string {
-	addr := os.Getenv("CONSUL")
-	if addr == "" {
-		addr = "localhost:8500"
-	}
-	fmt.Println(addr)
-	return addr
-}
-
-func setupConsul(serviceName string) (*Consul, *discovery.ServiceDefinition) {
-	consul, _ := NewConsulConfig(getTestConsulAddress())
-	service := &discovery.ServiceDefinition{
-		ID:        serviceName,
-		Name:      serviceName,
-		IPAddress: "192.168.1.1",
-		TTL:       1,
-		Port:      9000,
-	}
-	return consul, service
-}
-
-func setupWaitForLeader(consul *Consul) error {
-	maxRetry := 30
-	retry := 0
-	var err error
-
-	// we need to wait for Consul to start and self-elect
-	for ; retry < maxRetry; retry++ {
-		if retry > 0 {
-			time.Sleep(1 * time.Second)
-		}
-		if leader, err := consul.Status().Leader(); err == nil && leader != "" {
-			break
-		}
-	}
-	return err
-}
 
 func TestConsulObjectParse(t *testing.T) {
 	rawCfg := map[string]interface{}{
@@ -83,11 +44,28 @@ func runParseTest(t *testing.T, uri, expectedAddress, expectedScheme string) {
 	}
 }
 
-func TestConsulTTLPass(t *testing.T) {
-	consul, service := setupConsul("service-TestConsulTTLPass")
-	if err := setupWaitForLeader(consul); err != nil {
-		t.Errorf("Consul leader could not be elected.")
-	}
+/*
+The TestWithConsul suite of tests uses Hashicorp's own testutil for managing
+a Consul server for testing. The 'consul' binary must be in the $PATH
+ref https://github.com/hashicorp/consul/tree/master/testutil
+*/
+
+var testServer *testutil.TestServer
+
+func TestWithConsul(t *testing.T) {
+	testServer = testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+		c.LogLevel = "err"
+	})
+	defer testServer.Stop()
+	t.Run("TestConsulTTLPass", testConsulTTLPass)
+	t.Run("TestConsulReregister", testConsulReregister)
+	t.Run("TestConsulCheckForChanges", testConsulCheckForChanges)
+	t.Run("TestConsulEnableTagOverride", testConsulEnableTagOverride)
+}
+
+func testConsulTTLPass(t *testing.T) {
+	consul, _ := NewConsulConfig(testServer.HTTPAddr)
+	service := generateServiceDefinition(fmt.Sprintf("service-TestConsulTTLPass"))
 	id := service.ID
 
 	consul.SendHeartbeat(service) // force registration and 1st heartbeat
@@ -98,11 +76,9 @@ func TestConsulTTLPass(t *testing.T) {
 	}
 }
 
-func TestConsulReregister(t *testing.T) {
-	consul, service := setupConsul("service-TestConsulReregister")
-	if err := setupWaitForLeader(consul); err != nil {
-		t.Errorf("Consul leader could not be elected.")
-	}
+func testConsulReregister(t *testing.T) {
+	consul, _ := NewConsulConfig(testServer.HTTPAddr)
+	service := generateServiceDefinition(fmt.Sprintf("service-TestConsulReregister"))
 	id := service.ID
 	consul.SendHeartbeat(service) // force registration and 1st heartbeat
 	services, _ := consul.Agent().Services()
@@ -112,7 +88,7 @@ func TestConsulReregister(t *testing.T) {
 	}
 
 	// new Consul client (as though we've restarted)
-	consul, service = setupConsul("service-TestConsulReregister")
+	consul, _ = NewConsulConfig(testServer.HTTPAddr)
 	service.IPAddress = "192.168.1.2"
 	consul.SendHeartbeat(service) // force re-registration and 1st heartbeat
 
@@ -123,18 +99,15 @@ func TestConsulReregister(t *testing.T) {
 	}
 }
 
-func TestConsulCheckForChanges(t *testing.T) {
-	backend := "service-TestConsulCheckForChanges"
-	consul, service := setupConsul(backend)
-	if err := setupWaitForLeader(consul); err != nil {
-		t.Errorf("Consul leader could not be elected.")
-	}
+func testConsulCheckForChanges(t *testing.T) {
+	backend := fmt.Sprintf("service-TestConsulCheckForChanges")
+	consul, _ := NewConsulConfig(testServer.HTTPAddr)
+	service := generateServiceDefinition(backend)
 	id := service.ID
 	if consul.CheckForUpstreamChanges(backend, "") {
 		t.Fatalf("First read of %s should show `false` for change", id)
 	}
-	consul.SendHeartbeat(service) // force registration
-	consul.SendHeartbeat(service) // write TTL
+	consul.SendHeartbeat(service) // force registration and 1st heartbeat
 
 	if !consul.CheckForUpstreamChanges(backend, "") {
 		t.Errorf("%v should have changed after first health check TTL", id)
@@ -142,18 +115,15 @@ func TestConsulCheckForChanges(t *testing.T) {
 	if consul.CheckForUpstreamChanges(backend, "") {
 		t.Errorf("%v should not have changed without TTL expiring", id)
 	}
-	time.Sleep(2 * time.Second) // wait for TTL to expire
+	consul.Agent().UpdateTTL(id, "expired", "critical")
 	if !consul.CheckForUpstreamChanges(backend, "") {
 		t.Errorf("%v should have changed after TTL expired.", id)
 	}
 }
 
-func TestConsulEnableTagOverride(t *testing.T) {
-	backend := "service-TestConsulEnableTagOverride"
-	consul, _ := NewConsulConfig(getTestConsulAddress())
-	if err := setupWaitForLeader(consul); err != nil {
-		t.Errorf("Consul leader could not be elected.")
-	}
+func testConsulEnableTagOverride(t *testing.T) {
+	backend := fmt.Sprintf("service-TestConsulEnableTagOverride")
+	consul, _ := NewConsulConfig(testServer.HTTPAddr)
 	service := &discovery.ServiceDefinition{
 		ID:        backend,
 		Name:      backend,
@@ -178,5 +148,15 @@ func TestConsulEnableTagOverride(t *testing.T) {
 		if service.ServiceEnableTagOverride != true {
 			t.Errorf("%v should have had EnableTagOverride set to true", id)
 		}
+	}
+}
+
+func generateServiceDefinition(serviceName string) *discovery.ServiceDefinition {
+	return &discovery.ServiceDefinition{
+		ID:        serviceName,
+		Name:      serviceName,
+		IPAddress: "192.168.1.1",
+		TTL:       5,
+		Port:      9000,
 	}
 }


### PR DESCRIPTION
The behaviors we're testing in the consul package are very thin wrappers around the upstream Consul API library, but that library doesn't have a interfaces (in the golang sense) that we can mock. Using httptest with a test server could give us the HTTP server but not the stateful behaviors without having to implement a lot of Consul's own behavior and we'd have to build code generation in order to validate it.

Here we'll use Hashi's own test infrastructure around Consul to run the Consul binary and tear it down after tests. This lets us run locally without Docker (and is a lot faster!) and makes it clear where the boundary of tests that depend on the server lies. In future work we can try to minimize this test region and try to eliminate the requirement or move these pieces into integration tests.

~This PR contains all the commits from #285 and will be rebased once that's been merged. ~8494f83~ d6d0f58 contains the only commit in this PR.~