### PR TITLE
support TLS for Consul client

### DIFF
--- a/discovery/config.go
+++ b/discovery/config.go
@@ -1,34 +1,86 @@
 package discovery
 
 import (
+	"os"
 	"strings"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/joyent/containerpilot/utils"
 )
 
+type parsedConfig struct {
+	Address string `mapstructure:"address"`
+	Scheme  string `mapstructure:"scheme"`
+	Token   string `mapstructure:"token"`
+
+	// optional TLS settings
+	HTTPCAFile        string `mapstructure:"tlscafile"`
+	HTTPCAPath        string `mapstructure:"tlscapath"`
+	HTTPClientCert    string `mapstructure:"tlsclientcert"`
+	HTTPClientKey     string `mapstructure:"tlsclientkey"`
+	HTTPTLSServerName string `mapstructure:"tlsservername"`
+	HTTPSSLVerify     bool   `mapstructure:"tlsverify"`
+}
+
+// override an already-parsed parsedConfig with any options that might
+// be set in the environment and then return the TLSConfig
+func getTLSConfig(parsed *parsedConfig) api.TLSConfig {
+	if cafile := os.Getenv("CONSUL_CACERT"); cafile != "" {
+		parsed.HTTPCAFile = cafile
+	}
+	if capath := os.Getenv("CONSUL_CAPATH"); capath != "" {
+		parsed.HTTPCAPath = capath
+	}
+	if clientCert := os.Getenv("CONSUL_CLIENT_CERT"); clientCert != "" {
+		parsed.HTTPClientCert = clientCert
+	}
+	if clientKey := os.Getenv("CONSUL_CLIENT_KEY"); clientKey != "" {
+		parsed.HTTPClientKey = clientKey
+	}
+	if serverName := os.Getenv("CONSUL_TLS_SERVER_NAME"); serverName != "" {
+		parsed.HTTPClientKey = serverName
+	}
+	verify := os.Getenv("CONSUL_HTTP_SSL_VERIFY")
+	switch strings.ToLower(verify) {
+	case "1", "true":
+		parsed.HTTPSSLVerify = true
+	case "0", "false":
+		parsed.HTTPSSLVerify = false
+	}
+	tlsConfig := api.TLSConfig{
+		Address:            parsed.HTTPTLSServerName,
+		CAFile:             parsed.HTTPCAPath,
+		CertFile:           parsed.HTTPCAPath,
+		KeyFile:            parsed.HTTPClientKey,
+		InsecureSkipVerify: !parsed.HTTPSSLVerify,
+	}
+	return tlsConfig
+}
+
 func configFromMap(raw map[string]interface{}) (*api.Config, error) {
-	config := &struct {
-		Address string `mapstructure:"address"`
-		Scheme  string `mapstructure:"scheme"`
-		Token   string `mapstructure:"token"`
-	}{}
-	if err := utils.DecodeRaw(raw, config); err != nil {
+	parsed := &parsedConfig{}
+	if err := utils.DecodeRaw(raw, parsed); err != nil {
 		return nil, err
 	}
-	return &api.Config{
-		Address: config.Address,
-		Scheme:  config.Scheme,
-		Token:   config.Token,
-	}, nil
+	config := &api.Config{
+		Address:   parsed.Address,
+		Scheme:    parsed.Scheme,
+		Token:     parsed.Token,
+		TLSConfig: getTLSConfig(parsed),
+	}
+	return config, nil
 }
 
 func configFromURI(uri string) (*api.Config, error) {
 	address, scheme := parseRawURI(uri)
-	return &api.Config{
-		Address: address,
-		Scheme:  scheme,
-	}, nil
+	parsed := &parsedConfig{Address: address, Scheme: scheme}
+	config := &api.Config{
+		Address:   parsed.Address,
+		Scheme:    parsed.Scheme,
+		Token:     parsed.Token,
+		TLSConfig: getTLSConfig(parsed),
+	}
+	return config, nil
 }
 
 // Returns the uri broken into an address and scheme portion

--- a/discovery/consul_test.go
+++ b/discovery/consul_test.go
@@ -80,7 +80,7 @@ ref https://github.com/hashicorp/consul/tree/master/testutil
 var testServer *testutil.TestServer
 
 func TestWithConsul(t *testing.T) {
-	testServer = testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
+	testServer, _ = testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.LogLevel = "err"
 	})
 	defer testServer.Stop()

