### PR TITLE
catch the 'waitid: no child processes' message after exec wait

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -14,7 +14,10 @@ import (
 	"github.com/joyent/containerpilot/events"
 )
 
-const errNoChild = "wait: no child processes"
+const (
+	errWaitNoChild   = "wait: no child processes"
+	errWaitIDNoChild = "waitid: no child processes"
+)
 
 // Command wraps an os/exec.Cmd with a timeout, logging, and arg parsing.
 type Command struct {
@@ -178,7 +181,7 @@ func (c *Command) wait() (int, error) {
 		}
 		return returnStatus, fmt.Errorf("%s: %s", c.Name, waitStatus)
 	} else if err != nil {
-		if err.Error() == errNoChild {
+		if err.Error() == errWaitNoChild || err.Error() == errWaitIDNoChild {
 			log.Debugf(err.Error())
 			return 0, nil // process exited cleanly before we hit wait4
 		}


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/309

The `os` package says we should be getting [`wait: no child processes`](https://golang.org/src/os/exec_unix.go?s=962:989#L22) from our `wait` call. But we're also getting [`waitid: no child processes`](https://golang.org/src/os/wait_waitid.go?s=1174:1202#L37) from the earlier [`blockUntilWaitable`](https://golang.org/src/os/exec_unix.go?s=482:504#L22). Both "errors" are harmless to ignore as it just means we've lost the race to reap any children with the signal handler.

ref https://github.com/joyent/containerpilot/pull/222 for the previous work done on this subject.