### PR TITLE
transparently swap out JSON config parsing for JSON5

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -11,6 +10,8 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/flynn/json5"
+
 	"github.com/joyent/containerpilot/checks"
 	"github.com/joyent/containerpilot/control"
 	"github.com/joyent/containerpilot/discovery"
@@ -206,8 +207,8 @@ func renderConfigTemplate(configFlag string) ([]byte, error) {
 
 func unmarshalConfig(data []byte) (map[string]interface{}, error) {
 	var config map[string]interface{}
-	if err := json.Unmarshal(data, &config); err != nil {
-		syntax, ok := err.(*json.SyntaxError)
+	if err := json5.Unmarshal(data, &config); err != nil {
+		syntax, ok := err.(*json5.SyntaxError)
 		if !ok {
 			return nil, fmt.Errorf(
 				"could not parse configuration: %s",
@@ -218,7 +219,7 @@ func unmarshalConfig(data []byte) (map[string]interface{}, error) {
 	return config, nil
 }
 
-func newJSONparseError(js []byte, syntax *json.SyntaxError) error {
+func newJSONparseError(js []byte, syntax *json5.SyntaxError) error {
 	line, col, err := highlightError(js, syntax.Offset)
 	return fmt.Errorf("parse error at line:col [%d:%d]: %s\n%s", line, col, syntax, err)
 }

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -132,30 +132,6 @@ func TestJSONTemplateParseError(t *testing.T) {
 		"parse error at line:col [2:13]")
 }
 
-func TestJSONTemplateParseError2(t *testing.T) {
-	defer argTestCleanup(argTestSetup())
-	testParseExpectError(t,
-		`{
-    "test1": "1",
-    "test2": 2,
-    "test3": false,
-    test2: "hello"
-}`,
-		"parse error at line:col [5:5]")
-}
-
-func TestParseTrailingComma(t *testing.T) {
-	defer argTestCleanup(argTestSetup())
-	testParseExpectError(t,
-		`{
-			"consul": "consul:8500",
-			"tasks": [{
-				"command": ["echo","hi"]
-			},
-		]
-	}`, "Do you have an extra comma somewhere?")
-}
-
 func TestRenderArgs(t *testing.T) {
 	flags := []string{"-name", "{{ .HOSTNAME }}"}
 	expected := os.Getenv("HOSTNAME")
@@ -179,18 +155,18 @@ func TestRenderArgs(t *testing.T) {
 
 func TestControlServerCreation(t *testing.T) {
 
-        jsonFragment := `{
+	jsonFragment := `{
     "consul": "consul:8500"
   }`
 
-        app, err := NewApp(jsonFragment)
-        if err != nil {
-            t.Fatalf("got error while initializing config: %v", err)
-        }
+	app, err := NewApp(jsonFragment)
+	if err != nil {
+		t.Fatalf("got error while initializing config: %v", err)
+	}
 
-        if app.ControlServer == nil {
-            t.Error("expected control server to not be nil")
-        }
+	if app.ControlServer == nil {
+		t.Error("expected control server to not be nil")
+	}
 }
 
 func TestMetricServiceCreation(t *testing.T) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: da4c6759d51ce929aaf1e9959b9deed743e0b0e0aeed601024b5cf0b2385a5a6
-updated: 2017-02-10T18:26:54.577375574Z
+hash: 7a72ba93b39a5a461759ab476bfaabbf4e105deb67f93adc1bfda8e10b2e0fd7
+updated: 2017-04-05T15:10:03.856365456-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -7,18 +7,20 @@ imports:
   - quantile
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/flynn/json5
+  version: 7620272ed63390e979cf5882d2fa0506fe2a8db5
 - name: github.com/golang/protobuf
-  version: 8ee79997227bf9b34611aee7946ae64735e6fd93
+  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
   subpackages:
   - proto
 - name: github.com/hashicorp/consul
-  version: 1c442cb5704841704c1ba88daf1156245d0b311e
+  version: 21f2d5ad0c02af6c4b32d8fd04f7c81e9b002d41
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
-  version: ad28ea4487f05916463e2423a55166280e8254b5
+  version: 3573b8b52aa7b37b9358d966a898feb387f62437
 - name: github.com/hashicorp/serf
-  version: cb45b412ee4f9d6cc2eeb2b2b7dd0f6cfd7545c1
+  version: 19f2c401e122352c047a84d6584dd51e2fb8fcc4
   subpackages:
   - coordinate
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -55,4 +57,4 @@ imports:
   version: 50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e
   subpackages:
   - unix
-testImports: []
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -38,3 +38,5 @@ import:
   version: 50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e
   subpackages:
   - unix
+- package: github.com/flynn/json5
+  version: 7620272ed63390e979cf5882d2fa0506fe2a8db5

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	"encoding/json"
+	"github.com/flynn/json5"
 )
 
 // DecodeRawToSlice supports testing NewConfig functions, which never receive the
@@ -11,9 +11,9 @@ import (
 func DecodeRawToSlice(input string) []interface{} {
 	testCfg := []byte(input)
 	var raw []interface{}
-	if err := json.Unmarshal(testCfg, &raw); err != nil {
+	if err := json5.Unmarshal(testCfg, &raw); err != nil {
 		// this is an error in our test, not in the tested code
-		panic("unexpected error decoding test fixture JSON:\n" + err.Error())
+		panic("unexpected error decoding test fixture JSON5:\n" + err.Error())
 	}
 	return raw
 }
@@ -25,9 +25,9 @@ func DecodeRawToSlice(input string) []interface{} {
 func DecodeRaw(input string) interface{} {
 	testCfg := []byte(input)
 	var raw interface{}
-	if err := json.Unmarshal(testCfg, &raw); err != nil {
+	if err := json5.Unmarshal(testCfg, &raw); err != nil {
 		// this is an error in our test, not in the tested code
-		panic("unexpected error decoding test fixture JSON:\n" + err.Error())
+		panic("unexpected error decoding test fixture JSON5:\n" + err.Error())
 	}
 	return raw
 }


### PR DESCRIPTION
This PR swaps out the JSON config parser for a JSON5 config parser (per https://github.com/joyent/rfd/pull/31). This doesn't change out any of the expected configuration, so this should work transparently.