### PR TITLE
remove accidental gnu-sed assumption in kirby doc gen

### DIFF
--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+set -eu
 
 # rewrites the title as Kirby front-matter (in-place)
 addFrontMatter() {
-    title=$(head -1 "$1" | sed -r 's/^# //')
+    title=$(head -1 "$1" | sed 's/^# //')
     body=$(tail -n +2 "$1")
     {
         echo "Title: $title"
@@ -16,26 +17,27 @@ addFrontMatter() {
 
 # rewrites all markdown links to indexes (in-place)
 rewriteLinks() {
-    sed -i 's/\.md//g' "$1"
+    sed -i '.bak' 's/\.md//g' "$1"
+    rm "${1}.bak"
 }
 
 for file in $(find docs -name '*-*.md'); do
     x=$(basename "$file")
     dir=$(dirname "$file")
     f=${x%.md}
-    buildDir="build/$dir/$f"
+    buildDir="./build/${dir}/${f}"
     mkdir -p "$buildDir"
-    cp "$file" "$buildDir/docs.md"
-    addFrontMatter "$buildDir/docs.md"
-    rewriteLinks "$buildDir/docs.md"
+    cp "$file" "${buildDir}/docs.md"
+    addFrontMatter "${buildDir}/docs.md"
+    rewriteLinks "${buildDir}/docs.md"
 done
 
 # top-level index is weird exception to the structure
 buildDir="build/docs/00-index"
 mkdir -p "$buildDir"
-cp docs/README.md "$buildDir/docs.md"
-addFrontMatter "$buildDir/docs.md"
-rewriteLinks "$buildDir/docs.md"
+cp docs/README.md "${buildDir}/docs.md"
+addFrontMatter "${buildDir}/docs.md"
+rewriteLinks "${buildDir}/docs.md"
 
 # configuration examples in JSON5 format
 cp -R docs/30-configuration/examples build/docs/30-configuration/examples


### PR DESCRIPTION
For #402 

The doc generation script accidentally had a GNU-sed-ism in there. I've removed that and generally cleaned up the script so that it's more robust bash.

cc @fitzage 