### PR TITLE
fix child process exit handling (v3)

### DIFF
--- a/commands/reaper.go
+++ b/commands/reaper.go
@@ -1,0 +1,32 @@
+package commands
+
+import "syscall"
+
+// reapChildren cleans up zombies for a particular process group.
+// all our children have unique pgids so we can rely on this to reap
+// zombies arising from any children without interfering with other
+// children.
+func reapChildren(pgid int) {
+	go func() {
+		for {
+			// we need to allow for the possibility that multiple child
+			// processes have terminated while one is already being reaped,
+			// so we keep trying until there's nothing left
+			var wstatus syscall.WaitStatus
+			pid, err := syscall.Wait4(-pgid, &wstatus, syscall.WNOHANG, nil)
+			switch err {
+			case nil:
+				if pid > 0 {
+					continue
+				}
+				return
+			case syscall.ECHILD:
+				return
+			case syscall.EINTR:
+				continue
+			default:
+				return
+			}
+		}
+	}()
+}

--- a/core/app.go
+++ b/core/app.go
@@ -147,9 +147,6 @@ func getEnvVarNameFromService(service string) string {
 // Run starts the application and blocks until finished
 func (a *App) Run() {
 	// Set up handlers for polling and to accept signal interrupts
-	if 1 == os.Getpid() {
-		reapChildren()
-	}
 	for {
 		a.ControlServer.Serve()
 		a.Bus = events.NewEventBus()

--- a/core/signals.go
+++ b/core/signals.go
@@ -23,28 +23,3 @@ func (a *App) handleSignals() {
 		}
 	}()
 }
-
-// ReapChildren cleans up zombies
-// - on SIGCHLD send wait4() (ref http://linux.die.net/man/2/waitpid)
-func reapChildren() {
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGCHLD)
-	go func() {
-		// wait for signals on the channel until it closes
-		for _ = range sig {
-			for {
-				// only 1 SIGCHLD can be handled at a time from the channel,
-				// so we need to allow for the possibility that multiple child
-				// processes have terminated while one is already being reaped.
-				var wstatus syscall.WaitStatus
-				if _, err := syscall.Wait4(-1, &wstatus,
-					syscall.WNOHANG|syscall.WUNTRACED|syscall.WCONTINUED,
-					nil); err == syscall.EINTR {
-					continue
-				}
-				// return to the outer loop and wait for another signal
-				break
-			}
-		}
-	}()
-}

--- a/integration_tests/fixtures/zombie_maker/Dockerfile
+++ b/integration_tests/fixtures/zombie_maker/Dockerfile
@@ -6,4 +6,4 @@ ADD app.json5 /app.json5
 ADD zombie.sh /zombie.sh
 RUN chmod 755 /zombie.sh
 
-ENTRYPOINT ["/bin/containerpilot", "-config=file:///app.json5"]
+ENTRYPOINT ["/bin/containerpilot", "-config=/app.json5"]


### PR DESCRIPTION
For #330 and #331 in v3 only. (v2 will be under separate PR.)

There's a bunch of logic we don't need to mess with here because we no longer care about the exact exit code to return back to the container runtime now that we're not "shimming" an application.