### PR TITLE
move some configuration test fixtures into their own testdata files

### DIFF
--- a/checks/config_test.go
+++ b/checks/config_test.go
@@ -1,6 +1,8 @@
 package checks
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/joyent/containerpilot/tests"
@@ -8,26 +10,8 @@ import (
 )
 
 func TestCheckParse(t *testing.T) {
-	testCfg := tests.DecodeRawToSlice(`[
-{
-  "name": "serviceA",
-  "port": 8080,
-  "interfaces": "inet",
-  "health": ["/bin/checkA.sh", "A1", "A2"],
-  "poll": 30,
-  "ttl": 19,
-  "timeout": "1ms",
-  "tags": ["tag1","tag2"]
-},
-{
-  "name": "serviceB",
-  "port": 5000,
-  "interfaces": ["ethwe","eth0", "inet"],
-  "health": "/bin/checkB.sh B1 B2",
-  "poll": 30,
-  "ttl": 103
-}
-]`)
+	data, _ := ioutil.ReadFile(fmt.Sprintf("./testdata/%s.json5", t.Name()))
+	testCfg := tests.DecodeRawToSlice(string(data))
 	checks, err := NewConfigs(testCfg)
 	if err != nil {
 		t.Fatalf("could not parse config JSON: %s", err)

--- a/checks/testdata/TestCheckParse.json5
+++ b/checks/testdata/TestCheckParse.json5
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "serviceA",
+    "port": 8080,
+    "interfaces": "inet",
+    "health": ["/bin/checkA.sh", "A1", "A2"],
+    "poll": 30,
+    "ttl": 19,
+    "timeout": "1ms",
+    "tags": ["tag1","tag2"]
+  },
+  {
+    "name": "serviceB",
+    "port": 5000,
+    "interfaces": ["ethwe","eth0", "inet"],
+    "health": "/bin/checkB.sh B1 B2",
+    "poll": 30,
+    "ttl": 103
+  }
+]

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -12,76 +13,12 @@ are all in the individual package tests. Here we'll make sure all components
 come together as we expect and also check things like env var interpolation.
 */
 
