### PR TITLE
Remove feature to pass config JSON directly via CONTAINERPILOT env var

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,10 +1,10 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
-	"reflect"
 	"testing"
+
+	"github.com/joyent/containerpilot/tests/assert"
 )
 
 /*
@@ -13,23 +13,10 @@ are all in the individual package tests. Here we'll make sure all components
 come together as we expect and also check things like env var interpolation.
 */
 
-var testJSON string
-
-func init() {
-	data, _ := ioutil.ReadFile("./testdata/test.json5")
-	testJSON = string(data)
-}
-
-func assertEqual(t *testing.T, got, expected interface{}, msg string) {
-	if !reflect.DeepEqual(expected, got) {
-		t.Fatalf(msg, expected, got)
-	}
-}
-
 // jobs.Config
 func TestValidConfigJobs(t *testing.T) {
 	os.Setenv("TEST", "HELLO")
-	cfg, err := LoadConfig(testJSON)
+	cfg, err := LoadConfig("./testdata/test.json5")
 	if err != nil {
 		t.Fatalf("unexpected error in LoadConfig: %v", err)
 	}
@@ -38,86 +25,86 @@ func TestValidConfigJobs(t *testing.T) {
 		t.Fatalf("expected 8 jobs but got %v", cfg.Jobs)
 	}
 	job0 := cfg.Jobs[0]
-	assertEqual(t, job0.Name, "serviceA", "expected '%v' for job0.Name but got '%v'")
-	assertEqual(t, job0.Port, 8080, "expected '%v' for job0.Port but got '%v'")
-	assertEqual(t, job0.Exec, "/bin/serviceA", "expected '%v' for job0.Exec but got '%v'")
-	assertEqual(t, job0.Tags, []string{"tag1", "tag2"}, "expected '%v' for job0.Tags but got '%v'")
-	assertEqual(t, job0.Restarts, nil, "expected '%v' for job1.Restarts but got '%v'")
+	assert.Equal(t, job0.Name, "serviceA", "expected '%v' for job0.Name but got '%v'")
+	assert.Equal(t, job0.Port, 8080, "expected '%v' for job0.Port but got '%v'")
+	assert.Equal(t, job0.Exec, "/bin/serviceA", "expected '%v' for job0.Exec but got '%v'")
+	assert.Equal(t, job0.Tags, []string{"tag1", "tag2"}, "expected '%v' for job0.Tags but got '%v'")
+	assert.Equal(t, job0.Restarts, nil, "expected '%v' for job1.Restarts but got '%v'")
 
 	job1 := cfg.Jobs[1]
-	assertEqual(t, job1.Name, "serviceB", "expected '%v' for job1.Name but got '%v'")
-	assertEqual(t, job1.Port, 5000, "expected '%v' for job1.Port but got '%v'")
-	assertEqual(t, len(job1.Tags), 0, "expected '%v' for len(job1.Tags) but got '%v'")
-	assertEqual(t, job1.Exec, []interface{}{"/bin/serviceB", "B"}, "expected '%v' for job1.Exec but got '%v'")
-	assertEqual(t, job1.Restarts, nil, "expected '%v' for job1.Restarts but got '%v'")
+	assert.Equal(t, job1.Name, "serviceB", "expected '%v' for job1.Name but got '%v'")
+	assert.Equal(t, job1.Port, 5000, "expected '%v' for job1.Port but got '%v'")
+	assert.Equal(t, len(job1.Tags), 0, "expected '%v' for len(job1.Tags) but got '%v'")
+	assert.Equal(t, job1.Exec, []interface{}{"/bin/serviceB", "B"}, "expected '%v' for job1.Exec but got '%v'")
+	assert.Equal(t, job1.Restarts, nil, "expected '%v' for job1.Restarts but got '%v'")
 
 	job2 := cfg.Jobs[2]
-	assertEqual(t, job2.Name, "coprocessC", "expected '%v' for job2.Name but got '%v'")
-	assertEqual(t, job2.Port, 0, "expected '%v' for job2.Port but got '%v'")
-	assertEqual(t, job2.When.Frequency, "", "expected '%v' for job2.When.Frequency but got '%v'")
-	assertEqual(t, job2.Restarts, "unlimited", "expected '%v' for job2.Restarts but got '%v'")
+	assert.Equal(t, job2.Name, "coprocessC", "expected '%v' for job2.Name but got '%v'")
+	assert.Equal(t, job2.Port, 0, "expected '%v' for job2.Port but got '%v'")
+	assert.Equal(t, job2.When.Frequency, "", "expected '%v' for job2.When.Frequency but got '%v'")
+	assert.Equal(t, job2.Restarts, "unlimited", "expected '%v' for job2.Restarts but got '%v'")
 
 	job3 := cfg.Jobs[3]
-	assertEqual(t, job3.Name, "periodicTaskD", "expected '%v' for job3.Name but got '%v'")
-	assertEqual(t, job3.Port, 0, "expected '%v' for job3.Port but got '%v'")
-	assertEqual(t, job3.When.Frequency, "1s", "expected '%v' for job3.When.Frequency but got '%v'")
-	assertEqual(t, job3.Restarts, nil, "expected '%v' for job3.Restarts but got '%v'")
+	assert.Equal(t, job3.Name, "periodicTaskD", "expected '%v' for job3.Name but got '%v'")
+	assert.Equal(t, job3.Port, 0, "expected '%v' for job3.Port but got '%v'")
+	assert.Equal(t, job3.When.Frequency, "1s", "expected '%v' for job3.When.Frequency but got '%v'")
+	assert.Equal(t, job3.Restarts, nil, "expected '%v' for job3.Restarts but got '%v'")
 
 	job4 := cfg.Jobs[4]
-	assertEqual(t, job4.Name, "preStart", "expected '%v' for job4.Name but got '%v'")
-	assertEqual(t, job4.Port, 0, "expected '%v' for job4.Port but got '%v'")
-	assertEqual(t, job4.When.Frequency, "", "expected '%v' for job4.When.Frequency but got '%v'")
-	assertEqual(t, job4.Restarts, nil, "expected '%v' for job4.Restarts but got '%v'")
+	assert.Equal(t, job4.Name, "preStart", "expected '%v' for job4.Name but got '%v'")
+	assert.Equal(t, job4.Port, 0, "expected '%v' for job4.Port but got '%v'")
+	assert.Equal(t, job4.When.Frequency, "", "expected '%v' for job4.When.Frequency but got '%v'")
+	assert.Equal(t, job4.Restarts, nil, "expected '%v' for job4.Restarts but got '%v'")
 
 	job5 := cfg.Jobs[5]
-	assertEqual(t, job5.Name, "preStop", "expected '%v' for job5.Name but got '%v'")
-	assertEqual(t, job5.Port, 0, "expected '%v' for job5.Port but got '%v'")
-	assertEqual(t, job5.When.Frequency, "", "expected '%v' for job5.When.Frequency but got '%v'")
-	assertEqual(t, job5.Restarts, nil, "expected '%v' for job5.Restarts but got '%v'")
+	assert.Equal(t, job5.Name, "preStop", "expected '%v' for job5.Name but got '%v'")
+	assert.Equal(t, job5.Port, 0, "expected '%v' for job5.Port but got '%v'")
+	assert.Equal(t, job5.When.Frequency, "", "expected '%v' for job5.When.Frequency but got '%v'")
+	assert.Equal(t, job5.Restarts, nil, "expected '%v' for job5.Restarts but got '%v'")
 
 	job6 := cfg.Jobs[6]
-	assertEqual(t, job6.Name, "postStop", "expected '%v' for job6.Name but got '%v'")
-	assertEqual(t, job6.Port, 0, "expected '%v' for job6.Port but got '%v'")
-	assertEqual(t, job6.When.Frequency, "", "expected '%v' for job6.When.Frequency but got '%v'")
-	assertEqual(t, job6.Restarts, nil, "expected '%v' for job6.Restarts but got '%v'")
+	assert.Equal(t, job6.Name, "postStop", "expected '%v' for job6.Name but got '%v'")
+	assert.Equal(t, job6.Port, 0, "expected '%v' for job6.Port but got '%v'")
+	assert.Equal(t, job6.When.Frequency, "", "expected '%v' for job6.When.Frequency but got '%v'")
+	assert.Equal(t, job6.Restarts, nil, "expected '%v' for job6.Restarts but got '%v'")
 
 	job7 := cfg.Jobs[7]
-	assertEqual(t, job7.Name, "onChange-upstreamA", "expected '%v' for job7.Name but got '%v'")
-	assertEqual(t, job7.Port, 0, "expected '%v' for job7.Port but got '%v'")
-	assertEqual(t, job7.When.Frequency, "", "expected '%v' for job7.When.Frequency but got '%v'")
-	assertEqual(t, job7.Restarts, nil, "expected '%v' for job7.Restarts but got '%v'")
+	assert.Equal(t, job7.Name, "onChange-upstreamA", "expected '%v' for job7.Name but got '%v'")
+	assert.Equal(t, job7.Port, 0, "expected '%v' for job7.Port but got '%v'")
+	assert.Equal(t, job7.When.Frequency, "", "expected '%v' for job7.When.Frequency but got '%v'")
+	assert.Equal(t, job7.Restarts, nil, "expected '%v' for job7.Restarts but got '%v'")
 
 	job8 := cfg.Jobs[8]
-	assertEqual(t, job8.Name, "onChange-upstreamB", "expected '%v' for job8.Name but got '%v'")
-	assertEqual(t, job8.Port, 0, "expected '%v' for job8.Port but got '%v'")
-	assertEqual(t, job8.When.Frequency, "", "expected '%v' for job8.When.Frequency but got '%v'")
-	assertEqual(t, job8.Restarts, nil, "expected '%v' for job8.Restarts but got '%v'")
+	assert.Equal(t, job8.Name, "onChange-upstreamB", "expected '%v' for job8.Name but got '%v'")
+	assert.Equal(t, job8.Port, 0, "expected '%v' for job8.Port but got '%v'")
+	assert.Equal(t, job8.When.Frequency, "", "expected '%v' for job8.When.Frequency but got '%v'")
+	assert.Equal(t, job8.Restarts, nil, "expected '%v' for job8.Restarts but got '%v'")
 
 	job9 := cfg.Jobs[9]
-	assertEqual(t, job9.Name, "containerpilot", "expected '%v' for job9.Name but got '%v'")
-	assertEqual(t, job9.Port, 9000, "expected '%v' for job9.Port but got '%v'")
+	assert.Equal(t, job9.Name, "containerpilot", "expected '%v' for job9.Name but got '%v'")
+	assert.Equal(t, job9.Port, 9000, "expected '%v' for job9.Port but got '%v'")
 }
 
 // telemetry.Config
 func TestValidConfigTelemetry(t *testing.T) {
 	os.Setenv("TEST", "HELLO")
-	cfg, err := LoadConfig(testJSON)
+	cfg, err := LoadConfig("./testdata/test.json5")
 	if err != nil {
 		t.Fatalf("unexpected error in LoadConfig: %v", err)
 	}
 
 	telem := cfg.Telemetry
 	sensor0 := telem.SensorConfigs[0]
-	assertEqual(t, telem.Port, 9000, "expected '%v' for telem.Port but got '%v")
-	assertEqual(t, telem.Tags, []string{"dev"}, "expected '%v' for telem.Tags but got '%v")
-	assertEqual(t, sensor0.Timeout, "5s", "expected '%v' for sensor0.Timeout but got '%v")
-	assertEqual(t, sensor0.Poll, 10, "expected '%v' for sensor0.Poll but got '%v")
+	assert.Equal(t, telem.Port, 9000, "expected '%v' for telem.Port but got '%v")
+	assert.Equal(t, telem.Tags, []string{"dev"}, "expected '%v' for telem.Tags but got '%v")
+	assert.Equal(t, sensor0.Timeout, "5s", "expected '%v' for sensor0.Timeout but got '%v")
+	assert.Equal(t, sensor0.Poll, 10, "expected '%v' for sensor0.Poll but got '%v")
 }
 
 // watches.Config
 func TestValidConfigWatches(t *testing.T) {
 	os.Setenv("TEST", "HELLO")
-	cfg, err := LoadConfig(testJSON)
+	cfg, err := LoadConfig("./testdata/test.json5")
 	if err != nil {
 		t.Fatalf("unexpected error in LoadConfig: %v", err)
 	}
@@ -127,37 +114,36 @@ func TestValidConfigWatches(t *testing.T) {
 	}
 	watch0 := cfg.Watches[0]
 	watch1 := cfg.Watches[1]
-	assertEqual(t, watch0.Name, "watch.upstreamA", "expected '%v' for Name, but got '%v'")
-	assertEqual(t, watch0.Poll, 11, "expected '%v' for Poll, but got '%v'")
-	assertEqual(t, watch0.Tag, "dev", "expected '%v' for Tag, but got '%v'")
-	assertEqual(t, watch1.Name, "watch.upstreamB", "expected '%v' for Name, but got '%v'")
-	assertEqual(t, watch1.Poll, 79, "expected '%v' for Poll, but got '%v'")
-	assertEqual(t, watch1.Tag, "", "expected '%v' for Tag, but got '%v'")
+	assert.Equal(t, watch0.Name, "watch.upstreamA", "expected '%v' for Name, but got '%v'")
+	assert.Equal(t, watch0.Poll, 11, "expected '%v' for Poll, but got '%v'")
+	assert.Equal(t, watch0.Tag, "dev", "expected '%v' for Tag, but got '%v'")
+	assert.Equal(t, watch1.Name, "watch.upstreamB", "expected '%v' for Name, but got '%v'")
+	assert.Equal(t, watch1.Poll, 79, "expected '%v' for Poll, but got '%v'")
+	assert.Equal(t, watch1.Tag, "", "expected '%v' for Tag, but got '%v'")
 
 }
 
