### PR TITLE
fix race in integration test of Nginx template rendering

### DIFF
--- a/integration_tests/fixtures/consul/Dockerfile
+++ b/integration_tests/fixtures/consul/Dockerfile
@@ -1,3 +1,0 @@
-FROM consul:latest
-
-CMD ["agent","-dev","-client","0.0.0.0","-bind","0.0.0.0"]

--- a/integration_tests/fixtures/nginx/etc/nginx-consul.ctmpl
+++ b/integration_tests/fixtures/nginx/etc/nginx-consul.ctmpl
@@ -25,12 +25,13 @@ http {
 
     # for each service, create a backend
     {{range services}}
+    {{ if service .Name }}
     upstream {{.Name}} {
         # write the health service address:port pairs for this backend
         {{range service .Name}}
         server {{.Address}}:{{.Port}};
         {{end}}
-    }{{end}}
+    }{{end}}{{end}}
 
     server {
         listen       80;
@@ -46,6 +47,7 @@ http {
         }
 
         {{range services}}
+        {{ if service .Name }}
         location = /{{.Name}} {
             return 302 /{{.Name}}/;
         }
@@ -53,7 +55,7 @@ http {
         location /{{.Name}} {
             proxy_pass http://{{.Name}}/;
             proxy_redirect off;
-        }{{end}}
+        }{{end}}{{end}}
 
     }
 }

--- a/integration_tests/tests/test_config_reload/docker-compose.yml
+++ b/integration_tests/tests/test_config_reload/docker-compose.yml
@@ -3,9 +3,10 @@ version: "2.1"
 services:
 
   consul:
-    image: "cpfix_consul"
-    mem_limit: 256m
+    image: consul:latest
+    mem_limit: 128m
     hostname: consul
+    command: agent -dev -client 0.0.0.0 -bind 0.0.0.0
 
   app:
     image: "cpfix_app"

--- a/integration_tests/tests/test_coprocess/docker-compose.yml
+++ b/integration_tests/tests/test_coprocess/docker-compose.yml
@@ -1,10 +1,12 @@
 version: "2.1"
 
 services:
+
   consul:
-    image: "cpfix_consul"
+    image: consul:latest
     mem_limit: 128m
     hostname: consul
+    command: agent -dev -client 0.0.0.0 -bind 0.0.0.0
 
   app:
     image: "cpfix_app"

--- a/integration_tests/tests/test_discovery_consul/docker-compose.yml
+++ b/integration_tests/tests/test_discovery_consul/docker-compose.yml
@@ -1,10 +1,12 @@
 version: "2.1"
 
 services:
+
   consul:
-    image: "cpfix_consul"
+    image: consul:latest
     mem_limit: 128m
     hostname: consul
+    command: agent -dev -client 0.0.0.0 -bind 0.0.0.0
 
   app:
     image: "cpfix_app"

--- a/integration_tests/tests/test_discovery_consul/run.sh
+++ b/integration_tests/tests/test_discovery_consul/run.sh
@@ -16,7 +16,7 @@ result=$?
 
 if [ ! $result -eq 0 ]; then
     APP_ID=$(docker ps -l -f "ancestor=cpfix_app" --format="{{.ID}}")
-    CONSUL_ID=$(docker ps -l -f "ancestor=cpfix_consul" --format="{{.ID}}")
+    CONSUL_ID=$(docker ps -l -f "ancestor=consul" --format="{{.ID}}")
     NGINX_ID=$(docker ps -l -f "ancestor=cpfix_nginx" --format="{{.ID}}")
     echo '----- APP LOGS ------'
     docker logs "${CONSUL_ID}" | tee consul.log

--- a/integration_tests/tests/test_discovery_consul/run.sh
+++ b/integration_tests/tests/test_discovery_consul/run.sh
@@ -18,9 +18,11 @@ if [ ! $result -eq 0 ]; then
     APP_ID=$(docker ps -l -f "ancestor=cpfix_app" --format="{{.ID}}")
     CONSUL_ID=$(docker ps -l -f "ancestor=consul" --format="{{.ID}}")
     NGINX_ID=$(docker ps -l -f "ancestor=cpfix_nginx" --format="{{.ID}}")
