### PR TITLE
ensure stdout/stderr are connected when there are no logging fields

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -73,6 +73,10 @@ func RunAndWait(c *Command) (int, error) {
 	}
 	log.Debugf("%s.RunAndWait start", c.Name)
 	c.setUpCmd()
+	if c.logFields == nil {
+		c.Cmd.Stdout = os.Stdout
+		c.Cmd.Stderr = os.Stderr
+	}
 	log.Debugf("%s.Cmd.Run", c.Name)
 	if err := c.Cmd.Start(); err != nil {
 		// the stdlib almost certainly won't include the underlying error


### PR DESCRIPTION
For #304.

In the v3 work, we don't have commands that pipe directly to stdout/stderr, and I missed this while we backported. I've tested this out using the same minimal test rig described in https://github.com/joyent/containerpilot/issues/304#issuecomment-291568566 as follows:

```bash
$ docker run -it test /bin/containerpilot-dev cat /etc/containerpilot.json
2017/04/04 17:25:41 Loaded config: {"ServiceBackend":{},"LogConfig":{"level":"DEBUG","format":"default","output":"stdout"},"PreStart":null,"PreStop":null,"PostStop":null,"StopTimeout":5,"Coprocesses":null,"Services":[],"Backends":[],"Tasks":null,"Telemetry":null}
2017/04/04 17:25:41 APP.RunAndWait start
2017/04/04 17:25:41 APP.Cmd.Run
{
  "consul": "consul:8500",
  "logging": {
    "level": "DEBUG"
  }
}
2017/04/04 17:25:41 APP.RunAndWait end
```