### PR TITLE
use -reload subcommand in config reload test

### DIFF
--- a/integration_tests/fixtures/app/reload-containerpilot.sh
+++ b/integration_tests/fixtures/app/reload-containerpilot.sh
@@ -2,18 +2,16 @@
 set -e
 
 single() {
-    echo -e "POST /v3/reload HTTP/1.1\r\nHost: control\r\n\r\n" | \
-        nc -U /var/run/containerpilot.socket > /dev/null 2>&1
+    /bin/containerpilot -reload > /dev/null 2>&1
     exit 0
 }
 
 multi() {
     # we mask the output here because we expect many many lines that
-    # say "nc: unix connect failed: No such file or directory" while
-    # the config is being reloaded
+    # say "dial unix /var/run/containerpilot.sock: connect: no such
+    # file or directory" while the config is being reloaded
     for i in {1..200}; do
-        echo -e "POST /v3/reload HTTP/1.1\r\nHost: control\r\n\r\n" | \
-            nc -U /var/run/containerpilot.socket > /dev/null 2>&1
+        /bin/containerpilot -reload > /dev/null 2>&1
     done
     exit 0
 }


### PR DESCRIPTION
This does the same thing as the existing integration test, but uses the new `-reload` subcommand instead of hacking together the POST via netcat.

Sample test output:
```
2017/05/16 10:52:04 TEST: test_config_reload
Creating testconfigreload_consul_1 ...
Creating testconfigreload_consul_1 ... done
Creating testconfigreload_app_1 ...
Creating testconfigreload_app_1 ... done
2017/05/16 10:52:11 PASS: test_config_reload
```

cc @cheapRoc 