### PR TITLE
contribution helpers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+Thanks for reporting an issue with ContainerPilot!
+
+If you're reporting a problem, having trouble with a configuration, or think you've found a bug, please be sure to include the following information:
+
+- what is happening and what you expect to see
+- the output of `containerpilot -version`
+- the ContainerPilot configuration you're using
+- the output of any logs you can share; if you can it would be very helpful to turn on debug logging by adding `logging: { level: "DEBUG"}` to your ContainerPilot configuration.
+
+If you can't provide some of this information because it's private, include what you can and we'll try to assist anyways. If you're a Joyent customer you can also reach out to Joyent's support team.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Thanks for contributing to ContainerPilot! Please include with your pull request:
+
+- A description of what you did for the changelog
+- An explanation of why ContainerPilot needs this change
+- How to verify that it works (most PRs need tests!)
+- A link to the GitHub issue that it addresses
+
+If you're contributing a new feature, it's usually better to open an issue to discuss the feature rather than open a pull request unless the feature is trivial.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 ## Contributing
 
-Please report any issues you encounter with ContainerPilot or its documentation by opening a Github issue (https://github.com/joyent/containerpilot/issues). Roadmap items will be maintained as [enhancements](https://github.com/joyent/containerpilot/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement). PRs are welcome on any issue.
+ContainerPilot is open source under the [Mozilla Public License 2.0](https://github.com/joyent/containerpilot/blob/master/LICENSE).
 
+Pull requests on GitHub are welcome on any issue. If you'd like to propose a new feature, it's often a good idea to discuss the design by opening an issue first. We'll mark these as [`proposals`](https://github.com/joyent/containerpilot/issues?q=is%3Aopen+is%3Aissue+label%3Aproposal), and roadmap items will be maintained as [`enhancements`](https://github.com/joyent/containerpilot/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement).
 
-Thanks to the following contributors:
-- [@bbox-kula](https://github.com/bbox-kula): [first steps to allowing multiple discovery backends](https://github.com/joyent/containerpilot/pull/4)
-- [@justenwalker](https://github.com/justenwalker): hooks for preStop and postStop, deregistering services on SIGTERM, config templates, TravisCI integration, improved interface config parsing, and many many more code contributions.
-- [@wleese](https://github.com/wleese): [support for CONSUL_HTTP_TOKEN auth](https://github.com/joyent/containerpilot/pull/79)
+Many of our contributors have never contributed to an open source golang project before. If you are looking for a good first contribution, check out the [`help wanted` label](https://github.com/joyent/containerpilot/issues?q=is%3Aopen+is%3Aissue+label%3A"help+wanted"); not that we don't want help anywhere else of course! But these are low-hanging fruit to get started.
+
+Please make sure you've added tests for any new feature or tests that prove a bug has been fixed. Run `make lint` before submitting your PR. We test ContainerPilot on [TravisCI](https://travis-ci.org/joyent/containerpilot).


### PR DESCRIPTION
This PR updates the CONTRIBUTING.md document to match the text of the [docs/support](https://github.com/joyent/containerpilot/blob/master/docs/40-support.md#contributing) page. It also adds an issue template and PR template so that we can take advantage of [GitHub's issue/PR template feature](https://github.com/blog/2111-issue-and-pull-request-templates).

cc @misterbisson @heyawhite  @cheapRoc @geek for review