### PR TITLE
factor argument parsing out of LoadApp

### DIFF
--- a/core/flags.go
+++ b/core/flags.go
@@ -1,8 +1,12 @@
 package core
 
 import (
+	"flag"
 	"fmt"
+	"os"
 	"strings"
+
+	"github.com/joyent/containerpilot/subcommands"
 )
 
 // MultiFlag provides a custom CLI flag that stores its unique values into a
@@ -36,4 +40,102 @@ func (f *MultiFlag) Set(value string) error {
 // Len is the length of the slice of values for this MultiFlag.
 func (f MultiFlag) Len() int {
 	return len(f.Values)
+}
+
+// GetArgs parses the command line flags and returns the subcommand
+// we need and its parameters (if any)
+func GetArgs() (subcommands.Handler, subcommands.Params) {
+
+	var versionFlag bool
+	var templateFlag bool
+	var reloadFlag bool
+	var pingFlag bool
+
+	var configPath string
+	var renderFlag string
+	var maintFlag string
+
+	var putMetricFlags MultiFlag
+	var putEnvFlags MultiFlag
+
+	if !flag.Parsed() {
+		flag.BoolVar(&versionFlag, "version", false,
+			"Show version identifier and quit.")
+
+		flag.BoolVar(&templateFlag, "template", false,
+			"Render template and quit.")
+
+		flag.BoolVar(&reloadFlag, "reload", false,
+			"Reload a ContainerPilot process through its control socket.")
+
+		flag.StringVar(&configPath, "config", "",
+			"File path to JSON5 configuration file. Defaults to CONTAINERPILOT env var.")
+
+		flag.StringVar(&renderFlag, "out", "",
+			`File path where to save rendered config file when '-template' is used.
+	Defaults to stdout ('-').`)
+
+		flag.StringVar(&maintFlag, "maintenance", "",
+			`Toggle maintenance mode for a ContainerPilot process through its control socket.
+	Options: '-maintenance enable' or '-maintenance disable'`)
+
+		flag.Var(&putMetricFlags, "putmetric",
+			`Update metrics of a ContainerPilot process through its control socket.
+	Pass metrics in the format: 'key=value'`)
+
+		flag.Var(&putEnvFlags, "putenv",
+			`Update environ of a ContainerPilot process through its control socket.
+	Pass environment in the format: 'key=value'`)
+
+		flag.BoolVar(&pingFlag, "ping", false,
+			"Check that the ContainerPilot control socket is up.")
+
+		flag.Parse()
+	}
+
+	if versionFlag {
+		return subcommands.VersionHandler, subcommands.Params{
+			Version: Version,
+			GitHash: GitHash,
+		}
+	}
+	if configPath == "" {
+		configPath = os.Getenv("CONTAINERPILOT")
+	}
+	if templateFlag {
+		return subcommands.RenderHandler, subcommands.Params{
+			ConfigPath: configPath,
+			RenderFlag: renderFlag,
+		}
+	}
+	if reloadFlag {
+		return subcommands.ReloadHandler, subcommands.Params{
+			ConfigPath: configPath,
+		}
+	}
+	if maintFlag != "" {
+		return subcommands.MaintenanceHandler, subcommands.Params{
+			ConfigPath:      configPath,
+			MaintenanceFlag: maintFlag,
+		}
+	}
+	if putEnvFlags.Len() != 0 {
+		return subcommands.PutEnvHandler, subcommands.Params{
+			ConfigPath: configPath,
+			Env:        putEnvFlags.Values,
+		}
+	}
+	if putMetricFlags.Len() != 0 {
+		return subcommands.PutMetricsHandler, subcommands.Params{
+			ConfigPath: configPath,
+			Metrics:    putMetricFlags.Values,
+		}
+	}
+	if pingFlag {
+		return subcommands.GetPingHandler, subcommands.Params{
+			ConfigPath: configPath,
+		}
+	}
+
+	return nil, subcommands.Params{ConfigPath: configPath}
 }

--- a/core/flags_test.go
+++ b/core/flags_test.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/joyent/containerpilot/tests/assert"
+)
+
+func TestInvalidConfigNoConfigFlag(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	os.Args = []string{"this", "/testdata/test.sh", "invalid1", "--debug"}
+	_, p := GetArgs()
+	if _, err := NewApp(p.ConfigPath); err != nil && err.Error() != "-config flag is required" {
+		t.Errorf("expected error but got %s", err)
+	}
+}
+
+func TestInvalidConfigParseNoDiscovery(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	f1 := testCfgToTempFile(t, "{}")
+	defer os.Remove(f1.Name())
+	os.Args = []string{"this", "-config", f1.Name()}
+	_, p := GetArgs()
+	_, err := NewApp(p.ConfigPath)
+	assert.Error(t, err, "no discovery backend defined")
+}
+
+func TestInvalidConfigMissingFile(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	os.Args = []string{"this", "-config", "/xxxx"}
+	_, p := GetArgs()
+	_, err := NewApp(p.ConfigPath)
+	assert.Error(t, err,
+		"could not read config file: open /xxxx: no such file or directory")
+}
+
+func TestInvalidConfigParseNotJson(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	f1 := testCfgToTempFile(t, "<>")
+	defer os.Remove(f1.Name())
+	os.Args = []string{"this", "-config", f1.Name()}
+	_, p := GetArgs()
+	_, err := NewApp(p.ConfigPath)
+	assert.Error(t, fmt.Errorf("%s", err.Error()[:29]),
+		"parse error at line:col [1:1]")
+}
+
+func TestInvalidConfigParseTemplateError(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	// this config is missing quotes around the template
+	f1 := testCfgToTempFile(t, `{"test": {{ .NO_SUCH_KEY }}, "test2": "hello"}`)
+	defer os.Remove(f1.Name())
+	os.Args = []string{"this", "-config", f1.Name()}
+	_, p := GetArgs()
+	_, err := NewApp(p.ConfigPath)
+	assert.Error(t, fmt.Errorf("%s", err.Error()[:30]),
+		"parse error at line:col [1:10]")
+}
+
+func TestControlServerCreation(t *testing.T) {
+	f1 := testCfgToTempFile(t, `{"consul": "consul:8500"}`)
+	defer os.Remove(f1.Name())
+	app, err := NewApp(f1.Name())
+	if err != nil {
+		t.Fatalf("got error while initializing config: %v", err)
+	}
+	if app.ControlServer == nil {
+		t.Error("expected control server to not be nil")
+	}
+}
+
+func TestPidEnvVar(t *testing.T) {
+	defer argTestCleanup(argTestSetup())
+	os.Args = []string{"this", "-config", "{}", "/testdata/test.sh"}
+	_, p := GetArgs()
+	NewApp(p.ConfigPath)
+	if pid := os.Getenv("CONTAINERPILOT_PID"); pid == "" {
+		t.Errorf("expected CONTAINERPILOT_PID to be set even on error")
+	}
+}
+
+// ----------------------------------------------------
+// test helpers
+
+func argTestSetup() []string {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flag.Usage = nil
+	return os.Args
+}
+
+func argTestCleanup(oldArgs []string) {
+	os.Args = oldArgs
+}

--- a/main.go
+++ b/main.go
@@ -13,7 +13,16 @@ func main() {
 	// contention on the main application
 	runtime.GOMAXPROCS(1)
 
-	app, configErr := core.LoadApp()
+	subcommand, params := core.GetArgs()
+	if subcommand != nil {
+		err := subcommand(params)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	app, configErr := core.NewApp(params.ConfigPath)
 	if configErr != nil {
 		log.Fatal(configErr)
 	}


### PR DESCRIPTION
This PR breaks up the very large `core.LoadApp` in favor of having all the arg parsing in one place, and then letting `main.go` decide what to do with that. Not a critical fix of anything but the size of `LoadApp` was starting to get unwieldy.

cc @cheapRoc 