### PR TITLE
fix failure to update TTL because checkID != service.ID

### DIFF
--- a/discovery/service.go
+++ b/discovery/service.go
@@ -48,7 +48,8 @@ func (service *ServiceDefinition) SendHeartbeat() error {
 		service.wasRegistered = true
 		return nil
 	}
-	if err := service.Consul.PassTTL(service.ID, "ok"); err != nil {
+	checkID := fmt.Sprintf("service:%s", service.ID)
+	if err := service.Consul.PassTTL(checkID, "ok"); err != nil {
 		log.Infof("service not registered: %v", err)
 		if err = service.registerService(); err != nil {
 			log.Warnf("service registration failed: %s", err)


### PR DESCRIPTION
This PR fixes a bug I discovered in https://github.com/joyent/containerpilot/pull/403. The check ID is no longer the same as the service ID (as noted in the original), so we end up re-registering over and over again instead of simply updating the TTL.

cc @cheapRoc 