-    echo '----- APP LOGS ------'
+    echo '----- CONSUL LOGS ------'
     docker logs "${CONSUL_ID}" | tee consul.log
+    echo '----- NGINX LOGS ------'
     docker logs "${NGINX_ID}" | tee nginx.log
+    echo '----- APP LOGS ------'
     docker logs "${APP_ID}" | tee app.log
     echo '---------------------'
 fi

--- a/integration_tests/tests/test_logging/docker-compose.yml
+++ b/integration_tests/tests/test_logging/docker-compose.yml
@@ -3,9 +3,10 @@ version: "2.1"
 services:
 
   consul:
-    image: "cpfix_consul"
+    image: consul:latest
     mem_limit: 128m
     hostname: consul
+    command: agent -dev -client 0.0.0.0 -bind 0.0.0.0
 
   app:
     image: "cpfix_app"

--- a/integration_tests/tests/test_reap_zombies/docker-compose.yml
+++ b/integration_tests/tests/test_reap_zombies/docker-compose.yml
@@ -1,10 +1,12 @@
 version: "2.1"
 
 services:
+
   consul:
-    image: "cpfix_consul"
-    mem_limit: 256m
+    image: consul:latest
+    mem_limit: 128m
     hostname: consul
+    command: agent -dev -client 0.0.0.0 -bind 0.0.0.0
 
   app:
     image: "cpfix_zombie_maker"

--- a/integration_tests/tests/test_sigterm/docker-compose.yml
+++ b/integration_tests/tests/test_sigterm/docker-compose.yml
@@ -3,9 +3,10 @@ version: "2.1"
 services:
 
   consul:
-    image: "cpfix_consul"
-    mem_limit: 256m
+    image: consul:latest
+    mem_limit: 128m
     hostname: consul
+    command: agent -dev -client 0.0.0.0 -bind 0.0.0.0
 
   app:
     image: "cpfix_app"

--- a/integration_tests/tests/test_sigterm/run.sh
+++ b/integration_tests/tests/test_sigterm/run.sh
@@ -14,8 +14,12 @@ CONSUL_ID="$(docker-compose ps -q consul)"
 TEST_ID=$(docker ps -l -f "ancestor=cpfix_test_probe" --format="{{.ID}}")
 
 if [ $result -ne 0 ]; then
+    echo '----- TEST LOGS ------'
     docker logs "$TEST_ID" | tee test.log
+    echo '----- APP LOGS ------'
     docker logs "$APP_ID" | tee app.log
+    echo '----- CONSUL LOGS ------'
     docker logs "$CONSUL_ID" | tee consul.log
+    echo '---------------------'
 fi
 exit $result

--- a/integration_tests/tests/test_tasks/docker-compose.yml
+++ b/integration_tests/tests/test_tasks/docker-compose.yml
@@ -3,9 +3,10 @@ version: "2.1"
 services:
 
   consul:
-    image: "cpfix_consul"
+    image: consul:latest
     mem_limit: 128m
     hostname: consul
+    command: agent -dev -client 0.0.0.0 -bind 0.0.0.0
 
   app:
     image: "cpfix_app"

--- a/integration_tests/tests/test_telemetry/docker-compose.yml
+++ b/integration_tests/tests/test_telemetry/docker-compose.yml
@@ -3,9 +3,10 @@ version: "2.1"
 services:
 
   consul:
-    image: "cpfix_consul"
+    image: consul:latest
     mem_limit: 128m
     hostname: consul
+    command: agent -dev -client 0.0.0.0 -bind 0.0.0.0
 
   app:
     image: "cpfix_app"


### PR DESCRIPTION
This PR comes out of work done trying to debug #372. I'm trying to make the integration tests both more useful and less crufty:

- remove the `cpfix_consul` fixture, which doesn't give us anything over the official `consul:latest` container image
- add labels to the log outputs for `test_sigterm` and `test_discovery_consul` so it's easier to read out the logs when we have errors that show up only on TravisCI.
- allow for empty services in the Nginx config template so that we don't run into the race condition described here https://github.com/joyent/containerpilot/issues/372#issuecomment-303201410

cc @cheapRoc @misterbisson 