### PR TITLE
add /v3/ping endpoint to control socket

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -96,3 +96,18 @@ func (c HTTPClient) PutMetric(body string) error {
 	}
 	return nil
 }
+
+// GetPing make a request to the ping endpoint of the ContainerPilot control
+// socket, to verify it's listening
+func (c HTTPClient) GetPing() error {
+	resp, err := c.Get("http://control/v3/ping")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return fmt.Errorf("unprocessable entity received by control server")
+	}
+	return nil
+}

--- a/control/control.go
+++ b/control/control.go
@@ -71,6 +71,7 @@ func (srv *HTTPServer) Start() {
 		PostHandler(endpoints.PostEnableMaintenanceMode))
 	router.Handle("/v3/maintenance/disable",
 		PostHandler(endpoints.PostDisableMaintenanceMode))
+	router.HandleFunc("/v3/ping", GetPing)
 
 	srv.Handler = router
 	srv.SetKeepAlivesEnabled(false)

--- a/control/endpoints.go
+++ b/control/endpoints.go
@@ -120,3 +120,11 @@ func (e Endpoints) PostMetric(r *http.Request) (interface{}, int) {
 	}
 	return nil, http.StatusOK
 }
+
+// GetPing allows us to check if the control socket is up without
+// making a mutation of ContainerPilot's state
+func GetPing(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	w.WriteHeader(http.StatusOK)
+	io.WriteString(w, "\n")
+}

--- a/control/endpoints_test.go
+++ b/control/endpoints_test.go
@@ -205,3 +205,13 @@ func TestPostDisableMaintenanceMode(t *testing.T) {
 		assert.Equal(t, status, http.StatusOK, "status was not 200OK")
 	})
 }
+
+func TestGetPing(t *testing.T) {
+	req := httptest.NewRequest("GET", "/v3/ping", nil)
+	w := httptest.NewRecorder()
+	GetPing(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+	status := resp.StatusCode
+	assert.Equal(t, status, 200, "expected HTTP 200 OK")
+}

--- a/core/app.go
+++ b/core/app.go
@@ -51,16 +51,19 @@ func EmptyApp() *App {
 // LoadApp parses the commandline arguments and loads the config
 func LoadApp() (*App, error) {
 
-	var versionFlag bool
-	var templateFlag bool
-	var reloadFlag bool
+	var (
+		versionFlag  bool
+		templateFlag bool
+		reloadFlag   bool
 
-	var configFlag string
-	var renderFlag string
-	var maintFlag string
+		configFlag string
+		renderFlag string
+		maintFlag  string
 
-	var putMetricFlags MultiFlag
-	var putEnvFlags MultiFlag
+		putMetricFlags MultiFlag
+		putEnvFlags    MultiFlag
+		pingFlag       bool
+	)
 
 	if !flag.Parsed() {
 		flag.BoolVar(&versionFlag, "version", false,
@@ -90,6 +93,9 @@ func LoadApp() (*App, error) {
 		flag.Var(&putEnvFlags, "putenv",
 			`Update environ of a ContainerPilot process through its control socket.
 	Pass environment in the format: 'key=value'`)
+
+		flag.BoolVar(&pingFlag, "ping", false,
+			"Check that the ContainerPilot control socket is up.")
 
 		flag.Parse()
 	}
@@ -155,6 +161,18 @@ func LoadApp() (*App, error) {
 			return nil,
 				fmt.Errorf("-putmetric: failed to run subcommand: %v", err)
 		}
+		os.Exit(0)
+	}
+
+	if pingFlag {
+		cmd, err := subcommands.Init(configFlag)
+		if err != nil {
+			return nil, err
+		}
+		if err := cmd.GetPing(); err != nil {
+			return nil, fmt.Errorf("-ping: failed: %v", err)
+		}
+		fmt.Println("ok")
 		os.Exit(0)
 	}
 

--- a/docs/30-configuration/37-control-plane.md
+++ b/docs/30-configuration/37-control-plane.md
@@ -17,6 +17,8 @@ Usage of ./containerpilot:
   -out string
         File path where to save rendered config file when '-template' is used.
         Defaults to stdout ('-').
+  -ping
+        Check that the ContainerPilot control socket is up.
   -putenv value
         Update environ of a ContainerPilot process through its control socket.
         Pass environment in the format: 'key=value'
@@ -116,4 +118,30 @@ Content-Length: 21
 {
   "updated": true
 }
+```
+
+
+##### `Ping GET /v3/ping`
+
+This API checks if the ContainerPilot socket is up without mutating any state. This endpoint returns a HTTP200 if the socket is up.
+
+*Example Subcommand*
+
+```
+./containerpilot -ping
+```
+
+*Example HTTP Request*
+
+```
+curl --unix-socket /var/containerpilot.sock \
+    http:/v3/ping
+```
+
+*Example Response*
+
+```
+HTTP/1.1 200 OK
+Content-Length: 2
+ok
 ```

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -81,3 +81,8 @@ func (s Subcommand) SendMetric(metrics map[string]string) error {
 
 	return nil
 }
+
+// GetPing fires a ping check through the HTTPClient.
+func (s Subcommand) GetPing() error {
+	return s.client.GetPing()
+}


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/348

Because all other control socket endpoints change ContainerPilot's state, we need an endpoint that verifies if the socket is listening. Also added the appropriate subcommand and docs. Note that this is not the same as the `/status` endpoint, which is covered by #408, because the control socket is a different listener so we want a diagnostic endpoint for both server.

cc @cheapRoc @misterbisson