-// checks.Config
+// control.Config
 func TestValidConfigControl(t *testing.T) {
-	cfg, err := LoadConfig(testJSON)
+	cfg, err := LoadConfig("./testdata/test.json5")
 	if err != nil {
 		t.Fatalf("unexpected error in LoadConfig: %v", err)
 	}
-
-	assertEqual(t, cfg.Control.SocketPath, "/var/run/containerpilot.socket", "expected '%v' for control.socket, but got '%v'")
+	assert.Equal(t, cfg.Control.SocketPath,
+		"/var/run/containerpilot.socket",
+		"expected '%v' for control.socket, but got '%v'")
 }
 
 func TestCustomConfigControl(t *testing.T) {
 	var testJSONWithSocket = `{
-	"control": {
-		"socket": "/var/run/cp3-test.sock"
-	},
-	"consul": "consul:8500"
-}`
+	"control": {"socket": "/var/run/cp3-test.sock"},
+	"consul": "consul:8500"}`
 
-	cfg, err := LoadConfig(testJSONWithSocket)
+	cfg, err := newConfig([]byte(testJSONWithSocket))
 	if err != nil {
 		t.Fatalf("unexpected error in LoadConfig: %v", err)
 	}
-
-	assertEqual(t, cfg.Control.SocketPath, "/var/run/cp3-test.sock", "expected '%v' for control.socket, but got '%v'")
+	assert.Equal(t, cfg.Control.SocketPath,
+		"/var/run/cp3-test.sock",
+		"expected '%v' for control.socket, but got '%v'")
 }

--- a/config/template_test.go
+++ b/config/template_test.go
@@ -4,57 +4,76 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"testing"
 
 	// need to import this so that we have a registered backend
 	_ "github.com/joyent/containerpilot/discovery/consul"
+	"github.com/joyent/containerpilot/tests/assert"
 )
 
 func TestParseEnvironment(t *testing.T) {
-	validateParseEnvironment(t, "Empty Environment", []string{}, Environment{})
-	validateParseEnvironment(t, "Example Environment", []string{
+	parsed := parseEnvironment([]string{})
+	assert.Equal(t, parsed, Environment{}, "expected environment '%v' got '%v'")
+
+	parsed = parseEnvironment([]string{
 		"VAR1=test",
 		"VAR2=test2",
-	}, Environment{
+	})
+	assert.Equal(t, parsed, Environment{
 		"VAR1": "test",
 		"VAR2": "test2",
-	})
+	}, "expected environment '%v' got '%v'")
 }
 
 func TestTemplate(t *testing.T) {
 	env := parseEnvironment([]string{"NAME=Template", "USER=pilot", "PARTS=a:b:c"})
-	validateTemplate(t, "One var", `Hello, {{.NAME}}!`, env, "Hello, Template!")
-	validateTemplate(t, "Var undefined", `Hello, {{.NONAME}}!`, env, "Hello, !")
-	validateTemplate(t, "Default", `Hello, {{.NONAME | default "World" }}!`, env, "Hello, World!")
-	validateTemplate(t, "Default", `Hello, {{.NONAME | default 100 }}!`, env, "Hello, 100!")
-	validateTemplate(t, "Default", `Hello, {{.NONAME | default 10.1 }}!`, env, "Hello, 10.1!")
-	validateTemplate(t, "Split and Join", `Hello, {{.PARTS | split ":" | join "." }}!`, env, "Hello, a.b.c!")
-	validateTemplate(t, "Replace All", `Hello, {{.NAME | replaceAll "e" "_" }}!`, env, "Hello, T_mplat_!")
-	validateTemplate(t, "Regex Replace All", `Hello, {{.NAME | regexReplaceAll "[epa]+" "_" }}!`, env, "Hello, T_m_l_t_!")
+
+	testTemplate := func(name string, template string, expected string) {
+		tmpl, err := NewTemplate([]byte(template))
+		if err != nil {
+			t.Fatalf("%s - error parsing template: %s", name, err)
+		}
+		tmpl.Env = env
+		res, err2 := tmpl.Execute()
+		if err2 != nil {
+			t.Fatalf("%s - error executing template: %s", name, err2)
+		}
+		strRes := string(res)
+		if strRes != expected {
+			t.Fatalf("%s - expected %s but got: %s", name, expected, strRes)
+		}
+	}
+
+	testTemplate("One var", `Hello, {{.NAME}}!`, "Hello, Template!")
+	testTemplate("Var undefined", `Hello, {{.NONAME}}!`, "Hello, !")
+	testTemplate("Default", `Hello, {{.NONAME | default "World" }}!`, "Hello, World!")
+	testTemplate("Default", `Hello, {{.NONAME | default 100 }}!`, "Hello, 100!")
+	testTemplate("Default", `Hello, {{.NONAME | default 10.1 }}!`, "Hello, 10.1!")
+	testTemplate("Split and Join",
+		`Hello, {{.PARTS | split ":" | join "." }}!`, "Hello, a.b.c!")
+	testTemplate("Replace All",
+		`Hello, {{.NAME | replaceAll "e" "_" }}!`, "Hello, T_mplat_!")
+	testTemplate("Regex Replace All",
+		`Hello, {{.NAME | regexReplaceAll "[epa]+" "_" }}!`, "Hello, T_m_l_t_!")
 }
 
-func TestInvalidRenderConfigFile(t *testing.T) {
-	testRenderExpectError(t, "file:///xxxx", "-",
+func TestInvalidRenderConfigFileMissing(t *testing.T) {
+	err := RenderConfig("/xxxx", "-")
+	assert.Error(t, err,
 		"could not read config file: open /xxxx: no such file or directory")
 }
 
-func TestInvalidRenderFileConfig(t *testing.T) {
-	var testJSON = `{"consul": "consul:8500"}`
-	testRenderExpectError(t, testJSON, "file:///a/b/c/d/e/f.json",
-		"could not write config file: open /a/b/c/d/e/f.json: no such file or directory")
+func TestInvalidRenderConfigOutputMissing(t *testing.T) {
+	err := RenderConfig("./testdata/test.json5", "./xxxx/xxxx")
+	assert.Error(t, err,
+		"could not write config file: open ./xxxx/xxxx: no such file or directory")
 }
 
 func TestRenderConfigFileStdout(t *testing.T) {
 
-	var testJSON = `{
-	"consul": "consul:8500",
-	watches: [{"name": "upstreamA", "interval": 11}]}`
-
 	// Render to file
 	defer os.Remove("testJSON.json")
-	if err := RenderConfig(testJSON, "file://testJSON.json"); err != nil {
+	if err := RenderConfig("./testdata/test.json5", "testJSON.json"); err != nil {
 		t.Fatalf("expected no error from renderConfigTemplate but got: %v", err)
 	}
 	if exists, err := fileExists("testJSON.json"); !exists || err != nil {
@@ -66,7 +85,7 @@ func TestRenderConfigFileStdout(t *testing.T) {
 	temp, _ := os.Create(fname)
 	old := os.Stdout
 	os.Stdout = temp
-	if err := RenderConfig(testJSON, "-"); err != nil {
+	if err := RenderConfig("./testdata/test.json5", "-"); err != nil {
 		t.Fatalf("expected no error from renderConfigTemplate but got: %v", err)
 	}
 	temp.Close()
@@ -86,8 +105,8 @@ func TestRenderedConfigIsParseable(t *testing.T) {
 	watches: [{"name": "upstreamA{{.TESTRENDERCONFIGISPARSEABLE}}", "interval": 11}]}`
 
 	os.Setenv("TESTRENDERCONFIGISPARSEABLE", "-ok")
