### PR TITLE
removed mocks we already have in tests/mocks

### DIFF
--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/discovery/consul"
 	"github.com/joyent/containerpilot/events"
 	"github.com/joyent/containerpilot/jobs"
@@ -16,15 +15,7 @@ import (
 )
 
 // ------------------------------------------
-// Test setup with mock services
-
-// Mock Discovery
-type NoopServiceBackend struct{}
-
-func (c *NoopServiceBackend) SendHeartbeat(service *discovery.ServiceDefinition)      { return }
-func (c *NoopServiceBackend) CheckForUpstreamChanges(backend, tag string) bool        { return false }
-func (c *NoopServiceBackend) MarkForMaintenance(service *discovery.ServiceDefinition) {}
-func (c *NoopServiceBackend) Deregister(service *discovery.ServiceDefinition)         {}
+// Test setup
 
 func getSignalTestConfig(t *testing.T) *App {
 
@@ -36,7 +27,7 @@ func getSignalTestConfig(t *testing.T) *App {
 		Interfaces: []string{"inet"},
 		Exec:       []string{"./testdata/test.sh", "interruptSleep"},
 	}
-	cfg.Validate(&NoopServiceBackend{})
+	cfg.Validate(&mocks.NoopDiscoveryBackend{})
 	job := jobs.NewJob(cfg)
 	app := EmptyApp()
 	app.StopTimeout = 5

--- a/telemetry/telemetry_config_test.go
+++ b/telemetry/telemetry_config_test.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/joyent/containerpilot/tests"
 	"github.com/joyent/containerpilot/tests/assert"
+	"github.com/joyent/containerpilot/tests/mocks"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestTelemetryConfigParse(t *testing.T) {
 	data, _ := ioutil.ReadFile(fmt.Sprintf("./testdata/%s.json5", t.Name()))
 	testCfg := tests.DecodeRaw(string(data))
-	telem, err := NewConfig(testCfg, &NoopServiceBackend{})
+	telem, err := NewConfig(testCfg, &mocks.NoopDiscoveryBackend{})
 	if err != nil {
 		t.Fatalf("could not parse telemetry JSON: %s", err)
 	}
@@ -27,7 +28,7 @@ func TestTelemetryConfigParse(t *testing.T) {
 
 func TestTelemetryConfigBadSensor(t *testing.T) {
 	testCfg := tests.DecodeRaw(`{"sensors": [{"check": "true", "poll": 1}], "interfaces": ["inet"]}`)
-	_, err := NewConfig(testCfg, &NoopServiceBackend{})
+	_, err := NewConfig(testCfg, &mocks.NoopDiscoveryBackend{})
 	expected := "invalid sensor type"
 	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Fatalf("expected '%v' in error from bad sensor type but got %v", expected, err)
@@ -36,7 +37,7 @@ func TestTelemetryConfigBadSensor(t *testing.T) {
 
 func TestTelemetryConfigBadInterface(t *testing.T) {
 	testCfg := tests.DecodeRaw(`{"interfaces": ["xxxx"]}`)
-	_, err := NewConfig(testCfg, &NoopServiceBackend{})
+	_, err := NewConfig(testCfg, &mocks.NoopDiscoveryBackend{})
 	expected := "none of the interface specifications were able to match"
 	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Fatalf("expected '%v' in error from bad sensor type but got %v", expected, err)

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -5,13 +5,13 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/joyent/containerpilot/discovery"
+	"github.com/joyent/containerpilot/tests/mocks"
 )
 
 func TestTelemetryServerRestart(t *testing.T) {
 
 	cfg := &Config{Port: 9090, Interfaces: []interface{}{"lo", "lo0", "inet"}}
-	cfg.Validate(&NoopServiceBackend{})
+	cfg.Validate(&mocks.NoopDiscoveryBackend{})
 
 	telem := NewTelemetry(cfg)
 	// initial server
@@ -43,12 +43,3 @@ func verifyMetricsEndpointOk(t *testing.T, telem *Telemetry) {
 	}
 
 }
-
-// Mock Discovery
-// TODO this should probably go into the discovery package for use in testing everywhere
-type NoopServiceBackend struct{}
-
-func (c *NoopServiceBackend) SendHeartbeat(service *discovery.ServiceDefinition)      { return }
-func (c *NoopServiceBackend) CheckForUpstreamChanges(backend, tag string) bool        { return false }
-func (c *NoopServiceBackend) MarkForMaintenance(service *discovery.ServiceDefinition) {}
-func (c *NoopServiceBackend) Deregister(service *discovery.ServiceDefinition)         {}


### PR DESCRIPTION
While working on something else I noticed I'd missed a few places where we had package-local versions of the code in [tests/mocks](https://github.com/joyent/containerpilot/blob/master/tests/mocks/discovery.go) for a no-op discovery backend. I'm posting this as a separate PR to reduce the size of an upcoming changeset that will touch the discovery backend interface.

cc @cheapRoc @jasonpincin @geek 