### PR TITLE
Replace timeout code with Context and force default timeouts

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -20,6 +20,7 @@ type Backend struct {
 	discoveryService discovery.ServiceBackend
 	lastState        interface{}
 	onChangeCmd      *commands.Command
+	timeout          time.Duration
 }
 
 // NewBackends creates a new backend from a raw config structure
@@ -38,6 +39,9 @@ func NewBackends(raw []interface{}, disc discovery.ServiceBackend) ([]*Backend, 
 		if b.OnChangeExec == nil {
 			return nil, fmt.Errorf("`onChange` is required in backend %s",
 				b.Name)
+		}
+		if b.Timeout == "" {
+			b.Timeout = fmt.Sprintf("%ds", b.Poll)
 		}
 		cmd, err := commands.NewCommand(b.OnChangeExec, b.Timeout)
 		if err != nil {

--- a/backends/backends.go
+++ b/backends/backends.go
@@ -20,7 +20,6 @@ type Backend struct {
 	discoveryService discovery.ServiceBackend
 	lastState        interface{}
 	onChangeCmd      *commands.Command
-	timeout          time.Duration
 }
 
 // NewBackends creates a new backend from a raw config structure

--- a/backends/backends_test.go
+++ b/backends/backends_test.go
@@ -14,11 +14,11 @@ func TestOnChangeCmd(t *testing.T) {
 		onChangeCmd: cmd1,
 	}
 	if err := backend.OnChange(); err != nil {
-		t.Errorf("Unexpected error OnChange: %s", err)
+		t.Fatalf("Unexpected error OnChange: %s", err)
 	}
 	// Ensure we can run it more than once
 	if err := backend.OnChange(); err != nil {
-		t.Errorf("Unexpected error OnChange (x2): %s", err)
+		t.Fatalf("Unexpected error OnChange (x2): %s", err)
 	}
 }
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -142,8 +142,12 @@ func RunWithTimeout(c *Command, fields log.Fields) error {
 	go func() {
 		select {
 		case <-ctx.Done():
-			log.Warnf("%s timeout after %s: '%s'", c.Name, c.Timeout, c.Args)
-			c.Kill()
+			// if the context was canceled we don't want to kill the
+			// process because it's already gone
+			if ctx.Err().Error() == "context deadline exceeded" {
+				log.Warnf("%s timeout after %s: '%s'", c.Name, c.Timeout, c.Args)
+				c.Kill()
+			}
 		}
 	}()
 

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -129,13 +129,12 @@ func RunWithTimeout(c *Command, fields log.Fields) error {
 		// anyway in case the caller cares
 		return errors.New("Command for RunWithTimeout was nil")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), c.TimeoutDuration)
-	defer cancel()
-
 	log.Debugf("%s.RunWithTimeout start", c.Name)
 	c.setUpCmd(fields)
 	defer c.closeLogs()
 	log.Debugf("%s.Cmd start", c.Name)
+	ctx, cancel := context.WithTimeout(context.Background(), c.TimeoutDuration)
+	defer cancel()
 	if err := c.Cmd.Start(); err != nil {
 		log.Errorf("unable to start %s: %v", c.Name, err)
 		return err

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -61,23 +61,6 @@ func TestRunAndWaitForOutput(t *testing.T) {
 	}
 }
 
-// If the task isn't killed after 1 second, fail the test and
-// clean up the task
-func failIfNotTimedOut(t *testing.T, cmd *Command) context.CancelFunc {
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	go func() {
-		select {
-		case <-ctx.Done():
-			//			cmd.Kill()
-			if t != nil {
-				t.Fatalf("command was not stopped by timeout")
-			}
-			return
-		}
-	}()
-	return cancel
-}
-
 // We want to make sure test tasks don't run forever and so if they
 // exceed their timeouts and don't return an error we want to know that.
 func failTestIfExceedingTimeout(t *testing.T, cmd *Command) error {

--- a/documentation/12-configuration/README.md
+++ b/documentation/12-configuration/README.md
@@ -127,7 +127,7 @@ The format of the JSON file configuration is as follows:
 - `poll` is the time in seconds between polling for health checks.
 - `ttl` is the time-to-live of a successful health check. This should be longer than the polling rate so that the polling process and the TTL aren't racing; otherwise Consul will mark the service as unhealthy.
 - `tags` is an optional array of tags. If the discovery service supports it (Consul does), the service will register itself with these tags.
-- `timeout` an optional value to wait before forcibly killing the health check. Health checks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This means that a heartbeat will not be sent. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the health check. *Deprecation warning:* in ContainerPilot 3.0 this will default to the `poll` time.
+- `timeout` a value to wait before forcibly killing the health check. Health checks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This means that a heartbeat will not be sent. The minimum timeout is `1ms` (see the golang [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) docs for this format). This field is optional and defaults to be equal to the `poll` time.
 - `consul` an optional block of consul specific service configuration.
     - [`enableTagOverride`](https://www.consul.io/docs/agent/services.html) if set to `true`, then external agents can update this service in the catalog and modify the tags.
     - [`deregisterCriticalServiceAfter`](https://www.consul.io/docs/agent/http/agent.html) is a timeout in Go time format. If a check is in the critical state for more than this configured value, then its associated service (and all of its associated checks) will automatically be deregistered.
@@ -137,7 +137,7 @@ The format of the JSON file configuration is as follows:
 - `name` is the name of a backend service that this container depends on, as it will appear in Consul.
 - `poll` is the time in seconds between polling for changes.
 - `onChange` is the executable (and its arguments) that is called when there is a change in the list of IPs and ports for this backend.
-- `timeout` an optional value to wait before forcibly killing the `onChange` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the `onChange` handler. *Deprecation warning:* in ContainerPilot 3.0 this will default to the `poll` time.
+- `timeout` a value to wait before forcibly killing the `onChange` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms` (see the golang [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) docs for this format). This field is optional and defaults to be equal to the `poll` time.
 
 ### Service catalog
 

--- a/documentation/18-tasks/README.md
+++ b/documentation/18-tasks/README.md
@@ -11,4 +11,4 @@ A task accepts the following properties:
 - `timeout` is the amount of time to wait before forcibly killing the task.  Tasks killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. This value is optional and defaults to the `frequency`. The minimum timeout is `1ms`
 - `name` is a friendly name given to the task for logging purposes - this has no effect on the task execution. This value is optional, and defaults to the `command` if not given.
 
-**Note on task frequency:** *Pick a frequency of 1s or longer*. Although the task configuration permits frequencies as fast as 1ms, the overhead of spawning a process and its lifecycle is likely to be anywhere from 2ms to 25ms. Your task may not be able to run at all, or it might always be killed before it gets any useful work done. 
+**Note on task frequency:** *Pick a frequency of 1s or longer*. Although the task configuration permits frequencies as fast as 1ms, the overhead of spawning a process and its lifecycle is likely to be anywhere from 2ms to 25ms. Your task may not be able to run at all, or it might always be killed before it gets any useful work done.

--- a/documentation/19-telemetry/README.md
+++ b/documentation/19-telemetry/README.md
@@ -55,7 +55,7 @@ The fields for a sensor are as follows:
 - `type` is the type of collector Prometheus will use (one of `counter`, `gauge`, `histogram` or `summary`). See [below](#Collector_types) for details.
 - `poll` is the time in seconds between running the `check`.
 - `check` is the executable (and its arguments) that is called when it is time to perform a telemetry collection.
-- `timeout` an optional value to wait before forcibly killing the `check` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms`. Omitting this field means that ContainerPilot will wait indefinitely for the `check` handler. *Deprecation warning:* in ContainerPilot 3.0 this will default to the `poll` time.
+- `timeout` an optional value to wait before forcibly killing the `check` handler. Handlers killed in this way are terminated immediately (`SIGKILL`) without an opportunity to clean up their state. The minimum timeout is `1ms` (see the golang [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) docs for this format). This field is optional and defaults to be equal to the `poll` time.
 
 The check executable is expected to return via stdout a value that can be parsed as a single 64-bit float number. Whitespace will be trimmed, but any other text in the stdout of the executable will cause the metric to be dropped. If you need to return additional information for logging, you should return this via stderr (which ContainerPilot will pass along to the Docker engine).
 

--- a/services/services.go
+++ b/services/services.go
@@ -91,8 +91,7 @@ func parseService(s *Service, disc discovery.ServiceBackend) error {
 	// command; this is useful for the telemetry service
 	if s.HealthCheckExec != nil {
 		if s.Timeout == "" {
-			// default timeout
-			s.Timeout = "1s"
+			s.Timeout = fmt.Sprintf("%ds", s.Poll)
 		}
 		cmd, err := commands.NewCommand(s.HealthCheckExec, s.Timeout)
 		if err != nil {

--- a/services/services.go
+++ b/services/services.go
@@ -90,6 +90,10 @@ func parseService(s *Service, disc discovery.ServiceBackend) error {
 	// if the HealthCheckExec is nil then we'll have no health check
 	// command; this is useful for the telemetry service
 	if s.HealthCheckExec != nil {
+		if s.Timeout == "" {
+			// default timeout
+			s.Timeout = "1s"
+		}
 		cmd, err := commands.NewCommand(s.HealthCheckExec, s.Timeout)
 		if err != nil {
 			return fmt.Errorf("Could not parse `health` in service %s: %s", s.Name, err)

--- a/telemetry/sensors.go
+++ b/telemetry/sensors.go
@@ -82,6 +82,9 @@ func NewSensors(raw []interface{}) ([]*Sensor, error) {
 		return nil, fmt.Errorf("Sensor configuration error: %v", err)
 	}
 	for _, s := range sensors {
+		if s.Timeout == "" {
+			s.Timeout = fmt.Sprintf("%ds", s.Poll)
+		}
 		check, err := commands.NewCommand(s.CheckExec, s.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse check in sensor %s: %s", s.Name, err)


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/266 and https://github.com/joyent/containerpilot/issues/206

This replaces the timeout code we wrote for commands with `Context` (available in the stdlib after 1.7), which reduces the total amount of custom code and test surface we have. Note that in `RunWithTimeout` we can't simply instantiate the `Command` via `exec.CommandContext` because we need to kill the whole process tree. If we were to use the `exec.CommandContext` version then any children would continue to run after we run `Kill`.

cc @jasonpincin