### PR TITLE
Add subcommands and client for controlling ContainerPilot

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,12 +1,11 @@
 package client
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 type HTTPClient struct {
@@ -36,21 +35,69 @@ func NewHTTPClient(socketPath string) (*HTTPClient, error) {
 	return client, nil
 }
 
-func (c HTTPClient) Reload() error {
-	resp, err := c.Post("http://control/v3/reload", "application/json", nil)
+func (self HTTPClient) Reload() (*http.Response, error) {
+	resp, err := self.Post("http://control/v3/reload", "application/json", nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
-		return errors.New(mesg)
+		return nil, errors.New(mesg)
 	}
 
-	return nil
+	return resp, nil
 }
 
-// func (c Client) SetMaintenance()
-// func (c Client) PutEnv()
-// func (c Client) PutMetric()
+func (self HTTPClient) SetMaintenance(isEnabled bool) (*http.Response, error) {
+	var flag string
+	if isEnabled {
+		flag = "enable"
+	} else {
+		flag = "disable"
+	}
+
+	resp, err := self.Post("http://control/v3/maintenance/" + flag, "application/json", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
+		return nil, errors.New(mesg)
+	}
+
+	return resp, nil
+}
+
+func (self HTTPClient) PutEnv(body string) (*http.Response, error) {
+	resp, err := self.Post("http://control/v3/env", "application/json", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
+		return nil, errors.New(mesg)
+	}
+
+	return resp, nil
+}
+
+func (self HTTPClient) PutMetric(body string) (*http.Response, error) {
+	resp, err := self.Post("http://control/v3/metric", "application/json", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
+		return nil, errors.New(mesg)
+	}
+
+	return resp, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -73,7 +73,7 @@ func (self HTTPClient) SetMaintenance(isEnabled bool) (*http.Response, error) {
 }
 
 func (self HTTPClient) PutEnv(body string) (*http.Response, error) {
-	resp, err := self.Post("http://control/v3/env", "application/json",
+	resp, err := self.Post("http://control/v3/environ", "application/json",
 		strings.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -40,24 +40,18 @@ func NewHTTPClient(socketPath string) (*HTTPClient, error) {
 }
 
 // Reload makes a request to the reload endpoint of a ContainerPilot process.
-func (c HTTPClient) Reload() (*http.Response, error) {
+func (c HTTPClient) Reload() error {
 	resp, err := c.Post("http://control/v3/reload", "application/json", nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
-		return nil, errors.New(mesg)
-	}
-
-	return resp, nil
+	return nil
 }
 
 // SetMaintenance makes a request to either the enable or disable maintenance
 // endpoint of a ContainerPilot process.
-func (c HTTPClient) SetMaintenance(isEnabled bool) (*http.Response, error) {
+func (c HTTPClient) SetMaintenance(isEnabled bool) error {
 	flag := "disable"
 	if isEnabled {
 		flag = "enable"
@@ -65,50 +59,40 @@ func (c HTTPClient) SetMaintenance(isEnabled bool) (*http.Response, error) {
 
 	resp, err := c.Post("http://control/v3/maintenance/"+flag, "application/json", nil)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
-		return nil, errors.New(mesg)
-	}
-
-	return resp, nil
+	return nil
 }
 
 // PutEnv makes a request to the environ endpoint of a ContainerPilot process
 // for setting environ variable pairs.
-func (c HTTPClient) PutEnv(body string) (*http.Response, error) {
+func (c HTTPClient) PutEnv(body string) error {
 	resp, err := c.Post("http://control/v3/environ", "application/json",
 		strings.NewReader(body))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
-		return nil, errors.New(mesg)
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return fmt.Errorf("unprocessable entity received by control server")
 	}
-
-	return resp, nil
+	return nil
 }
 
 // PutMetric makes a request to the metric endpoint of a ContainerPilot process
 // for setting custom metrics.
-func (c HTTPClient) PutMetric(body string) (*http.Response, error) {
+func (c HTTPClient) PutMetric(body string) error {
 	resp, err := c.Post("http://control/v3/metric", "application/json",
 		strings.NewReader(body))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
-		return nil, errors.New(mesg)
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return fmt.Errorf("unprocessable entity received by control server")
 	}
-
-	return resp, nil
+	return nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -1,16 +1,16 @@
 package client
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 )
 
 type HTTPClient struct {
 	http.Client
-	socketPath   string
+	socketPath  string
 }
 
 var SocketType = "unix"
@@ -73,7 +73,8 @@ func (self HTTPClient) SetMaintenance(isEnabled bool) (*http.Response, error) {
 }
 
 func (self HTTPClient) PutEnv(body string) (*http.Response, error) {
-	resp, err := self.Post("http://control/v3/env", "application/json", body)
+	resp, err := self.Post("http://control/v3/env", "application/json",
+		strings.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +89,8 @@ func (self HTTPClient) PutEnv(body string) (*http.Response, error) {
 }
 
 func (self HTTPClient) PutMetric(body string) (*http.Response, error) {
-	resp, err := self.Post("http://control/v3/metric", "application/json", body)
+	resp, err := self.Post("http://control/v3/metric", "application/json",
+		strings.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+type HTTPClient struct {
+	http.Client
+	socketPath   string
+}
+
+var SocketType = "unix"
+
+func socketDialer(socketPath string) func(string, string) (net.Conn, error) {
+	return func(_, _ string) (net.Conn, error) {
+		return net.Dial(SocketType, socketPath)
+	}
+}
+
+func NewHTTPClient(socketPath string) (*HTTPClient, error) {
+	if socketPath == "" {
+		err := errors.New("control server not loading due to missing config")
+		return nil, err
+	}
+
+	client := &HTTPClient{}
+	client.Transport = &http.Transport{
+		Dial: socketDialer(socketPath),
+	}
+
+	return client, nil
+}
+
+func (c HTTPClient) Reload() error {
+	resp, err := c.Post("http://control/v3/reload", "application/json", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		mesg := fmt.Sprintf("expected 200 but got %v\n%+v", resp.StatusCode, resp)
+		return errors.New(mesg)
+	}
+
+	return nil
+}
+
+// func (c Client) SetMaintenance()
+// func (c Client) PutEnv()
+// func (c Client) PutMetric()

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ import (
 
 type HTTPClient struct {
 	http.Client
-	socketPath  string
+	socketPath string
 }
 
 var SocketType = "unix"
@@ -58,7 +58,7 @@ func (self HTTPClient) SetMaintenance(isEnabled bool) (*http.Response, error) {
 		flag = "disable"
 	}
 
-	resp, err := self.Post("http://control/v3/maintenance/" + flag, "application/json", nil)
+	resp, err := self.Post("http://control/v3/maintenance/"+flag, "application/json", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,13 +1,25 @@
 package client
 
-// func TestClientReload() {
-// }
+import (
+	// "fmt"
+	"testing"
 
-// func TestClientSetMaintenance() {
-// }
+	"github.com/joyent/containerpilot/tests"
+	"github.com/joyent/containerpilot/tests/assert"
+)
 
-// func TestClientPutEnv() {
-// }
+func TestClientReload(t *testing.T) {
+	t.Skip("Not implemented")
+}
 
-// func TestClientPutMetric() {
-// }
+func TestClientSetMaintenance(t *testing.T) {
+	t.Skip("Not implemented")
+}
+
+func TestClientPutEnv(t *testing.T) {
+	t.Skip("Not implemented")
+}
+
+func TestClientPutMetric(t *testing.T) {
+	t.Skip("Not implemented")
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,13 @@
+package client
+
+// func TestClientReload() {
+// }
+
+// func TestClientSetMaintenance() {
+// }
+
+// func TestClientPutEnv() {
+// }
+
+// func TestClientPutMetric() {
+// }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,11 +1,7 @@
 package client
 
 import (
-	// "fmt"
 	"testing"
-
-	"github.com/joyent/containerpilot/tests"
-	"github.com/joyent/containerpilot/tests/assert"
 )
 
 func TestClientReload(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,18 +4,38 @@ import (
 	"testing"
 )
 
+func TestNewHTTPClient(t *testing.T) {
+	t.Skip("Not implemented")
+
+	// Test NewHTTPClient. Test missing unix socket file
+	// Test passing in nil socketPath....(? do we even need this ?)
+}
+
 func TestClientReload(t *testing.T) {
 	t.Skip("Not implemented")
+
+	// Bring up an HTTP server on a unix socket file
+	// Setup route to our endpoint
+	// Do not include proper endpoint
+	// Return status 200
+	// Return status 500
 }
 
 func TestClientSetMaintenance(t *testing.T) {
 	t.Skip("Not implemented")
+
+	// Test bool input switches endpoint to enable
+	// Test bool input switches endpoint to disable
 }
 
 func TestClientPutEnv(t *testing.T) {
 	t.Skip("Not implemented")
+
+	// Test string input passes through Post call
 }
 
 func TestClientPutMetric(t *testing.T) {
 	t.Skip("Not implemented")
+
+	// Test string input passes through Post call
 }

--- a/core/app.go
+++ b/core/app.go
@@ -97,10 +97,20 @@ func LoadApp() (*App, error) {
 	}
 
 	if reloadFlag {
-		if err := subcommands.SendReload(configFlag); err != nil {
+		cmd, err := subcommands.Init(configFlag)
+		if err != nil {
+			fmt.Println("Reload: Failed to load subcommand:", err)
+			os.Exit(2)
+		}
+		if err := cmd.SendReload(); err != nil {
 			fmt.Println("Reload: Failed to reload control socket:", err)
 			os.Exit(2)
 		}
+		os.Exit(0)
+	}
+
+	if putEnvFlags != "" {
+		fmt.Printf("putEnvFlags: %v", putEnvFlags)
 		os.Exit(0)
 	}
 

--- a/core/app.go
+++ b/core/app.go
@@ -70,22 +70,22 @@ func LoadApp() (*App, error) {
 			"Render template and quit. (default: false)")
 
 		flag.BoolVar(&reloadFlag, "reload", false,
-			"reload a ContainerPilot process through its control socket.")
+			"Reload a ContainerPilot process through its control socket.")
 
 		flag.StringVar(&configFlag, "config", "",
-			"file path to JSON5 configuration file.")
+			"File path to JSON5 configuration file.")
 
 		flag.StringVar(&renderFlag, "out", "-",
 			"-(default) for stdout or file path where to save rendered JSON config file.")
 
 		flag.StringVar(&maintFlag, "maintenance", "",
-			"enable/disable maintanence mode through a ContainerPilot process control socket.")
+			"Enable/disable maintanence mode through a ContainerPilot process control socket.")
 
 		flag.Var(&putMetricFlags, "putmetric",
-			"update metrics of a ContainerPilot process through its control socket.")
+			"Update metrics of a ContainerPilot process through its control socket.")
 
 		flag.Var(&putEnvFlags, "putenv",
-			"update environ of a ContainerPilot process through its control socket.")
+			"Update environ of a ContainerPilot process through its control socket.")
 
 		flag.Parse()
 	}

--- a/core/app.go
+++ b/core/app.go
@@ -107,11 +107,7 @@ func LoadApp() (*App, error) {
 		os.Exit(0)
 	}
 
-	cmd, err := subcommands.Init(configFlag)
-	if err != nil {
-		fmt.Println("Subcommands: failed to init config:", err)
-		os.Exit(2)
-	}
+	cmd, _ := subcommands.Init(configFlag)
 
 	if reloadFlag {
 		if err := cmd.SendReload(); err != nil {

--- a/core/app.go
+++ b/core/app.go
@@ -54,6 +54,9 @@ func LoadApp() (*App, error) {
 	var configFlag string
 	var versionFlag bool
 	var renderFlag string
+	var maintFlag string
+	var putEnvFlags string
+	var putMetricFlags string
 	var templateFlag bool
 	var reloadFlag bool
 

--- a/core/app.go
+++ b/core/app.go
@@ -66,7 +66,13 @@ func LoadApp() (*App, error) {
 			"-(default) for stdout or file path where to save rendered JSON config file.")
 		flag.BoolVar(&versionFlag, "version", false, "Show version identifier and quit.")
 		flag.BoolVar(&reloadFlag, "reload", false,
-			"reload a ContainerPilot process through its application control socket.")
+			"reload a ContainerPilot process through its control socket.")
+		flag.StringVar(&maintFlag, "maintenance", "enable",
+			"enable/disable maintanence mode through a ContainerPilot process control socket.")
+		flag.StringVar(&putEnvFlags, "putenv", "MY_ENV=my_val",
+			"update environ of a ContainerPilot process through its control socket.")
+		flag.StringVar(&putMetricFlags, "putmetric", "MY_METRIC=my_val",
+			"update metrics of a ContainerPilot process through its control socket.")
 		flag.Parse()
 	}
 

--- a/core/flags.go
+++ b/core/flags.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MultiFlag provides a custom CLI flag that stores its unique values into a
+// simple map.
+type MultiFlag struct {
+	Values map[string]string
+}
+
+// String satisfies the flag.Value interface by joining together the flag values
+// map into a single String.
+func (self MultiFlag) String() string {
+	return fmt.Sprintf("%v", self.Values)
+}
+
+// Set satisfies the flag.Value interface by creating a map of all unique CLI
+// flag values.
+func (self *MultiFlag) Set(value string) error {
+	if self.Len() == 0 {
+		self.Values = make(map[string]string, 1)
+	}
+	pair := strings.Split(value, "=")
+	key, val := strings.Join(pair[0:1], ""), strings.Join(pair[1:2], "")
+	self.Values[key] = val
+	return nil
+}
+
+// Len is the length of the slice of values for this MultiFlag.
+func (self MultiFlag) Len() int {
+	return len(self.Values)
+}

--- a/core/flags.go
+++ b/core/flags.go
@@ -13,23 +13,23 @@ type MultiFlag struct {
 
 // String satisfies the flag.Value interface by joining together the flag values
 // map into a single String.
-func (self MultiFlag) String() string {
-	return fmt.Sprintf("%v", self.Values)
+func (f MultiFlag) String() string {
+	return fmt.Sprintf("%v", f.Values)
 }
 
 // Set satisfies the flag.Value interface by creating a map of all unique CLI
 // flag values.
-func (self *MultiFlag) Set(value string) error {
-	if self.Len() == 0 {
-		self.Values = make(map[string]string, 1)
+func (f *MultiFlag) Set(value string) error {
+	if f.Len() == 0 {
+		f.Values = make(map[string]string, 1)
 	}
 	pair := strings.Split(value, "=")
 	key, val := strings.Join(pair[0:1], ""), strings.Join(pair[1:2], "")
-	self.Values[key] = val
+	f.Values[key] = val
 	return nil
 }
 
 // Len is the length of the slice of values for this MultiFlag.
-func (self MultiFlag) Len() int {
-	return len(self.Values)
+func (f MultiFlag) Len() int {
+	return len(f.Values)
 }

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -3,7 +3,6 @@ package subcommands
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	"github.com/joyent/containerpilot/client"
 	"github.com/joyent/containerpilot/config"
@@ -41,7 +40,6 @@ func Init(configFlag string) (*Subcommand, error) {
 func (self Subcommand) SendReload() error {
 	_, err := self.client.Reload()
 	if err != nil {
-		err := errors.New("Reload: failed send reload command")
 		return err
 	}
 
@@ -51,7 +49,6 @@ func (self Subcommand) SendReload() error {
 func (self Subcommand) SendEnableMaintenance() error {
 	_, err := self.client.SetMaintenance(true)
 	if err != nil {
-		err := errors.New("EnableMaintanence: failed send client maintanance enable command")
 		return err
 	}
 
@@ -61,7 +58,6 @@ func (self Subcommand) SendEnableMaintenance() error {
 func (self Subcommand) SendDisableMaintenance() error {
 	_, err := self.client.SetMaintenance(false)
 	if err != nil {
-		err := errors.New("DisableMaintenance: failed send client maintanance disable command")
 		return err
 	}
 
@@ -71,12 +67,11 @@ func (self Subcommand) SendDisableMaintenance() error {
 func (self Subcommand) SendEnviron(env map[string]string) error {
 	envJSON, err := json.Marshal(env)
 	if err != nil {
-		fmt.Println("SendEnviron: failed to marshal JSON values", err)
+		return err
 	}
 
 	_, err = self.client.PutEnv(string(envJSON))
 	if err != nil {
-		err := errors.New("SendEnviron: failed send environ command")
 		return err
 	}
 
@@ -86,12 +81,11 @@ func (self Subcommand) SendEnviron(env map[string]string) error {
 func (self Subcommand) SendMetric(metrics map[string]string) error {
 	metricsJSON, err := json.Marshal(metrics)
 	if err != nil {
-		fmt.Println("SendMetric: failed to marshal JSON values", err)
+		return err
 	}
 
 	_, err = self.client.PutMetric(string(metricsJSON))
 	if err != nil {
-		err := errors.New("SendMetric: failed send metric command")
 		return err
 	}
 

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -7,28 +7,34 @@ import (
 	"github.com/joyent/containerpilot/config"
 )
 
-func initClient(configFlag string) error {
+type Subcommand struct {
+	client *client.HTTPClient
+}
+
+func Init(configFlag string) (*Subcommand, error) {
 	cfg, err := config.LoadConfig(configFlag)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if cfg.Control == nil {
 		err := errors.New("Reload: Couldn't reuse control config")
-		return err
+		return nil, err
 	}
 
 	httpclient, err := client.NewHTTPClient(cfg.Control.SocketPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return httpclient
+	return &Subcommand{
+		httpclient,
+	}, nil
 }
 
-func SendReload(configFlag string) error {
-	httpclient := initClient(configFlag)
-	if err := httpclient.Reload(); err != nil {
+func (self Subcommand) SendReload() error {
+	_, err := self.client.Reload()
+	if err != nil {
 		err := errors.New("Reload: Failed send reload command")
 		return err
 	}
@@ -36,9 +42,9 @@ func SendReload(configFlag string) error {
 	return nil
 }
 
-func SendEnableMaintenance(configFlag string) error {
-	httpclient := initClient(configFlag)
-	if err := httpclient.SetMaintenance(true); err != nil {
+func (self Subcommand) SendEnableMaintenance() error {
+	_, err := self.client.SetMaintenance(true)
+	if err != nil {
 		err := errors.New("EnableMaintanence: Failed send client maintanance enable command")
 		return err
 	}
@@ -46,9 +52,9 @@ func SendEnableMaintenance(configFlag string) error {
 	return nil
 }
 
-func SendDisableMaintenance(configFlag string) error {
-	httpclient := initClient(configFlag)
-	if err := httpclient.SetMaintenance(false); err != nil {
+func (self Subcommand) SendDisableMaintenance() error {
+	_, err := self.client.SetMaintenance(false)
+	if err != nil {
 		err := errors.New("DisableMaintenance: Failed send client maintanance disable command")
 		return err
 	}
@@ -56,10 +62,9 @@ func SendDisableMaintenance(configFlag string) error {
 	return nil
 }
 
-func SendEnviron(env string, configFlag string) error {
-	httpclient := initClient(configFlag)
-	// TODO: Encode environment into JSON map
-	if err := httpclient.PutEnv(env); err != nil {
+func (self Subcommand) SendEnviron(env string) error {
+	_, err := self.client.PutEnv(env)
+	if err != nil {
 		err := errors.New("SendEnviron: Failed send environ command")
 		return err
 	}
@@ -67,10 +72,9 @@ func SendEnviron(env string, configFlag string) error {
 	return nil
 }
 
-func SendMetric(metrics string, configFlag string) error {
-	httpclient := initClient(configFlag)
-	// TODO: Encode metrics into JSON map
-	if err := httpclient.PutMetric(env); err != nil {
+func (self Subcommand) SendMetric(metrics string) error {
+	_, err := self.client.PutMetric(metrics)
+	if err != nil {
 		err := errors.New("PutMetric: Failed send metric command")
 		return err
 	}

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -2,7 +2,6 @@ package subcommands
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/joyent/containerpilot/client"
 	"github.com/joyent/containerpilot/config"
@@ -16,21 +15,12 @@ type Subcommand struct {
 // Init initializes the configuration of a Subcommand function and the
 // HTTPClient which they utilize for control plane interaction.
 func Init(configFlag string) (*Subcommand, error) {
-	var socketPath = "/var/run/containerpilot.socket"
-
-	if configFlag != "" {
-		cfg, err := config.LoadConfig(configFlag)
-		if err != nil {
-			return nil, err
-		}
-		if cfg.Control == nil {
-			err := errors.New("Reload: Couldn't reuse control config")
-			return nil, err
-		}
-		socketPath = cfg.Control.SocketPath
+	cfg, err := config.LoadConfig(configFlag)
+	if err != nil {
+		return nil, err
 	}
 
-	httpclient, err := client.NewHTTPClient(socketPath)
+	httpclient, err := client.NewHTTPClient(cfg.Control.SocketPath)
 	if err != nil {
 		return nil, err
 	}

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -7,7 +7,7 @@ import (
 	"github.com/joyent/containerpilot/config"
 )
 
-func SendReload(configFlag string) error {
+func initClient(configFlag string) error {
 	cfg, err := config.LoadConfig(configFlag)
 	if err != nil {
 		return err
@@ -18,19 +18,62 @@ func SendReload(configFlag string) error {
 		return err
 	}
 
-	c, err := client.NewHTTPClient(cfg.Control.SocketPath)
+	httpclient, err := client.NewHTTPClient(cfg.Control.SocketPath)
 	if err != nil {
 		return err
 	}
 
-	if err := c.Reload(); err != nil {
-		err := errors.New("Reload: Failed to call client reload command")
+	return httpclient
+}
+
+func SendReload(configFlag string) error {
+	httpclient := initClient(configFlag)
+	if err := httpclient.Reload(); err != nil {
+		err := errors.New("Reload: Failed send reload command")
 		return err
 	}
 
 	return nil
 }
 
-// func SendMaintenance() {}
-// func SendEnviron() {}
-// func SendMetric() {}
+func SendEnableMaintenance(configFlag string) error {
+	httpclient := initClient(configFlag)
+	if err := httpclient.SetMaintenance(true); err != nil {
+		err := errors.New("EnableMaintanence: Failed send client maintanance enable command")
+		return err
+	}
+
+	return nil
+}
+
+func SendDisableMaintenance(configFlag string) error {
+	httpclient := initClient(configFlag)
+	if err := httpclient.SetMaintenance(false); err != nil {
+		err := errors.New("DisableMaintenance: Failed send client maintanance disable command")
+		return err
+	}
+
+	return nil
+}
+
+func SendEnviron(env string, configFlag string) error {
+	httpclient := initClient(configFlag)
+	// TODO: Encode environment into JSON map
+	if err := httpclient.PutEnv(env); err != nil {
+		err := errors.New("SendEnviron: Failed send environ command")
+		return err
+	}
+
+	return nil
+}
+
+func SendMetric(metrics string, configFlag string) error {
+	httpclient := initClient(configFlag)
+	// TODO: Encode metrics into JSON map
+	if err := httpclient.PutMetric(env); err != nil {
+		err := errors.New("PutMetric: Failed send metric command")
+		return err
+	}
+
+	return nil
+}

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -1,7 +1,9 @@
 package subcommands
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/joyent/containerpilot/client"
 	"github.com/joyent/containerpilot/config"
@@ -35,7 +37,7 @@ func Init(configFlag string) (*Subcommand, error) {
 func (self Subcommand) SendReload() error {
 	_, err := self.client.Reload()
 	if err != nil {
-		err := errors.New("Reload: Failed send reload command")
+		err := errors.New("Reload: failed send reload command")
 		return err
 	}
 
@@ -45,7 +47,7 @@ func (self Subcommand) SendReload() error {
 func (self Subcommand) SendEnableMaintenance() error {
 	_, err := self.client.SetMaintenance(true)
 	if err != nil {
-		err := errors.New("EnableMaintanence: Failed send client maintanance enable command")
+		err := errors.New("EnableMaintanence: failed send client maintanance enable command")
 		return err
 	}
 
@@ -55,27 +57,37 @@ func (self Subcommand) SendEnableMaintenance() error {
 func (self Subcommand) SendDisableMaintenance() error {
 	_, err := self.client.SetMaintenance(false)
 	if err != nil {
-		err := errors.New("DisableMaintenance: Failed send client maintanance disable command")
+		err := errors.New("DisableMaintenance: failed send client maintanance disable command")
 		return err
 	}
 
 	return nil
 }
 
-func (self Subcommand) SendEnviron(env string) error {
-	_, err := self.client.PutEnv(env)
+func (self Subcommand) SendEnviron(env map[string]string) error {
+	envJSON, err := json.Marshal(env)
 	if err != nil {
-		err := errors.New("SendEnviron: Failed send environ command")
+		fmt.Println("SendEnviron: failed to marshal JSON values", err)
+	}
+
+	_, err = self.client.PutEnv(string(envJSON))
+	if err != nil {
+		err := errors.New("SendEnviron: failed send environ command")
 		return err
 	}
 
 	return nil
 }
 
-func (self Subcommand) SendMetric(metrics string) error {
-	_, err := self.client.PutMetric(metrics)
+func (self Subcommand) SendMetric(metrics map[string]string) error {
+	metricsJSON, err := json.Marshal(metrics)
 	if err != nil {
-		err := errors.New("PutMetric: Failed send metric command")
+		fmt.Println("SendMetric: failed to marshal JSON values", err)
+	}
+
+	_, err = self.client.PutMetric(string(metricsJSON))
+	if err != nil {
+		err := errors.New("SendMetric: failed send metric command")
 		return err
 	}
 

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -1,0 +1,36 @@
+package subcommands
+
+import (
+	"errors"
+
+	"github.com/joyent/containerpilot/client"
+	"github.com/joyent/containerpilot/config"
+)
+
+func SendReload(configFlag string) error {
+	cfg, err := config.LoadConfig(configFlag)
+	if err != nil {
+		return err
+	}
+
+	if cfg.Control == nil {
+		err := errors.New("Reload: Couldn't reuse control config")
+		return err
+	}
+
+	c, err := client.NewHTTPClient(cfg.Control.SocketPath)
+	if err != nil {
+		return err
+	}
+
+	if err := c.Reload(); err != nil {
+		err := errors.New("Reload: Failed to call client reload command")
+		return err
+	}
+
+	return nil
+}
+
+// func SendMaintenance() {}
+// func SendEnviron() {}
+// func SendMetric() {}

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -14,17 +14,21 @@ type Subcommand struct {
 }
 
 func Init(configFlag string) (*Subcommand, error) {
-	cfg, err := config.LoadConfig(configFlag)
-	if err != nil {
-		return nil, err
+	var socketPath = "/var/run/containerpilot.socket"
+
+	if configFlag != "" {
+		cfg, err := config.LoadConfig(configFlag)
+		if err != nil {
+			return nil, err
+		}
+		if cfg.Control == nil {
+			err := errors.New("Reload: Couldn't reuse control config")
+			return nil, err
+		}
+		socketPath = cfg.Control.SocketPath
 	}
 
-	if cfg.Control == nil {
-		err := errors.New("Reload: Couldn't reuse control config")
-		return nil, err
-	}
-
-	httpclient, err := client.NewHTTPClient(cfg.Control.SocketPath)
+	httpclient, err := client.NewHTTPClient(socketPath)
 	if err != nil {
 		return nil, err
 	}

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -46,17 +46,8 @@ func (self Subcommand) SendReload() error {
 	return nil
 }
 
-func (self Subcommand) SendEnableMaintenance() error {
-	_, err := self.client.SetMaintenance(true)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (self Subcommand) SendDisableMaintenance() error {
-	_, err := self.client.SetMaintenance(false)
+func (self Subcommand) SendMaintenance(isEnabled bool) error {
+	_, err := self.client.SetMaintenance(isEnabled)
 	if err != nil {
 		return err
 	}

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -32,8 +32,7 @@ func Init(configFlag string) (*Subcommand, error) {
 
 // SendReload fires a Reload request through the HTTPClient.
 func (s Subcommand) SendReload() error {
-	_, err := s.client.Reload()
-	if err != nil {
+	if err := s.client.Reload(); err != nil {
 		return err
 	}
 
@@ -48,8 +47,7 @@ func (s Subcommand) SendMaintenance(isEnabled string) error {
 		flag = true
 	}
 
-	_, err := s.client.SetMaintenance(flag)
-	if err != nil {
+	if err := s.client.SetMaintenance(flag); err != nil {
 		return err
 	}
 
@@ -63,8 +61,7 @@ func (s Subcommand) SendEnviron(env map[string]string) error {
 		return err
 	}
 
-	_, err = s.client.PutEnv(string(envJSON))
-	if err != nil {
+	if err = s.client.PutEnv(string(envJSON)); err != nil {
 		return err
 	}
 
@@ -78,8 +75,7 @@ func (s Subcommand) SendMetric(metrics map[string]string) error {
 		return err
 	}
 
-	_, err = s.client.PutMetric(string(metricsJSON))
-	if err != nil {
+	if err = s.client.PutMetric(string(metricsJSON)); err != nil {
 		return err
 	}
 

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -8,10 +8,13 @@ import (
 	"github.com/joyent/containerpilot/config"
 )
 
+// Subcommand provides a simple object for storing a configured HTTPClient.
 type Subcommand struct {
 	client *client.HTTPClient
 }
 
+// Init initializes the configuration of a Subcommand function and the
+// HTTPClient which they utilize for control plane interaction.
 func Init(configFlag string) (*Subcommand, error) {
 	var socketPath = "/var/run/containerpilot.socket"
 
@@ -37,8 +40,9 @@ func Init(configFlag string) (*Subcommand, error) {
 	}, nil
 }
 
-func (self Subcommand) SendReload() error {
-	_, err := self.client.Reload()
+// SendReload fires a Reload request through the HTTPClient.
+func (s Subcommand) SendReload() error {
+	_, err := s.client.Reload()
 	if err != nil {
 		return err
 	}
@@ -46,8 +50,15 @@ func (self Subcommand) SendReload() error {
 	return nil
 }
 
-func (self Subcommand) SendMaintenance(isEnabled bool) error {
-	_, err := self.client.SetMaintenance(isEnabled)
+// SendMaintenance fires either an enable or disable SetMaintenance request
+// through the HTTPClient.
+func (s Subcommand) SendMaintenance(isEnabled string) error {
+	flag := false
+	if isEnabled == "enable" {
+		flag = true
+	}
+
+	_, err := s.client.SetMaintenance(flag)
 	if err != nil {
 		return err
 	}
@@ -55,13 +66,14 @@ func (self Subcommand) SendMaintenance(isEnabled bool) error {
 	return nil
 }
 
-func (self Subcommand) SendEnviron(env map[string]string) error {
+// SendEnviron fires a PutEnv request through the HTTPClient.
+func (s Subcommand) SendEnviron(env map[string]string) error {
 	envJSON, err := json.Marshal(env)
 	if err != nil {
 		return err
 	}
 
-	_, err = self.client.PutEnv(string(envJSON))
+	_, err = s.client.PutEnv(string(envJSON))
 	if err != nil {
 		return err
 	}
@@ -69,13 +81,14 @@ func (self Subcommand) SendEnviron(env map[string]string) error {
 	return nil
 }
 
-func (self Subcommand) SendMetric(metrics map[string]string) error {
+// SendMetric fires a PutMetric request through the HTTPClient.
+func (s Subcommand) SendMetric(metrics map[string]string) error {
 	metricsJSON, err := json.Marshal(metrics)
 	if err != nil {
 		return err
 	}
 
-	_, err = self.client.PutMetric(string(metricsJSON))
+	_, err = s.client.PutMetric(string(metricsJSON))
 	if err != nil {
 		return err
 	}

--- a/subcommands/subcommands_test.go
+++ b/subcommands/subcommands_test.go
@@ -1,11 +1,7 @@
 package subcommands
 
 import (
-	// "fmt"
 	"testing"
-
-	"github.com/joyent/containerpilot/tests"
-	"github.com/joyent/containerpilot/tests/assert"
 )
 
 func TestReloadCommand(t *testing.T) {

--- a/subcommands/subcommands_test.go
+++ b/subcommands/subcommands_test.go
@@ -1,0 +1,14 @@
+package subcommands
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/joyent/containerpilot/tests"
+	"github.com/joyent/containerpilot/tests/assert"
+)
+
+func TestReloadCommand() {}
+func TestMaintenanceCommand() {}
+func TestEnvironCommand() {}
+func TestMetricCommand() {}

--- a/subcommands/subcommands_test.go
+++ b/subcommands/subcommands_test.go
@@ -6,16 +6,30 @@ import (
 
 func TestReloadCommand(t *testing.T) {
 	t.Skip("Not implemented")
+
+	// Stub out client...
+	// Nothing to test? Calls out to client...
 }
 
 func TestMaintenanceCommand(t *testing.T) {
 	t.Skip("Not implemented")
+
+	// Stub out client...
+	// Make sure sending bool parameter into client....
 }
 
 func TestEnvironCommand(t *testing.T) {
 	t.Skip("Not implemented")
+
+	// Stub out client
+	// Make sure map is sent to client as JSON
+	// Test variations of bad maps that break JSON
 }
 
 func TestMetricCommand(t *testing.T) {
 	t.Skip("Not implemented")
+
+	// Stub out client
+	// Make sure map is sent to client as JSON
+	// Test variations of bad maps that break JSON
 }

--- a/subcommands/subcommands_test.go
+++ b/subcommands/subcommands_test.go
@@ -1,14 +1,25 @@
 package subcommands
 
 import (
-	"fmt"
+	// "fmt"
 	"testing"
 
 	"github.com/joyent/containerpilot/tests"
 	"github.com/joyent/containerpilot/tests/assert"
 )
 
-func TestReloadCommand() {}
-func TestMaintenanceCommand() {}
-func TestEnvironCommand() {}
-func TestMetricCommand() {}
+func TestReloadCommand(t *testing.T) {
+	t.Skip("Not implemented")
+}
+
+func TestMaintenanceCommand(t *testing.T) {
+	t.Skip("Not implemented")
+}
+
+func TestEnvironCommand(t *testing.T) {
+	t.Skip("Not implemented")
+}
+
+func TestMetricCommand(t *testing.T) {
+	t.Skip("Not implemented")
+}


### PR DESCRIPTION
Ref: #340. 

This PR introduces both the `subcommands` and `client` packages. 

`client.HTTPClient` provides a simple HTTP client that formalizes requests sent to CP3's new control socket. I've tied this into `subcommands` which map into the CLI flags of `app/core`. 

I believe breaking it out this way could more easily allow any external Go projects to import the client package. This client package can probably be utilized in unit tests as well.

Still **WiP** but I had reload working earlier so I decided to continue on with the remaining subcommands. Tests and lint will fail for the moment.