### PR TITLE
Emit RFC3339 dates in logs

### DIFF
--- a/config/logging.go
+++ b/config/logging.go
@@ -76,11 +76,10 @@ func (l *LogConfig) init() error {
 type DefaultLogFormatter struct {
 }
 
-//RFC3339 formatter
+// RFC3339logWriter io.Writer that outputs RFC3339 dates
 type RFC3339logWriter struct {
 }
 
-// Define new time io.writer that outputs RFC3339 dates
 func (writer RFC3339logWriter) Write(bytes []byte) (int, error) {
 	return fmt.Print(time.Now().UTC().Format(time.RFC3339Nano) + " " + string(bytes))
 }

--- a/config/logging.go
+++ b/config/logging.go
@@ -81,7 +81,7 @@ type RFC3339logWriter struct {
 }
 
 func (writer RFC3339logWriter) Write(bytes []byte) (int, error) {
-	return fmt.Print(time.Now().UTC().Format(time.RFC3339Nano) + " " + string(bytes))
+	return fmt.Print(time.Now().Format(time.RFC3339Nano) + " " + string(bytes))
 }
 
 // Format formats the logrus entry by passing it to the "log" package

--- a/config/logging.go
+++ b/config/logging.go
@@ -76,6 +76,7 @@ func (l *LogConfig) init() error {
 type DefaultLogFormatter struct {
 }
 
+//RFC3339 formatter
 type RFC3339logWriter struct {
 }
 

--- a/config/logging.go
+++ b/config/logging.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"time"
 	"log"
 	"os"
 	"strings"
@@ -75,10 +76,19 @@ func (l *LogConfig) init() error {
 type DefaultLogFormatter struct {
 }
 
+type RFC3339logWriter struct {
+}
+
+// Define new time io.writer that outputs RFC3339 dates
+func (writer RFC3339logWriter) Write(bytes []byte) (int, error) {
+	return fmt.Print(time.Now().UTC().Format(time.RFC3339Nano) + " " + string(bytes))
+}
+
 // Format formats the logrus entry by passing it to the "log" package
 func (f *DefaultLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	
 	b := &bytes.Buffer{}
-	logger := log.New(b, "", log.LstdFlags)
+	logger := log.New(new(RFC3339logWriter), "", 0)
 	logger.Println(entry.Message)
 	// Panic and Fatal are handled by logrus automatically
 	return b.Bytes(), nil


### PR DESCRIPTION
This PR formats the date emited by Containerpilot according to RFC3339 as per [#442](https://github.com/joyent/containerpilot/issues/422).
This is useful when consuming CP logs for correlation with other time sources as it remove ambiguity related to timezones.

If this patch works, dates in the logs should look like:
```
2017-07-04T23:00:00.00000Z REST OF THE LOG LINE
```