### PR TITLE
correctly restrict job starts and health checks

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -284,6 +284,11 @@ func (job *Job) processEvent(ctx context.Context, event events.Event) bool {
 			// if we have unlimited restarts we want to make sure we don't
 			// decrement forever and then wrap-around
 			job.startsRemain--
+			if job.startsRemain == 0 && job.restartsRemain == 0 {
+				// prevent ourselves from receiving the start event again
+				// if it fires while we're still running the job's exec
+				job.startEvent = events.NonEvent
+			}
 		}
 		job.StartJob(ctx)
 	}

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -210,6 +211,7 @@ func TestJobProcessEvent(t *testing.T) {
 			Name:         "testJob",
 			startEvent:   events.Event{events.StatusChanged, "upstream"},
 			startsRemain: unlimited,
+			statusLock:   &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
 		assert.False(t, got, "processEvent returned %v after 1st startEvent, expected %v")
@@ -236,6 +238,7 @@ func TestJobProcessEvent(t *testing.T) {
 			startsRemain:   1,
 			restartLimit:   2,
 			restartsRemain: 2,
+			statusLock:     &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
 		assert.False(t, got, "processEvent returned %v after 1st startEvent, expected %v")
@@ -261,6 +264,7 @@ func TestJobProcessEvent(t *testing.T) {
 			startsRemain:   0,
 			restartLimit:   unlimited,
 			restartsRemain: unlimited,
+			statusLock:     &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
 		assert.False(t, got, "processEvent returned %v after 1st exit, expected %v")
@@ -280,6 +284,7 @@ func TestJobProcessEvent(t *testing.T) {
 			startsRemain:   0,
 			restartLimit:   1,
 			restartsRemain: 1,
+			statusLock:     &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
 		assert.False(t, got, "processEvent returned %v after 1st exit, expected %v")

--- a/mysql.json5
+++ b/mysql.json5
@@ -1,0 +1,27 @@
+{
+  consul: "localhost:8500",
+  logging: { level: "DEBUG" },
+  jobs: [
+    {
+      name: "preStart",
+      exec: "sleep 20",
+      when: {
+        source: "consul-agent",
+        once: "healthy"
+      }
+    },
+    {
+      name: "consul-agent",
+      restarts: "unlimited",
+      exec: "sleep 1000",
+      health: {
+        exec: "sleep 1",
+        interval: 5,
+        ttl: 10
+      }
+    }
+  ],
+  control: {
+    socket: "./containerpilot.sock"
+  }
+}


### PR DESCRIPTION
In https://github.com/joyent/containerpilot/issues/417 we saw a fairly serious bug where a new start event can interrupt a long-running `exec` for the same job. This PR turns the start event into a no-op once we never expect to receive the event again.

In https://github.com/joyent/containerpilot/issues/415 we saw a somewhat related but more minor bug where health checks can start executing before the job's `exec` does. This is the same behavior as v2 but that behavior is incorrect in v3 where a job can potentially be waiting for another job's `ExitSuccess` event. This is particularly problematic when the health check has side-effects.

cc @cheapRoc @misterbisson 