-	template, _ := renderConfigTemplate(testJSON)
-	config, err := LoadConfig(string(template))
+	template, _ := renderConfigTemplate([]byte(testJSON))
+	config, err := newConfig(template)
 	if err != nil {
 		t.Fatalf("unexpected error in LoadConfig: %v", err)
 	}
@@ -97,36 +116,8 @@ func TestRenderedConfigIsParseable(t *testing.T) {
 	}
 }
 
-// Helper Functions
-
-func validateParseEnvironment(t *testing.T, message string, environ []string, expected Environment) {
-	if parsed := parseEnvironment(environ); !reflect.DeepEqual(expected, parsed) {
-		t.Fatalf("%s; Expected %s but got %s", message, expected, parsed)
-	}
-}
-
-func validateTemplate(t *testing.T, name string, template string, env Environment, expected string) {
-	tmpl, err := NewTemplate([]byte(template))
-	if err != nil {
-		t.Fatalf("%s - Error parsing template: %s", name, err)
-	}
-	tmpl.Env = env
-	res, err2 := tmpl.Execute()
-	if err2 != nil {
-		t.Fatalf("%s - Error executing template: %s", name, err2)
-	}
-	strRes := string(res)
-	if strRes != expected {
-		t.Fatalf("%s - Expected %s but got: %s", name, expected, strRes)
-	}
-}
-
-func testRenderExpectError(t *testing.T, testJSON, render, expected string) {
-	err := RenderConfig(testJSON, render)
-	if err == nil || !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected %s but got %s", expected, err)
-	}
-}
+// ----------------------------------------------------
+// test helpers
 
 func fileExists(path string) (bool, error) {
 	_, err := os.Stat(path)

--- a/core/app.go
+++ b/core/app.go
@@ -36,7 +36,7 @@ type App struct {
 	Watches       []*watches.Watch
 	Telemetry     *telemetry.Telemetry
 	StopTimeout   int
-	maintModeLock *sync.RWMutex // TODO v3: probably want to move this to Service.Status
+	maintModeLock *sync.RWMutex
 	signalLock    *sync.RWMutex
 	paused        bool
 	ConfigFlag    string
@@ -61,11 +61,11 @@ func LoadApp() (*App, error) {
 
 	if !flag.Parsed() {
 		flag.StringVar(&configFlag, "config", "",
-			"JSON config or file:// path to JSON config file.")
+			"file path to JSON5 configuration file.")
 		flag.BoolVar(&templateFlag, "template", false,
 			"Render template and quit. (default: false)")
 		flag.StringVar(&renderFlag, "out", "-",
-			"-(default) for stdout or file:// path where to save rendered JSON config file.")
+			"-(default) for stdout or file path where to save rendered JSON config file.")
 		flag.BoolVar(&versionFlag, "version", false, "Show version identifier and quit.")
 		flag.Parse()
 	}

--- a/integration_tests/fixtures/app/Dockerfile
+++ b/integration_tests/fixtures/app/Dockerfile
@@ -14,7 +14,7 @@ COPY reload-app.sh /reload-app.sh
 COPY sensor.sh /sensor.sh
 COPY task.sh /task.sh
 
-ENV CONTAINERPILOT=file:///etc/containerpilot.json5
+ENV CONTAINERPILOT=/etc/containerpilot.json5
 
 # default port, allows us to override in docker-compose and also test
 # env var interpolation in the command args

--- a/integration_tests/fixtures/nginx/Dockerfile
+++ b/integration_tests/fixtures/nginx/Dockerfile
@@ -20,6 +20,6 @@ COPY etc /etc
 EXPOSE 80
 
 # by default use nginx-with-consul.json, allows for override in docker-compose
-ENV CONTAINERPILOT=file:///etc/nginx-with-consul.json5
+ENV CONTAINERPILOT=/etc/nginx-with-consul.json5
 
 ENTRYPOINT [ "/bin/containerpilot" ]

--- a/integration_tests/tests/test_coprocess/docker-compose.yml
+++ b/integration_tests/tests/test_coprocess/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       # needs to be in the container already or we'll potentially
       # error when we try to rewrite it; update in the future
       # with an env var change to the args instead
-      - CONTAINERPILOT=file:///etc/containerpilot-with-coprocess.json5
+      - CONTAINERPILOT=/etc/containerpilot-with-coprocess.json5
     volumes:
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
       - './coprocess.sh:/bin/coprocess.sh'

--- a/integration_tests/tests/test_envvars/run.sh
+++ b/integration_tests/tests/test_envvars/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
 
-# run and make sure we get the env var out
-docker-compose run test | grep CONTAINERPILOT_TESTENVVAR_IP
+# run and make sure we get the env var out but print
+# the full result if it fails, for debugging
+result=$(docker-compose run test)
+echo "$result" | grep CONTAINERPILOT_TESTENVVAR_IP || (echo "$result" && exit 1)


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/236 (not everything in that issue yet) and per [RFD86](https://github.com/joyent/rfd/blob/master/rfd/0086/config.md):

> The CONTAINERPILOT environment variable and -config command line flag will no longer support passing in the contents of the configuration file as a string. Instead they will now indicate the directory location for configuration files, with a default value of /etc/containerpilot.d (note that we're removing the file:// prefix as well).

This PR does not yet include having a directory location for configuration files but lays some of the groundwork for this to happen.

cc @misterbisson @geek @jasonpincin @cheapRoc 