-var testJSON = `{
-	"consul": "consul:8500",
-	"stopTimeout": 5,
-	"services": [
-			{
-					"name": "serviceA",
-					"port": 8080,
-					"interfaces": "inet",
-					"exec": "/bin/serviceA",
-					"preStart": "/bin/to/preStart.sh arg1 arg2",
-					"preStop": ["/bin/to/preStop.sh","arg1","arg2"],
-					"postStop": ["/bin/to/postStop.sh"],
-					"health": "/bin/to/healthcheck/for/service/A.sh",
-					"poll": 30,
-					"ttl": "19",
-					"tags": ["tag1","tag2"]
-			},
-			{
-					"name": "serviceB",
-					"port": 5000,
-					"interfaces": ["ethwe","eth0", "inet"],
-					"exec": ["/bin/serviceB", "B"],
-					"health": ["/bin/to/healthcheck/for/service/B.sh", "B"],
-					"timeout": "2s",
-					"poll": 20,
-					"ttl": "103"
-			},
-			{
-					"name": "coprocessC",
-					"exec": "/bin/coprocessC",
-					"restarts": "unlimited"
-			},
-			{
-					"name": "taskD",
-					"exec": "/bin/taskD",
-					"frequency": "1s"
-			}
-	],
-	"backends": [
-			{
-					"name": "upstreamA",
-					"poll": 11,
-					"onChange": "/bin/to/onChangeEvent/for/upstream/A.sh {{.TEST}}",
-					"tag": "dev"
-			},
-			{
-					"name": "upstreamB",
-					"poll": 79,
-					"onChange": "/bin/to/onChangeEvent/for/upstream/B.sh {{.ENV_NOT_FOUND}}"
-			}
-	],
-	"telemetry": {
-		"port": 9000,
-		"interfaces": ["inet"],
-		"tags": ["dev"],
-		"sensors": [
-			{
-				"namespace": "org",
-				"subsystem": "app",
-				"name": "zed",
-				"help": "gauge of zeds in org app",
-				"type": "gauge",
-				"poll": 10,
-				"check": "/bin/sensorZ",
-				"timeout": "5s"
-			}
-		]
-	}
+var testJSON string
+
+func init() {
+	data, _ := ioutil.ReadFile("./testdata/test.json5")
+	testJSON = string(data)
 }
-`
 
 func assertEqual(t *testing.T, got, expected interface{}, msg string) {
 	if !reflect.DeepEqual(expected, got) {

--- a/config/testdata/test.json5
+++ b/config/testdata/test.json5
@@ -1,0 +1,69 @@
+{
+  "consul": "consul:8500",
+  "stopTimeout": 5,
+  "services": [
+      {
+          "name": "serviceA",
+          "port": 8080,
+          "interfaces": "inet",
+          "exec": "/bin/serviceA",
+          "preStart": "/bin/to/preStart.sh arg1 arg2",
+          "preStop": ["/bin/to/preStop.sh","arg1","arg2"],
+          "postStop": ["/bin/to/postStop.sh"],
+          "health": "/bin/to/healthcheck/for/service/A.sh",
+          "poll": 30,
+          "ttl": "19",
+          "tags": ["tag1","tag2"]
+      },
+      {
+          "name": "serviceB",
+          "port": 5000,
+          "interfaces": ["ethwe","eth0", "inet"],
+          "exec": ["/bin/serviceB", "B"],
+          "health": ["/bin/to/healthcheck/for/service/B.sh", "B"],
+          "timeout": "2s",
+          "poll": 20,
+          "ttl": "103"
+      },
+      {
+          "name": "coprocessC",
+          "exec": "/bin/coprocessC",
+          "restarts": "unlimited"
+      },
+      {
+          "name": "taskD",
+          "exec": "/bin/taskD",
+          "frequency": "1s"
+      }
+  ],
+  "backends": [
+      {
+          "name": "upstreamA",
+          "poll": 11,
+          "onChange": "/bin/to/onChangeEvent/for/upstream/A.sh {{.TEST}}",
+          "tag": "dev"
+      },
+      {
+          "name": "upstreamB",
+          "poll": 79,
+          "onChange": "/bin/to/onChangeEvent/for/upstream/B.sh {{.ENV_NOT_FOUND}}"
+      }
+  ],
+  "telemetry": {
+    "port": 9000,
+    "interfaces": ["inet"],
+    "tags": ["dev"],
+    "sensors": [
+      {
+        "namespace": "org",
+        "subsystem": "app",
+        "name": "zed",
+        "help": "gauge of zeds in org app",
+        "type": "gauge",
+        "poll": 10,
+        "check": "/bin/sensorZ",
+        "timeout": "5s"
+      }
+    ]
+  }
+}

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -16,49 +16,6 @@ import (
 TODO v3: a LOT of the these tests should be moved to the config package
 */
 
-// ------------------------------------------
-
-var testJSON = `{
-	"consul": "consul:8500",
-	"preStart": "/bin/to/preStart.sh arg1 arg2",
-	"preStop": ["/bin/to/preStop.sh","arg1","arg2"],
-	"postStop": ["/bin/to/postStop.sh"],
-	"stopTimeout": 5,
-	"services": [
-			{
-					"name": "serviceA",
-					"port": 8080,
-					"interfaces": "inet",
-					"health": "/bin/to/healthcheck/for/service/A.sh",
-					"poll": 30,
-					"ttl": "19",
-					"tags": ["tag1","tag2"]
-			},
-			{
-					"name": "serviceB",
-					"port": 5000,
-					"interfaces": ["ethwe","eth0", "inet"],
-					"health": "/bin/to/healthcheck/for/service/B.sh",
-					"poll": 30,
-					"ttl": 103
-			}
-	],
-	"backends": [
-			{
-					"name": "upstreamA",
-					"poll": 11,
-					"onChange": "/bin/to/onChangeEvent/for/upstream/A.sh {{.TEST}}",
-					"tag": "dev"
-			},
-			{
-					"name": "upstreamB",
-					"poll": 79,
-					"onChange": "/bin/to/onChangeEvent/for/upstream/B.sh {{.ENV_NOT_FOUND}}"
-			}
-	]
-}
-`
-
 func TestServiceConfigRequiredFields(t *testing.T) {
 	// Missing `name`
 	var testJSON = `{"consul": "consul:8500", "services": [

--- a/jobs/testdata/TestInvalidJobsConsulExtrasDeregisterCriticalServiceAfter.json5
+++ b/jobs/testdata/TestInvalidJobsConsulExtrasDeregisterCriticalServiceAfter.json5
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "serviceA",
+    "port": 8080,
+    "interfaces": "inet",
+    "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
+    "poll": 30,
+    "ttl": 19,
+    "timeout": "1ms",
+    "tags": ["tag1","tag2"],
+    "consul": {
+      "deregisterCriticalServiceAfter": "nope"
+    }
+  }
+]

--- a/jobs/testdata/TestInvalidJobsConsulExtrasEnableTagOverride.json5
+++ b/jobs/testdata/TestInvalidJobsConsulExtrasEnableTagOverride.json5
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "serviceA",
+    "port": 8080,
+    "interfaces": "inet",
+    "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
+    "poll": 30,
+    "ttl": 19,
+    "timeout": "1ms",
+    "tags": ["tag1","tag2"],
+    "consul": {
+      "enableTagOverride": "nope"
+    }
+  }
+]

--- a/jobs/testdata/TestJobConfigHappyPath.json5
+++ b/jobs/testdata/TestJobConfigHappyPath.json5
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "serviceA",
+    "port": 8080,
+    "interfaces": "inet",
+    "exec": "/bin/serviceA",
+    "preStart": "/bin/to/preStart.sh arg1 arg2",
+    "preStop": ["/bin/to/preStop.sh","arg1","arg2"],
+    "postStop": ["/bin/to/postStop.sh"],
+    "health": "/bin/to/healthcheck/for/service/A.sh",
+    "poll": 30,
+    "ttl": "19",
+    "tags": ["tag1","tag2"]
+  },
+  {
+    "name": "serviceB",
+    "port": 5000,
+    "interfaces": ["ethwe","eth0", "inet"],
+    "exec": ["/bin/serviceB", "B"],
+    "health": ["/bin/to/healthcheck/for/service/B.sh", "B"],
+    "timeout": "2s",
+    "poll": 20,
+    "ttl": "103"
+  },
+  {
+    "name": "coprocessC",
+    "exec": "/bin/coprocessC",
+    "restarts": "unlimited"
+  },
+    {
+    "name": "taskD",
+    "exec": "/bin/taskD",
+    "frequency": "1s"
+  }
+]

--- a/jobs/testdata/TestJobsConsulExtrasDeregisterCriticalServiceAfter.json5
+++ b/jobs/testdata/TestJobsConsulExtrasDeregisterCriticalServiceAfter.json5
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "serviceA",
+    "port": 8080,
+    "interfaces": "inet",
+    "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
+    "poll": 30,
+    "ttl": 19,
+    "timeout": "1ms",
+    "tags": ["tag1","tag2"],
+    "consul": {
+      "deregisterCriticalServiceAfter": "40m"
+    }
+  }
+]

--- a/jobs/testdata/TestJobsConsulExtrasEnableTagOverride.json5
+++ b/jobs/testdata/TestJobsConsulExtrasEnableTagOverride.json5
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "serviceA",
+    "port": 8080,
+    "interfaces": "inet",
+    "health": ["/bin/to/healthcheck/for/service/A.sh", "A1", "A2"],
+    "poll": 30,
+    "ttl": 19,
+    "timeout": "1ms",
+    "tags": ["tag1","tag2"],
+    "consul": {
+      "enableTagOverride": true
+    }
+  }
+]

--- a/telemetry/telemetry_config_test.go
+++ b/telemetry/telemetry_config_test.go
@@ -1,6 +1,8 @@
 package telemetry
 
 import (
+	"fmt"
+	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -10,22 +12,8 @@ import (
 )
 
 func TestTelemetryConfigParse(t *testing.T) {
-	testCfg := tests.DecodeRaw(`{
-	"port": 8000,
-	"interfaces": ["inet"],
-	"sensors": [
-       {
-		"namespace": "telemetry",
-		"subsystem": "telemetry",
-		"name": "TestTelemetryParse",
-		"help": "help",
-		"type": "counter",
-		"poll": 5,
-		"check": ["/bin/sensor.sh"]
-	  }
-	]
- }`)
-
+	data, _ := ioutil.ReadFile(fmt.Sprintf("./testdata/%s.json5", t.Name()))
+	testCfg := tests.DecodeRaw(string(data))
 	telem, err := NewConfig(testCfg, &NoopServiceBackend{})
 	if err != nil {
 		t.Fatalf("could not parse telemetry JSON: %s", err)

--- a/telemetry/testdata/TestTelemetryConfigParse.json5
+++ b/telemetry/testdata/TestTelemetryConfigParse.json5
@@ -1,0 +1,15 @@
+{
+  "port": 8000,
+  "interfaces": ["inet"],
+  "sensors": [
+       {
+    "namespace": "telemetry",
+    "subsystem": "telemetry",
+    "name": "TestTelemetryParse",
+    "help": "help",
+    "type": "counter",
+    "poll": 5,
+    "check": ["/bin/sensor.sh"]
+    }
+  ]
+}

--- a/watches/config_test.go
+++ b/watches/config_test.go
@@ -1,6 +1,8 @@
 package watches
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/joyent/containerpilot/tests"
@@ -8,19 +10,8 @@ import (
 )
 
 func TestWatchesParse(t *testing.T) {
-	testCfg := tests.DecodeRawToSlice(`[
-{
-  "name": "upstreamA",
-  "poll": 11,
-  "onChange": ["/bin/upstreamA.sh", "A1", "A2"],
-  "tag": "dev"
-},
-{
-  "name": "upstreamB",
-  "poll": 79,
-  "onChange": "/bin/upstreamB.sh B1 B2"
-}
-]`)
+	data, _ := ioutil.ReadFile(fmt.Sprintf("./testdata/%s.json5", t.Name()))
+	testCfg := tests.DecodeRawToSlice(string(data))
 	watches, err := NewConfigs(testCfg, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/watches/testdata/TestWatchesParse.json5
+++ b/watches/testdata/TestWatchesParse.json5
@@ -1,0 +1,13 @@
+[
+  {
+    "name": "upstreamA",
+    "poll": 11,
+    "onChange": ["/bin/upstreamA.sh", "A1", "A2"],
+    "tag": "dev"
+  },
+  {
+    "name": "upstreamB",
+    "poll": 79,
+    "onChange": "/bin/upstreamB.sh B1 B2"
+  }
+]


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/299

This moves a bunch of the larger test configuration JSON5 snippets into their own test fixture files under the `testdata/` directory for their respective packages. This will make it a bit easier to edit test configs without making silly syntax mistakes, as well as making it easier to diff them in code reviews. It's entirely possible I missed one or two that we might want to move, but we can do that incrementally as part of other work -- it's a judgement call as to "at what point does this chunk of text want to be its own file"

cc @cheapRoc 