### PR TITLE
remove PID from logging to avoid race on process exit

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -171,7 +171,7 @@ func (c *Command) setUpCmd() {
 func (c *Command) Kill() error {
 	log.Debugf("%s.kill", c.Name)
 	if c.Cmd != nil && c.Cmd.Process != nil {
-		log.Warnf("killing command at pid: %d", c.Cmd.Process.Pid)
+		log.Warnf("killing command for %s", c.Name)
 		return c.Cmd.Process.Kill()
 	}
 	return nil
@@ -212,7 +212,7 @@ func (c *Command) waitForTimeout() error {
 		// we'll deadlock
 		defer func() { quit <- 0 }()
 	}
-	log.Debugf("%s.run waiting for PID %d: ", c.Name, cmd.Process.Pid)
+	log.Debugf("%s.run waiting", c.Name)
 
 	defer reapChildren(c.Cmd.SysProcAttr.Pgid)
 	err := c.Cmd.Wait()

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -180,7 +180,6 @@ func (c *Command) Kill() error {
 func (c *Command) waitForTimeout() error {
 
 	quit := make(chan int)
-	cmd := c.Cmd
 
 	// for commands that don't have a timeout we just block forever;
 	// this is required for backwards compat.


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/351 in v2.

The NPE is getting hit when the process exits before we wait for it. If we check nil before writing the log we'll have a [TOCTOU](https://en.wikipedia.org/wiki/Time_of_check_to_time_of_use) bug, so instead I'm just dropping the field from the log line.

There is one other place where we can potentially hit this which is in setting the environment variable for the PID in [`RunAndWait`](https://github.com/joyent/containerpilot/blob/3372754eec6805b0d6c417b96404526ceff7849d/commands/commands.go#L92). But `RunAndWait` is only called for the long-running "main" processes in v2, where we won't in practice see the race condition. Dropping the env var feature would break backwards compatibility, so it's my judgement we should leave the bug in for that case knowing it's not going to be hit in practice. We'll drop the feature in the v3 code base.