### PR TITLE
Introduce `subcommands` and `client` packages

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// HTTPClient provides a properly configured http.Client object used to send
+// requests out to a ContainerPilot process's control socket.
+type HTTPClient struct {
+	http.Client
+	socketPath string
+}
+
+var socketType = "unix"
+
+func socketDialer(socketPath string) func(string, string) (net.Conn, error) {
+	return func(_, _ string) (net.Conn, error) {
+		return net.Dial(socketType, socketPath)
+	}
+}
+
+// NewHTTPClient initializes an client.HTTPClient object by configuring it's
+// socketPath for HTTP communication through the local file system.
+func NewHTTPClient(socketPath string) (*HTTPClient, error) {
+	if socketPath == "" {
+		err := errors.New("control server not loading due to missing config")
+		return nil, err
+	}
+
+	client := &HTTPClient{}
+	client.Transport = &http.Transport{
+		Dial: socketDialer(socketPath),
+	}
+
+	return client, nil
+}
+
+// Reload makes a request to the reload endpoint of a ContainerPilot process.
+func (c HTTPClient) Reload() error {
+	resp, err := c.Post("http://control/v3/reload", "application/json", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// SetMaintenance makes a request to either the enable or disable maintenance
+// endpoint of a ContainerPilot process.
+func (c HTTPClient) SetMaintenance(isEnabled bool) error {
+	flag := "disable"
+	if isEnabled {
+		flag = "enable"
+	}
+
+	resp, err := c.Post("http://control/v3/maintenance/"+flag, "application/json", nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+// PutEnv makes a request to the environ endpoint of a ContainerPilot process
+// for setting environ variable pairs.
+func (c HTTPClient) PutEnv(body string) error {
+	resp, err := c.Post("http://control/v3/environ", "application/json",
+		strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return fmt.Errorf("unprocessable entity received by control server")
+	}
+	return nil
+}
+
+// PutMetric makes a request to the metric endpoint of a ContainerPilot process
+// for setting custom metrics.
+func (c HTTPClient) PutMetric(body string) error {
+	resp, err := c.Post("http://control/v3/metric", "application/json",
+		strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return fmt.Errorf("unprocessable entity received by control server")
+	}
+	return nil
+}

--- a/core/flags.go
+++ b/core/flags.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MultiFlag provides a custom CLI flag that stores its unique values into a
+// simple map.
+type MultiFlag struct {
+	Values map[string]string
+}
+
+// String satisfies the flag.Value interface by joining together the flag values
+// map into a single String.
+func (f MultiFlag) String() string {
+	return fmt.Sprintf("%v", f.Values)
+}
+
+// Set satisfies the flag.Value interface by creating a map of all unique CLI
+// flag values.
+func (f *MultiFlag) Set(value string) error {
+	if f.Len() == 0 {
+		f.Values = make(map[string]string, 1)
+	}
+	pair := strings.Split(value, "=")
+	key, val := strings.Join(pair[0:1], ""), strings.Join(pair[1:2], "")
+	f.Values[key] = val
+	return nil
+}
+
+// Len is the length of the slice of values for this MultiFlag.
+func (f MultiFlag) Len() int {
+	return len(f.Values)
+}

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -1,0 +1,83 @@
+package subcommands
+
+import (
+	"encoding/json"
+
+	"github.com/joyent/containerpilot/client"
+	"github.com/joyent/containerpilot/config"
+)
+
+// Subcommand provides a simple object for storing a configured HTTPClient.
+type Subcommand struct {
+	client *client.HTTPClient
+}
+
+// Init initializes the configuration of a Subcommand function and the
+// HTTPClient which they utilize for control plane interaction.
+func Init(configFlag string) (*Subcommand, error) {
+	cfg, err := config.LoadConfig(configFlag)
+	if err != nil {
+		return nil, err
+	}
+
+	httpclient, err := client.NewHTTPClient(cfg.Control.SocketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Subcommand{
+		httpclient,
+	}, nil
+}
+
+// SendReload fires a Reload request through the HTTPClient.
+func (s Subcommand) SendReload() error {
+	if err := s.client.Reload(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SendMaintenance fires either an enable or disable SetMaintenance request
+// through the HTTPClient.
+func (s Subcommand) SendMaintenance(isEnabled string) error {
+	flag := false
+	if isEnabled == "enable" {
+		flag = true
+	}
+
+	if err := s.client.SetMaintenance(flag); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SendEnviron fires a PutEnv request through the HTTPClient.
+func (s Subcommand) SendEnviron(env map[string]string) error {
+	envJSON, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+
+	if err = s.client.PutEnv(string(envJSON)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SendMetric fires a PutMetric request through the HTTPClient.
+func (s Subcommand) SendMetric(metrics map[string]string) error {
+	metricsJSON, err := json.Marshal(metrics)
+	if err != nil {
+		return err
+	}
+
+	if err = s.client.PutMetric(string(metricsJSON)); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Ref: #340

* CP CLI subcommands simplify calls to the control socket
* `-reload` for reloading another CP process
* `-putenv` for updating the environment of a CP process
* `-putmetric` for updating custom metrics inside a CP process
* `-maintenance` for switching maintaince mode on or off
* Introduce ContainerPilot client package for HTTP requests
* Introduce MultiFlag for entering multiple values for the same CLI flag