### PR TITLE
provide 'when.once' and 'when.each' instead of 'when.event'

### DIFF
--- a/config/testdata/test.json5
+++ b/config/testdata/test.json5
@@ -11,7 +11,7 @@
       exec: "/bin/serviceA",
       when: {
         source: "preStart",
-        event: "exitSuccess"
+        once: "exitSuccess"
       },
       health: {
         exec: "/bin/to/healthcheck/for/service/A.sh",
@@ -53,7 +53,7 @@
       exec: ["/bin/to/preStop.sh","arg1","arg2"],
       when: {
         source: "serviceA",
-        event: "stopping"
+        once: "stopping"
       }
     },
     {
@@ -61,7 +61,7 @@
       exec: ["/bin/to/postStop.sh"],
       when: {
         source: "serviceA",
-        event: "stopped"
+        once: "stopped"
       }
     },
     {
@@ -69,7 +69,7 @@
       exec: ["/bin/onChangeA.sh"],
       when: {
         source: "watch.upstreamA",
-        event: "changed"
+        each: "changed"
       }
     },
     {
@@ -77,7 +77,7 @@
       exec: ["/bin/onChangeB.sh"],
       when: {
         source: "watch.upstreamB",
-        event: "healthy"
+        each: "healthy"
       }
     }
   ],

--- a/integration_tests/fixtures/app/containerpilot.json5
+++ b/integration_tests/fixtures/app/containerpilot.json5
@@ -10,7 +10,7 @@
       port: 8000,
       when: {
         source: "preStart",
-        event: "exitSuccess"
+        once: "exitSuccess"
       },
       exec: [
         "/usr/local/bin/node",
@@ -30,7 +30,7 @@
       name: "reload-for-nginx",
       when: {
         source: "watch.nginx",
-        event: "changed"
+        each: "changed"
       },
       exec: "/reload-app.sh"
     },
@@ -38,7 +38,7 @@
       name: "reload-for-app",
       when: {
         source: "watch.app",
-        event: "changed"
+        each: "changed"
       },
       exec: "/reload-app.sh"
     }

