### PR TITLE
update logrus to 1.0, use Entry.Writer to catch exec stdout

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4d1f003a7ecfbdf9a7c02771b8b0ff92401f76950ae1e91afce73481fbb98207
-updated: 2017-06-15T17:52:02.0614202Z
+hash: c78fd9afa84fae131536303beb1a73af84291e218d904c7eddddae2275562c91
+updated: 2017-07-03T20:08:48.202257396Z
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -14,7 +14,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/hashicorp/consul
-  version: f4360770d8e7b852e2d05835b583d20799e58133
+  version: 2c7715154d8d4568524b76d2d4deb7ca6fd1b285
   subpackages:
   - api
   - testutil
@@ -58,7 +58,7 @@ imports:
 - name: github.com/samalba/dockerclient
   version: a3036261847103270e9f732509f43b5f98710ace
 - name: github.com/Sirupsen/logrus
-  version: be52937128b38f1d99787bb476c789e2af1147f1
+  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: golang.org/x/net
   version: 7f88271ea9913b72aca44fa7fc8af919eacc17ce
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ homepage: https://www.joyent.com/containerpilot
 license: MPL-2.0
 import:
 - package: github.com/Sirupsen/logrus
-  version: ~0.9.0
+  version: 1.0.0
 - package: github.com/hashicorp/consul
   version: ~0.8.4
   subpackages:

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -338,7 +338,6 @@ func (job *Job) cleanup(ctx context.Context, cancel context.CancelFunc) {
 		}
 	}
 	cancel()
-	job.exec.CloseLogs()
 	job.Deregister()         // deregister from Consul
 	job.Unsubscribe(job.Bus) // deregister from events
 	job.Bus.Publish(events.Event{Code: events.Stopped, Source: job.Name})


### PR DESCRIPTION
For #393 and possibly #423 if it applies to v3

Fixes a regression in log formatting for exec stdout/stderr; we were creating a new logger without any of our configuration. In Logrus 1.0 we can access the Writer of a contextual logger and attach it to our process's stdout/stderr.

Will need to backport this to v2 as well.