--- a/docs/30-configuration/33-consul.md
+++ b/docs/30-configuration/33-consul.md
@@ -11,13 +11,14 @@ consul: {
   address: "consul.example.com:8500",
   scheme: "https",
   token: "aba7cbe5-879b-999a-07cc-2efd9ac0ffe", // or CONSUL_HTTP_TOKEN
-
-  tlscafile: "ca.crt",                 // or CONSUL_CACERT
-  tlscapath: "ca_certs/",              // or CONSUL_CAPATH
-  tlsclientcert: "client.crt",         // or CONSUL_CLIENT_CERT
-  tlsclientkey: "client.key",          // or CONSUL_CLIENT_KEY
-  tlsservername: "consul.example.com", // or CONSUL_TLS_SERVER_NAME
-  tlsverify: true,                     // or CONSUL_HTTP_SSL_VERIFY
+  tls: {
+    cafile: "ca.crt",                 // or CONSUL_CACERT
+    capath: "ca_certs/",              // or CONSUL_CAPATH
+    clientcert: "client.crt",         // or CONSUL_CLIENT_CERT
+    clientkey: "client.key",          // or CONSUL_CLIENT_KEY
+    servername: "consul.example.com", // or CONSUL_TLS_SERVER_NAME
+    verify: true,                     // or CONSUL_HTTP_SSL_VERIFY
+  }
 }
 ```
 

--- a/docs/30-configuration/33-consul.md
+++ b/docs/30-configuration/33-consul.md
@@ -4,8 +4,22 @@ ContainerPilot uses Hashicorp's [Consul](https://www.consul.io/) to register job
 
 ## Client configuration
 
-The `consul` field in the ContainerPilot config file configures ContainerPilot's Consul client. For use with Consul's ACL system, use the `CONSUL_HTTP_TOKEN` environment variable. If you are communicating with Consul over TLS you may include the scheme (ex. https://consul:8500):
+The `consul` field in the ContainerPilot config file configures ContainerPilot's Consul client. For use with Consul's ACL system, use the `CONSUL_HTTP_TOKEN` environment variable. If you are communicating with Consul over TLS you may include the scheme (ex. https://consul:8500). Note that generally the Consul client will be communicating to an agent on localhost, so TLS may not b necessary. If you need extra configuration options for TLS, you can use the following optional fields (or environment variable options described in the [Consul documentation](https://www.consul.io/docs/commands/index.html#environment-variables))instead of a simple string:
 
+```json5
+consul: {
+  address: "consul.example.com:8500",
+  scheme: "https",
+  token: "aba7cbe5-879b-999a-07cc-2efd9ac0ffe", // or CONSUL_HTTP_TOKEN
+
+  tlscafile: "ca.crt",                 // or CONSUL_CACERT
+  tlscapath: "ca_certs/",              // or CONSUL_CAPATH
+  tlsclientcert: "client.crt",         // or CONSUL_CLIENT_CERT
+  tlsclientkey: "client.key",          // or CONSUL_CLIENT_KEY
+  tlsservername: "consul.example.com", // or CONSUL_TLS_SERVER_NAME
+  tlsverify: true,                     // or CONSUL_HTTP_SSL_VERIFY
+}
+```
 
 ## Consul agent configuration
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7a72ba93b39a5a461759ab476bfaabbf4e105deb67f93adc1bfda8e10b2e0fd7
-updated: 2017-04-05T15:10:03.856365456-04:00
+hash: 4d1f003a7ecfbdf9a7c02771b8b0ff92401f76950ae1e91afce73481fbb98207
+updated: 2017-06-15T17:52:02.0614202Z
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -14,11 +14,17 @@ imports:
   subpackages:
   - proto
 - name: github.com/hashicorp/consul
-  version: 21f2d5ad0c02af6c4b32d8fd04f7c81e9b002d41
+  version: f4360770d8e7b852e2d05835b583d20799e58133
   subpackages:
   - api
+  - testutil
+  - testutil/retry
 - name: github.com/hashicorp/go-cleanhttp
   version: 3573b8b52aa7b37b9358d966a898feb387f62437
+- name: github.com/hashicorp/go-rootcerts
+  version: 6bb64b370b90e7ef1fa532be9e591a81c3493e00
+- name: github.com/hashicorp/go-uuid
+  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
 - name: github.com/hashicorp/serf
   version: 19f2c401e122352c047a84d6584dd51e2fb8fcc4
   subpackages:
@@ -27,8 +33,12 @@ imports:
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
+- name: github.com/mitchellh/go-homedir
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
+- name: github.com/pkg/errors
+  version: c605e284fe17294bda444b34710735b29d1a9d90
 - name: github.com/prometheus/client_golang
   version: 90c15b5efa0dc32a7d259234e02ac9a99e6d3b82
   subpackages:
@@ -57,4 +67,4 @@ imports:
   version: 50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e
   subpackages:
   - unix
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/Sirupsen/logrus
   version: ~0.9.0
 - package: github.com/hashicorp/consul
-  version: ~0.7.0
+  version: ~0.8.4
   subpackages:
   - api
 - package: github.com/matttproud/golang_protobuf_extensions


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/169

This extends the existing (but poorly undocumented) option to have additional options passed to the Consul client configuration to include TLS config. Note that _most_ users will never need this, as they're going to be communicating to the Consul agent inside the container or to an agent on localhost on the host.

The configuration looks like the following:

```json5
consul: {
  address: "consul.example.com:8500",
  scheme: "https",
  token: "aba7cbe5-879b-999a-07cc-2efd9ac0ffe", // or CONSUL_HTTP_TOKEN

  tlscafile: "ca.crt",                 // or CONSUL_CACERT
  tlscapath: "ca_certs/",              // or CONSUL_CAPATH
  tlsclientcert: "client.crt",         // or CONSUL_CLIENT_CERT
  tlsclientkey: "client.key",          // or CONSUL_CLIENT_KEY
  tlsservername: "consul.example.com", // or CONSUL_TLS_SERVER_NAME
  tlsverify: true,                     // or CONSUL_HTTP_SSL_VERIFY
}
```

I had to bump our Consul API bindings version to get this all to work. The big thing I don't like here is the lack of testing because of how painful setting up the TLS server would be, but even the upstream Consul client API doesn't test this stuff ( ☹️  ).

cc @cheapRoc 