### PR TITLE
improve output of -help

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,7 @@ func RenderConfig(configFlag, renderFlag string) error {
 	}
 
 	// Save the rendered template, either to stdout or to file
-	if renderFlag == "-" {
+	if renderFlag == "-" || renderFlag == "" {
 		fmt.Printf("%s", renderedConfig)
 	} else {
 		var err error

--- a/core/app.go
+++ b/core/app.go
@@ -67,25 +67,29 @@ func LoadApp() (*App, error) {
 			"Show version identifier and quit.")
 
 		flag.BoolVar(&templateFlag, "template", false,
-			"Render template and quit. (default: false)")
+			"Render template and quit.")
 
 		flag.BoolVar(&reloadFlag, "reload", false,
 			"Reload a ContainerPilot process through its control socket.")
 
 		flag.StringVar(&configFlag, "config", "",
-			"File path to JSON5 configuration file.")
+			"File path to JSON5 configuration file. Defaults to CONTAINERPILOT env var.")
 
-		flag.StringVar(&renderFlag, "out", "-",
-			"-(default) for stdout or file path where to save rendered JSON config file.")
+		flag.StringVar(&renderFlag, "out", "",
+			`File path where to save rendered config file when '-template' is used.
+	Defaults to stdout ('-').`)
 
 		flag.StringVar(&maintFlag, "maintenance", "",
-			"Enable/disable maintanence mode through a ContainerPilot process control socket.")
+			`Toggle maintenance mode for a ContainerPilot process through its control socket.
+	Options: '-maintenance enable' or '-maintenance disable'`)
 
 		flag.Var(&putMetricFlags, "putmetric",
-			"Update metrics of a ContainerPilot process through its control socket.")
+			`Update metrics of a ContainerPilot process through its control socket.
+	Pass metrics in the format: 'key=value'`)
 
 		flag.Var(&putEnvFlags, "putenv",
-			"Update environ of a ContainerPilot process through its control socket.")
+			`Update environ of a ContainerPilot process through its control socket.
+	Pass environment in the format: 'key=value'`)
 
 		flag.Parse()
 	}


### PR DESCRIPTION
Given that it was so easy to screw up the metrics values in https://github.com/joyent/containerpilot/issues/364 I took a second look at the output of `-help`. This improves some of the language, expands on the required details for options, and eliminates a weird side-effect of the way the flags package reports default values. The output of this is:

```
$ ./containerpilot -help
Usage of ./containerpilot:
  -config string
        File path to JSON5 configuration file. Defaults to CONTAINERPILOT env var.
  -maintenance string
        Toggle maintenance mode for a ContainerPilot process through its control socket.
        Options: '-maintenance enable' or '-maintenance disable'
  -out string
        File path where to save rendered config file when '-template' is used.
        Defaults to stdout ('-').
  -putenv value
        Update environ of a ContainerPilot process through its control socket.
        Pass environment in the format: 'key=value'
  -putmetric value
        Update metrics of a ContainerPilot process through its control socket.
        Pass metrics in the format: 'key=value'
  -reload
        Reload a ContainerPilot process through its control socket.
  -template
        Render template and quit.
  -version
        Show version identifier and quit.
```

This is the sort of thing where some day it might be nice to use one of the many nicer 3rd-party command line options packages. But we're just barely at the annoyance threshold for that.
cc @cheapRoc 