### PR TITLE
increase frequency timer for periodic tasks

### DIFF
--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -115,11 +115,11 @@ func TestJobRunPeriodic(t *testing.T) {
 	cfg := &Config{
 		Name: "myjob",
 		Exec: []string{"./testdata/test.sh", "doStuff", "runPeriodicTest"},
-		When: &WhenConfig{Frequency: "10ms"},
+		When: &WhenConfig{Frequency: "250ms"},
 		// we need to make sure we don't have any events getting cut off
-		// by the test run of 100ms (which would result in flaky tests),
+		// by the test run of 1sec (which would result in flaky tests),
 		// so this should ensure we get a predictable number within the window
-		Restarts: "5",
+		Restarts: "2",
 	}
 	cfg.Validate(noop)
 	job := NewJob(cfg)
@@ -127,7 +127,7 @@ func TestJobRunPeriodic(t *testing.T) {
 	job.Bus.Publish(events.GlobalStartup)
 	exitOk := events.Event{Code: events.ExitSuccess, Source: "myjob"}
 	exitFail := events.Event{Code: events.ExitFailed, Source: "myjob"}
-	time.Sleep(200 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	job.Quit()
 	bus.Wait()
 	results := bus.DebugEvents()
@@ -141,8 +141,8 @@ func TestJobRunPeriodic(t *testing.T) {
 			}
 		}
 	}
-	if got != 6 {
-		t.Fatalf("expected exactly 6 task executions but got %d\n%v", got, results)
+	if got != 3 {
+		t.Fatalf("expected exactly 3 task executions but got %d\n%v", got, results)
 	}
 }
 


### PR DESCRIPTION
Embarrassingly I somehow screwed up my rebase of https://github.com/joyent/containerpilot/pull/359 so this is the new PR for that.

---

For #332

The `TestRunJobPeriodicTask` unit test has been flaky, and if I'd thought about it a bit more I would have remembered [my remarks in our own documentation](https://github.com/joyent/containerpilot/tree/abd3070533108a98d559e809d6ce9884a5e7364c/documentation/18-tasks):

> Note on task frequency: Pick a frequency of 1s or longer. Although the task configuration permits frequencies as fast as 1ms, the overhead of spawning a process and its lifecycle is likely to be anywhere from 2ms to 25ms. Your task may not be able to run at all, or it might always be killed before it gets any useful work done.

:blush:

I don't really want a test that takes 4 seconds though, so I'm going to set the timer to 250ms which should realistically be more than enough. This lets us get 2 restarts which will fully exercise our restart logic in 1 second.
