### PR TITLE
retry binding to control socket listener on error

### DIFF
--- a/integration_tests/tests/test_config_reload/run.sh
+++ b/integration_tests/tests/test_config_reload/run.sh
@@ -16,6 +16,7 @@ if [[ "$reloads" -ne 1 ]] || [[ "$serves" -ne 2 ]]; then
     echo '--------------------'
     echo 'single reload failed'
     echo '----- APP LOGS -----'
+    cat app.log
     exit 1
 fi
 
@@ -31,6 +32,7 @@ if [[ $? -ne 0 ]]; then
     echo '--------------------'
     echo 'multi reload failed'
     echo '----- APP LOGS -----'
+    cat app.log
     exit 1
 fi
 


### PR DESCRIPTION
For #328.

The problem really is inherent to the fact that we’re try to rebind the same socket we’re getting the message on, so we can’t safely do it synchronously even if the rest of the architecture supported it. So this PR tries to solve the problem by just letting the server retry a couple times if it gets an error on binding to the socket.

cc @cheapRoc 