### PR TITLE
update logrus to 1.0, use Entry.Writer to catch exec stdout

### DIFF
--- a/backends/backends.go
+++ b/backends/backends.go
@@ -73,12 +73,8 @@ func (b *Backend) PollAction() {
 	}
 }
 
-// PollStop closes the Backends logs
-func (b *Backend) PollStop() {
-	if b.onChangeCmd != nil {
-		b.onChangeCmd.CloseLogs()
-	}
-}
+// PollStop is a no-op
+func (b *Backend) PollStop() {}
 
 // CheckForUpstreamChanges checks the service discovery endpoint for any changes
 // in a dependent backend. Returns true when there has been a change.

--- a/coprocesses/coprocess.go
+++ b/coprocesses/coprocess.go
@@ -143,6 +143,5 @@ func (c *Coprocess) Stop() {
 	c.restart = false
 	if c.cmd != nil {
 		c.cmd.Kill()
-		c.cmd.CloseLogs()
 	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 874e4f3d7d988b377f35781a0bc6b063efe4c70422072bc4a0ab8861fc2d4e7b
-updated: 2016-11-18T13:01:24.244820685-06:00
+hash: 833fd3f2a02483bc140e96a2ed74c57b46995a645c9767fc9de5d355c0eeb93c
+updated: 2017-07-03T20:29:44.437809506Z
 imports:
 - name: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
@@ -20,7 +20,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/hashicorp/consul
-  version: a9455cd4fc2809570ff1855c37d6ffc2449bd42f
+  version: 21f2d5ad0c02af6c4b32d8fd04f7c81e9b002d41
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
@@ -54,7 +54,7 @@ imports:
 - name: github.com/samalba/dockerclient
   version: a3036261847103270e9f732509f43b5f98710ace
 - name: github.com/Sirupsen/logrus
-  version: be52937128b38f1d99787bb476c789e2af1147f1
+  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: golang.org/x/net
   version: 7f88271ea9913b72aca44fa7fc8af919eacc17ce
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ homepage: https://www.joyent.com/containerpilot
 license: MPL-2.0
 import:
 - package: github.com/Sirupsen/logrus
-  version: ~0.9.0
+  version: 1.0.0
 - package: github.com/beorn7/perks
   version: b965b613227fddccbfffe13eae360ed3fa822f8d
   subpackages:

--- a/services/services.go
+++ b/services/services.go
@@ -152,12 +152,8 @@ func (s *Service) PollAction() {
 	}
 }
 
-// PollStop closes the Service's logs
-func (s *Service) PollStop() {
-	if s.healthCheckCmd != nil {
-		s.healthCheckCmd.CloseLogs()
-	}
-}
+// PollStop is a no-op
+func (s *Service) PollStop() {}
 
 // SendHeartbeat sends a heartbeat for this service
 func (s *Service) SendHeartbeat() {

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -79,7 +79,6 @@ func (t *Task) PollStop() {
 	log.Debugf("task[%s].PollStop", t.Name)
 	if t.cmd != nil {
 		t.cmd.Kill()
-		t.cmd.CloseLogs()
 	}
 }
 

--- a/telemetry/sensors.go
+++ b/telemetry/sensors.go
@@ -41,12 +41,8 @@ func (s *Sensor) PollAction() {
 	}
 }
 
-// PollStop closes the Sensor's logs
-func (s *Sensor) PollStop() {
-	if s.checkCmd != nil {
-		s.checkCmd.CloseLogs()
-	}
-}
+// PollStop is a no-op
+func (s *Sensor) PollStop() {}
 
 // wrapping this func call makes it easier to test
 func (s *Sensor) observe() (string, error) {


### PR DESCRIPTION
For #393 and possibly #423 if it applies to v3

Fixes a regression in log formatting for exec stdout/stderr; we were creating a new logger without any of our configuration. In Logrus 1.0 we can access the Writer of a contextual logger and attach it to our process's stdout/stderr.