### PR TITLE
fix flaky integration test timer

### DIFF
--- a/integration_tests/fixtures/app/reload-containerpilot.sh
+++ b/integration_tests/fixtures/app/reload-containerpilot.sh
@@ -3,7 +3,7 @@ set -e
 
 single() {
     echo -e "POST /v3/reload HTTP/1.1\r\nHost: control\r\n\r\n" | \
-        nc -U /var/run/containerpilot.socket
+        nc -U /var/run/containerpilot.socket > /dev/null 2>&1
     exit 0
 }
 

--- a/integration_tests/tests/test_config_reload/run.sh
+++ b/integration_tests/tests/test_config_reload/run.sh
@@ -21,8 +21,11 @@ fi
 
 # slam reload endpoint to verify we don't deadlock
 docker exec "$APP_ID" /reload-containerpilot.sh multi
-sleep 10
-docker exec "$APP_ID" /reload-containerpilot.sh single
+for _ in $(seq 0 20)
+do
+    # might take a little while for the control server to settle
+    docker exec "$APP_ID" /reload-containerpilot.sh single && break
+done
 if [[ $? -ne 0 ]]; then
     echo '--------------------'
     echo 'multi reload failed'


### PR DESCRIPTION
The config reload test is a little flaky because we have a fixed timer on there for it to become healthy again. I'm fairly certain this is just a matter of control server taking a few moments to recover, but it doesn't _always_ require a long period of time so this returns early once it's ready.

cc @cheapRoc 