### PR TITLE
use -putmetric subcommand in telemetry integration test

### DIFF
--- a/integration_tests/fixtures/app/sensor.sh
+++ b/integration_tests/fixtures/app/sensor.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-echo -e 'POST /v3/metric HTTP/1.1\r\nHost: control\r\nContent-Type: application/json\r\nContent-Length: 39\r\n\r\n{"containerpilot_app_some_counter": 42}' | \
-    nc -U /var/run/containerpilot.socket
+/bin/containerpilot -putmetric 'containerpilot_app_some_counter=42'


### PR DESCRIPTION
This does the same thing as the existing integration test, but uses the new `-reload` subcommand instead of hacking together the POST via netcat.

Sample test output:
```
2017/05/16 11:17:57 TEST: test_telemetry
Creating testtelemetry_consul_1 ...
Creating testtelemetry_consul_1 ... done
testtelemetry_consul_1 is up-to-date
Creating testtelemetry_app_1 ...
Creating testtelemetry_app_1 ... done
containerpilot_app_some_counter 42
        "ServiceID": "containerpilot-79594b160d7c",
        "ServiceName": "containerpilot",
Stopping testtelemetry_app_1 ... done
[
    {
        "ID": "b7e58d47-dcbd-4011-aeb8-75b3782ed9c5",
        "Node": "consul",
        "Address": "192.168.16.2",
        "TaggedAddresses": {
            "lan": "192.168.16.2",
            "wan": "192.168.16.2"
        },
        "NodeMeta": {},
        "ServiceTags": [],
        "ServiceAddress": "192.168.16.3",
        "ServicePort": 9090,
        "ServiceEnableTagOverride": false,
        "CreateIndex": 10,
        "ModifyIndex": 10
    }
]
Going to remove testtelemetry_app_1, testtelemetry_test_run_1
Removing testtelemetry_app_1 ... done
Removing testtelemetry_test_run_1 ... done
2017/05/16 11:18:21 PASS: test_telemetry
```

cc @cheapRoc 