### PR TITLE
add discovery disable flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -186,7 +186,7 @@ func RenderConfig(configFlag, renderFlag string) error {
 }
 
 // ParseConfig parses a raw config flag
-func ParseConfig(configFlag string) (*Config, error) {
+func ParseConfig(configFlag string, noDiscoveryFlag bool) (*Config, error) {
 
 	template, err := renderConfigTemplate(configFlag)
 	if err != nil {
@@ -197,7 +197,7 @@ func ParseConfig(configFlag string) (*Config, error) {
 		return nil, err
 	}
 	discoveryService, err := parseServiceBackend(configMap)
-	if err != nil {
+	if err != nil && !noDiscoveryFlag{
 		return nil, err
 	}
 	// Delete discovery backend keys

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -231,7 +231,7 @@ func TestMetricServiceCreation(t *testing.T) {
       "port": 9090
     }
   }`
-	if app, err := NewApp(jsonFragment); err != nil {
+	if app, err := NewApp(jsonFragment, false); err != nil {
 		t.Fatalf("Got error while initializing config: %v", err)
 	} else {
 		if len(app.Services) != 1 {
@@ -283,7 +283,7 @@ func testParseExpectError(t *testing.T, testJSON string, expected string) {
 }
 
 func validateParseError(t *testing.T, testJSON string, matchStrings []string) {
-	if _, err := NewApp(testJSON); err == nil {
+	if _, err := NewApp(testJSON, false); err == nil {
 		t.Errorf("Expected error parsing config")
 	} else {
 		for _, match := range matchStrings {


### PR DESCRIPTION
Using containerpilot without discovery was raised in #211.

Here is my simple proposal to add a --no-discovery flag for containerpilot. If we don't find any configured backends while the --no-discovery flag is true, then ignore the error when parsing the config instead of dying with a fatal error.

The main concern raised in #211 was that under normal usage the error about not defining any backends is a valid one. In this case the user needs to opt-in with a flag, so they would never need a configuration warning.

Seems to be working well for me in a development build. Still evaluating this project for using in production :)