### PR TITLE
validate flag input for -putmetrics, -putenv

### DIFF
--- a/core/flags.go
+++ b/core/flags.go
@@ -24,6 +24,10 @@ func (f *MultiFlag) Set(value string) error {
 		f.Values = make(map[string]string, 1)
 	}
 	pair := strings.Split(value, "=")
+	if len(pair) < 2 {
+		return fmt.Errorf(
+			"flag value '%v' was not in the format 'key=val'", value)
+	}
 	key, val := strings.Join(pair[0:1], ""), strings.Join(pair[1:2], "")
 	f.Values[key] = val
 	return nil


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/364

This validates the length of the input to the `-putmetric` and `-putenv` subcommands after splitting on the `=`. If we don't have a key and a value, we return an error which will bubble up to the user.

cc @cheapRoc 