--- a/integration_tests/fixtures/nginx/etc/nginx-with-consul.json5
+++ b/integration_tests/fixtures/nginx/etc/nginx-with-consul.json5
@@ -11,7 +11,7 @@
       interfaces: ["eth0"],
       when: {
         source: "preStart",
-        event: "exitSuccess",
+        once: "exitSuccess",
       },
       exec: "nginx",
       health: {
@@ -30,7 +30,7 @@
       name: "onChange",
       when: {
         source: "watch.app",
-        event: "changed"
+        each: "changed"
       },
       exec: [
           "consul-template", "-once", "-consul", "consul:8500", "-template",

--- a/integration_tests/tests/test_discovery_consul/containerpilot.json5
+++ b/integration_tests/tests/test_discovery_consul/containerpilot.json5
@@ -10,7 +10,7 @@
       port: 8000,
       when: {
         source: "preStart",
-        event: "exitSuccess"
+        once: "exitSuccess"
       },
       exec: [
         "/usr/local/bin/node",
@@ -30,7 +30,7 @@
       name: "reload-for-nginx",
       when: {
         source: "watch.nginx",
-        event: "changed"
+        each: "changed"
       },
       exec: "/reload-app.sh"
     },
@@ -38,7 +38,7 @@
       name: "reload-for-app",
       when: {
         source: "watch.app",
-        event: "changed"
+        each: "changed"
       },
       exec: "/reload-app.sh"
     }

--- a/integration_tests/tests/test_tasks/containerpilot.json5
+++ b/integration_tests/tests/test_tasks/containerpilot.json5
@@ -44,7 +44,7 @@
       port: 8000,
       when: {
         source: "preStart",
-        event: "exitSuccess"
+        once: "exitSuccess"
       },
       exec: [
         "/usr/local/bin/node",

--- a/jobs/config_test.go
+++ b/jobs/config_test.go
@@ -191,14 +191,14 @@ func TestJobConfigSmokeTest(t *testing.T) {
 	job5 := jobs[5]
 	assert.Equal(t, job5.Name, "preStop", "expected '%v' for job5.Name but got '%v'")
 	assert.Equal(t, job5.Port, 0, "expected '%v' for job5.Port but got '%v'")
-	assert.Equal(t, job5.When, &WhenConfig{Source: "serviceA", Event: "stopping"},
+	assert.Equal(t, job5.When, &WhenConfig{Source: "serviceA", Once: "stopping"},
 		"expected '%v' for job5.When but got '%v'")
 	assert.Equal(t, job5.Restarts, nil, "expected '%v' for job5.Restarts but got '%v'")
 
 	job6 := jobs[6]
 	assert.Equal(t, job6.Name, "postStop", "expected '%v' for job6.Name but got '%v'")
 	assert.Equal(t, job6.Port, 0, "expected '%v' for job6.Port but got '%v'")
-	assert.Equal(t, job6.When, &WhenConfig{Source: "serviceA", Event: "stopped"},
+	assert.Equal(t, job6.When, &WhenConfig{Source: "serviceA", Once: "stopped"},
 		"expected '%v' for job6.When but got '%v'")
 	assert.Equal(t, job6.Restarts, nil, "expected '%v' for job6.Restarts but got '%v'")
 }

--- a/jobs/testdata/TestJobConfigServiceWithPreStart.json5
+++ b/jobs/testdata/TestJobConfigServiceWithPreStart.json5
@@ -6,7 +6,7 @@
     exec: "/bin/serviceA.sh",
     when: {
       source: "preStart",
-      event: "exitSuccess",
+      once: "exitSuccess",
     },
     health: {
       exec: "/bin/healthCheckA.sh A1 A2",
@@ -23,7 +23,7 @@
     name: "preStop",
     when: {
       source: "serviceA",
-      event: "stopping"
+      once: "stopping"
     },
     exec: ["/bin/to/preStop.sh","arg1","arg2"]
   },
@@ -31,7 +31,7 @@
     name: "postStop",
     when: {
       source: "serviceA",
-      event: "stopped"
+      once: "stopped"
     },
     exec: ["/bin/to/postStop.sh"]
   }

--- a/jobs/testdata/TestJobConfigServiceWithStopping.json5
+++ b/jobs/testdata/TestJobConfigServiceWithStopping.json5
@@ -5,7 +5,7 @@
     exec: "/bin/serviceA.sh",
     when: {
       source: "preStart",
-      event: "exitSuccess",
+      once: "exitSuccess",
     },
     health: {
       interval: 1,
@@ -21,7 +21,7 @@
     name: "preStop",
     when: {
       source: "serviceA",
-      event: "stopping"
+      once: "stopping"
     },
     exec: ["/bin/to/preStop.sh","arg1","arg2"]
   },
@@ -29,7 +29,7 @@
     name: "postStop",
     when: {
       source: "serviceA",
-      event: "stopped"
+      once: "stopped"
     },
     exec: ["/bin/to/postStop.sh"]
   }

--- a/jobs/testdata/TestJobConfigSmokeTest.json5
+++ b/jobs/testdata/TestJobConfigSmokeTest.json5
@@ -6,7 +6,7 @@
     exec: "/bin/serviceA",
     when: {
       source: "preStart",
-      event: "exitSuccess",
+      once: "exitSuccess",
     },
     health: {
       exec: "/bin/to/healthcheck/for/service/A.sh",
@@ -47,7 +47,7 @@
     name: "preStop",
     when: {
       source: "serviceA",
-      event: "stopping"
+      once: "stopping"
     },
     exec: ["/bin/to/preStop.sh","arg1","arg2"]
   },
@@ -55,7 +55,7 @@
     name: "postStop",
     when: {
       source: "serviceA",
-      event: "stopped"
+      once: "stopped"
     },
     exec: ["/bin/to/postStop.sh"]
   }


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/323, implementing the design fix discussed in https://github.com/joyent/rfd/pull/32#issuecomment-294011192.

The result is that a `when` configuration block for a job can say either `when.once` or `when.each` to determine if it's going to respond only one time or an unlimited number of times to its starting event. If the `when` block is omitted, it's treated as "once on global startup." This configuration option is separate from `restarts`, which says how many times it'll restart _immediately_ after an exit, rather than on the `when` event source. The `restarts` block is intentionally not inside the `when` block so that the `when` block can be elided without confusion.

This will look like the following:

```json5
// application waits for preStart one-time, but then will restart if it stops
{
  exec: "/bin/myapp",
  restarts: "unlimited",
  when: {
    source: "preStart",
    once: "exitSuccess"
  }
}
```

```json5
{
  // onChange handler fires every time 'myapp' changes
  exec: "/bin/onChange.sh",
  when: {
    source: "watch.myapp",
    each: "changed"
  }
}
```

```json5
{
  // myTask runs an unlimited number of times, every 20s
  exec: "/bin/my/task.sh",
  restarts: "unlimited",
  when: {
    interval: "20s"
  }
}
```

cc @jasonpincin @misterbisson @geek @cheapRoc 