### PR TITLE
add startsLimit logic to ExitSuccess handler, unit test restart logic

### DIFF
--- a/events/bus.go
+++ b/events/bus.go
@@ -3,6 +3,8 @@ package events
 import (
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // EventBus manages the state of and transmits messages to all its Subscribers
@@ -97,6 +99,7 @@ func (bus *EventBus) Unregister(subscriber Subscriber, isInternal ...bool) {
 func (bus *EventBus) Publish(event Event) {
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
+	log.Debugf("event: %v", event)
 	for subscriber := range bus.registry {
 		// sending to an unsubscribed Subscriber shouldn't be a runtime
 		// error, so this is in intentionally allowed to panic here


### PR DESCRIPTION
For #368. We have a concept of both multiple starts (`when.once` vs `when.each`) and `restarts` (behavior on exit). This PR fixes two failures in the logic:

- We were decrementing the `startsRemain` after the initial start but then checking it for equality vs the const `unlimited`. Now we check if the `startsRemain` is 0 and return early, and don't decrement if `startsRemain` is unlimited to avoid integer underflow in extremely long running processes.
- We were checking `restartPermitted` after exiting a job and returning based on that, but weren't checking if the job needed to be able to listen to new events for new starts. Now we check for `startsLimit` as well, and we also inverted the logic of the check to make it easier to read.

I've included a reasonably comprehensive unit test of the expected behaviors as well. Each subtest includes a comment that has the configuration that would trigger that case.

I've also tested this out with the hello-world blueprint and I'm seeing the expected behavior now.

cc @cheapRoc 