### PR TITLE
avoid dropping job logs by moving log Close() to after unsubscribe

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -143,6 +143,8 @@ func (c *Command) Kill() {
 
 // CloseLogs safely closes the io.WriteCloser we're using to pipe logs
 func (c *Command) CloseLogs() {
+	// need to nil check these because they might have been closed
+	// concurrently.
 	if c != nil && c.logger != nil {
 		c.logger.Close()
 	}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -143,8 +143,7 @@ func (c *Command) Kill() {
 
 // CloseLogs safely closes the io.WriteCloser we're using to pipe logs
 func (c *Command) CloseLogs() {
-	if c != nil && c.logger != nil {
+	if c.logger != nil {
 		c.logger.Close()
 	}
-	return
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -143,7 +143,8 @@ func (c *Command) Kill() {
 
 // CloseLogs safely closes the io.WriteCloser we're using to pipe logs
 func (c *Command) CloseLogs() {
-	if c.logger != nil {
+	if c != nil && c.logger != nil {
 		c.logger.Close()
 	}
+	return
 }

--- a/integration_tests/tests/test_envvars/containerpilot.json5
+++ b/integration_tests/tests/test_envvars/containerpilot.json5
@@ -1,5 +1,6 @@
 {
   consul: "127.0.0.1:8500",
+  logging: { level: "DEBUG" },
   jobs: [
     {
       name: "testenvvar",

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -314,10 +314,10 @@ func (job *Job) cleanup(ctx context.Context, cancel context.CancelFunc) {
 		}
 	}
 	cancel()
-	job.Unsubscribe(job.Bus) // deregister from events
-	job.Deregister()         // deregister from Consul
-	job.Bus.Publish(events.Event{Code: events.Stopped, Source: job.Name})
 	job.exec.CloseLogs()
+	job.Deregister()         // deregister from Consul
+	job.Unsubscribe(job.Bus) // deregister from events
+	job.Bus.Publish(events.Event{Code: events.Stopped, Source: job.Name})
 }
 
 // String implements the stdlib fmt.Stringer interface for pretty-printing


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/365

For short-lived containers, logs are getting cut off before we can log them to stdout. The log close happens after the event bus is sent the "unsubscribe" message for the job, and that means the event bus can potentially halt ContainerPilot before we've closed the logs. By moving the `CloseLogs` until after this, we'll make sure we've logged everything we can.

I've also moved the step where we deregister from Consul for the same reason.

cc @misterbisson @cheapRoc 