### PR TITLE
update telemetry server to use EventBus for graceful reload

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -288,7 +288,7 @@ func (a *App) handlePolling() {
 		for _, sensor := range a.Telemetry.Sensors {
 			sensor.Run(a.Bus)
 		}
-		a.Telemetry.Serve()
+		a.Telemetry.Run(a.Bus)
 	}
 	// kick everything off
 	a.Bus.Publish(events.GlobalStartup)


### PR DESCRIPTION
For #341 and #166
Updates the Telemetry server to use the EventBus for control, and to use the graceful reload for the HTTP server in golang 1.8. This makes the Telemetry server largely mimic the control socket.

cc @cheapRoc
Note that this PR currently contains all the commits in #354 and I'll have to rebase it once that's merged. The only commit specific to this PR is 5e6b3a9