### PR TITLE
move subcommand.Init into flag blocks to avoid extra config parse

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -111,40 +111,50 @@ func LoadApp() (*App, error) {
 		os.Exit(0)
 	}
 
-	cmd, _ := subcommands.Init(configFlag)
-
 	if reloadFlag {
+		cmd, err := subcommands.Init(configFlag)
+		if err != nil {
+			return nil, err
+		}
 		if err := cmd.SendReload(); err != nil {
-			fmt.Println("Reload: failed to run subcommand:", err)
-			os.Exit(2)
+			return nil,
+				fmt.Errorf("-reload: failed to run subcommand: %v", err)
 		}
 		os.Exit(0)
 	}
 
 	if maintFlag != "" {
-		if err := cmd.SendMaintenance(maintFlag); err != nil {
-			fmt.Println("SendMaintenance: failed to run subcommand:", err)
-			os.Exit(2)
+		cmd, err := subcommands.Init(configFlag)
+		if err != nil {
+			return nil, err
 		}
-
+		if err := cmd.SendMaintenance(maintFlag); err != nil {
+			return nil,
+				fmt.Errorf("-maintenance: failed to run subcommand: %v", err)
+		}
 		os.Exit(0)
 	}
 
 	if putEnvFlags.Len() != 0 {
-		if err := cmd.SendEnviron(putEnvFlags.Values); err != nil {
-			fmt.Println("SendEnviron: failed to run subcommand:", err)
-			os.Exit(2)
+		cmd, err := subcommands.Init(configFlag)
+		if err != nil {
+			return nil, err
 		}
-
+		if err := cmd.SendEnviron(putEnvFlags.Values); err != nil {
+			return nil, fmt.Errorf("-putenv: failed to run subcommand: %v", err)
+		}
 		os.Exit(0)
 	}
 
 	if putMetricFlags.Len() != 0 {
-		if err := cmd.SendMetric(putMetricFlags.Values); err != nil {
-			fmt.Println("SendMetric: failed to run subcommand:", err)
-			os.Exit(2)
+		cmd, err := subcommands.Init(configFlag)
+		if err != nil {
+			return nil, err
 		}
-
+		if err := cmd.SendMetric(putMetricFlags.Values); err != nil {
+			return nil,
+				fmt.Errorf("-putmetric: failed to run subcommand: %v", err)
+		}
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/382.

This fixes the panic in that issue by making sure we catch the error and abort if the config can't be loaded. It also fixes the redundant configuration parsing we do in the normal case where there's no subcommand by moving the `subcommand.Init` into the flag-handling block. Error messages end up looking like this:

```
2017/05/30 13:13:52 -reload: failed to run subcommand: Post http://control/v3/reload: dial unix /var/run/containerpilot.socket: connect: no such file or directory
```

And for what it's worth, at some point I'd like to replace the use of the stdlib `flag` with something less clumsy. And probably move the whole command-line parsing out of the `core` package. But it's low-priority.

cc @cheapRoc 