### PR TITLE
support datacenter field in watch configuration

### DIFF
--- a/discovery/consul.go
+++ b/discovery/consul.go
@@ -73,8 +73,9 @@ func (c *Consul) ServiceDeregister(serviceID string) error {
 // CheckForUpstreamChanges requests the set of healthy instances of a
 // service from Consul and checks whether there has been a change since
 // the last check.
-func (c *Consul) CheckForUpstreamChanges(backendName, backendTag string) (didChange, isHealthy bool) {
-	instances, meta, err := c.Health().Service(backendName, backendTag, true, nil)
+func (c *Consul) CheckForUpstreamChanges(backendName, backendTag, dc string) (didChange, isHealthy bool) {
+	opts := &api.QueryOptions{Datacenter: dc}
+	instances, meta, err := c.Health().Service(backendName, backendTag, true, opts)
 	if err != nil {
 		log.Warnf("failed to query %v: %s [%v]", backendName, err, meta)
 		return false, false

--- a/discovery/consul_test.go
+++ b/discovery/consul_test.go
@@ -134,19 +134,19 @@ func testConsulCheckForChanges(t *testing.T) {
 	consul, _ := NewConsul(testServer.HTTPAddr)
 	service := generateServiceDefinition(backend, consul)
 	id := service.ID
-	if changed, _ := consul.CheckForUpstreamChanges(backend, ""); changed {
+	if changed, _ := consul.CheckForUpstreamChanges(backend, "", ""); changed {
 		t.Fatalf("First read of %s should show `false` for change", id)
 	}
 	service.SendHeartbeat() // force registration and 1st heartbeat
 
-	if changed, _ := consul.CheckForUpstreamChanges(backend, ""); !changed {
+	if changed, _ := consul.CheckForUpstreamChanges(backend, "", ""); !changed {
 		t.Errorf("%v should have changed after first health check TTL", id)
 	}
-	if changed, _ := consul.CheckForUpstreamChanges(backend, ""); changed {
+	if changed, _ := consul.CheckForUpstreamChanges(backend, "", ""); changed {
 		t.Errorf("%v should not have changed without TTL expiring", id)
 	}
 	consul.Agent().UpdateTTL(id, "expired", "critical")
-	if changed, _ := consul.CheckForUpstreamChanges(backend, ""); !changed {
+	if changed, _ := consul.CheckForUpstreamChanges(backend, "", ""); !changed {
 		t.Errorf("%v should have changed after TTL expired.", id)
 	}
 }
@@ -164,7 +164,7 @@ func testConsulEnableTagOverride(t *testing.T) {
 		Consul:            consul,
 	}
 	id := service.ID
-	if changed, _ := consul.CheckForUpstreamChanges(backend, ""); changed {
+	if changed, _ := consul.CheckForUpstreamChanges(backend, "", ""); changed {
 		t.Fatalf("First read of %s should show `false` for change", id)
 	}
 	service.SendHeartbeat() // force registration

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -4,7 +4,7 @@ import "github.com/hashicorp/consul/api"
 
 // Backend is an interface which all service discovery backends must implement
 type Backend interface {
-	CheckForUpstreamChanges(backendName string, backendTag string) (bool, bool)
+	CheckForUpstreamChanges(service, tag, dc string) (bool, bool)
 	CheckRegister(check *api.AgentCheckRegistration) error
 	PassTTL(checkID, note string) error
 	ServiceDeregister(serviceID string) error

--- a/docs/30-configuration/35-watches.md
+++ b/docs/30-configuration/35-watches.md
@@ -9,12 +9,13 @@ watches: [
   {
     name: "backend",
     interval: 3,
-    tag: "prod" // optional
+    tag: "prod",    // optional
+    dc: "us-east-1" // optional
   }
 ]
 ```
 
-The `interval` is the time (in seconds) between polling attempts to Consul. The `name` is the service to query and the `tag` is the optional tag to add to the query.
+The `interval` is the time (in seconds) between polling attempts to Consul. The `name` is the service to query, the `tag` is the optional tag to add to the query, and the `dc` is the optional Consul [datacenter](https://www.consul.io/docs/guides/datacenters.html) to query.
 
 A watch keeps an in-memory list of the healthy IP addresses associated with the service. The list is not persisted to disk and if ContainerPilot is restarted it will need to check back in with the canonical data store, which is Consul. If this list changes between polls, the watch emits one or two events:
 

--- a/tests/mocks/discovery.go
+++ b/tests/mocks/discovery.go
@@ -11,7 +11,7 @@ type NoopDiscoveryBackend struct {
 // CheckForUpstreamChanges will return the public Val field to mock
 // whether a change has occurred. Will not report a change on the second
 // check unless the Val has been updated externally by the test rig
-func (noop *NoopDiscoveryBackend) CheckForUpstreamChanges(backend, tag string) (didChange, isHealthy bool) {
+func (noop *NoopDiscoveryBackend) CheckForUpstreamChanges(_, _, _ string) (didChange, isHealthy bool) {
 	if noop.lastVal != noop.Val {
 		didChange = true
 	}

--- a/watches/config.go
+++ b/watches/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	serviceName      string
 	Poll             int    `mapstructure:"interval"` // time in seconds
 	Tag              string `mapstructure:"tag"`
+	DC               string `mapstructure:"dc"` // Consul datacenter
 	discoveryService discovery.Backend
 }
 

--- a/watches/config_test.go
+++ b/watches/config_test.go
@@ -22,6 +22,10 @@ func TestWatchesParse(t *testing.T) {
 		"expected %v for Name got %v")
 	assert.Equal(t, watches[0].Poll, 11,
 		"expected %v for Poll got %v")
+	assert.Equal(t, watches[0].Tag, "dev",
+		"expected %v for Tag got %v")
+	assert.Equal(t, watches[0].DC, "",
+		"expected %v for DC got %v")
 
 	assert.Equal(t, watches[1].serviceName, "upstreamB",
 		"expected %v for serviceName got %v")
@@ -29,6 +33,8 @@ func TestWatchesParse(t *testing.T) {
 		"expected %v for Name got %v")
 	assert.Equal(t, watches[1].Poll, 79,
 		"expected %v for Poll got %v")
+	assert.Equal(t, watches[1].DC, "us-east-1",
+		"expected %v for DC got %v")
 }
 
 func TestWatchesConfigError(t *testing.T) {

--- a/watches/testdata/TestWatchesParse.json5
+++ b/watches/testdata/TestWatchesParse.json5
@@ -6,6 +6,7 @@
   },
   {
     name: "upstreamB",
-    interval: 79
+    interval: 79,
+    dc: "us-east-1"
   }
 ]

--- a/watches/watches.go
+++ b/watches/watches.go
@@ -16,6 +16,7 @@ type Watch struct {
 	Name             string
 	serviceName      string
 	tag              string
+	dc               string
 	poll             int
 	discoveryService discovery.Backend
 
@@ -28,6 +29,7 @@ func NewWatch(cfg *Config) *Watch {
 		Name:             cfg.Name,
 		serviceName:      cfg.serviceName,
 		tag:              cfg.Tag,
+		dc:               cfg.DC,
 		poll:             cfg.Poll,
 		discoveryService: cfg.discoveryService,
 	}
@@ -48,7 +50,7 @@ func FromConfigs(cfgs []*Config) []*Watch {
 // CheckForUpstreamChanges checks the service discovery endpoint for any changes
 // in a dependent backend. Returns true when there has been a change.
 func (watch *Watch) CheckForUpstreamChanges() (bool, bool) {
-	return watch.discoveryService.CheckForUpstreamChanges(watch.serviceName, watch.tag)
+	return watch.discoveryService.CheckForUpstreamChanges(watch.serviceName, watch.tag, watch.dc)
 }
 
 // Run executes the event loop for the Watch


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/288

This PR adds support for multi-DC Consul setups, simply by adding a `dc` field to the `watch` configuration. Services in Consul are already inherently registered with a particular DC by dint of being registered with a particular node, so there really wasn't much to do here and it's all pass-thru to the Consul API.

cc @cheapRoc @misterbisson