### PR TITLE
update logrus import to use lower case package name

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -8,8 +8,8 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/events"
+	log "github.com/sirupsen/logrus"
 )
 
 // Command wraps an os/exec.Cmd with a timeout, logging, and arg parsing.

--- a/config/logging.go
+++ b/config/logging.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // LogConfig configures the log levels

--- a/config/logging_test.go
+++ b/config/logging_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func TestLoggingBootstrap(t *testing.T) {

--- a/control/control.go
+++ b/control/control.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/events"
+	log "github.com/sirupsen/logrus"
 )
 
 // SocketType is the default listener type

--- a/control/endpoints.go
+++ b/control/endpoints.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/events"
+	log "github.com/sirupsen/logrus"
 )
 
 // Endpoints wraps the EventBus so we can bridge data across the App and

--- a/core/app.go
+++ b/core/app.go
@@ -16,7 +16,7 @@ import (
 	"github.com/joyent/containerpilot/telemetry"
 	"github.com/joyent/containerpilot/watches"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/discovery/consul.go
+++ b/discovery/consul.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/hashicorp/consul/api"
+	log "github.com/sirupsen/logrus"
 )
 
 // Consul wraps the service discovery backend for the Hashicorp Consul client

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -3,8 +3,8 @@ package discovery
 import (
 	"fmt"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/hashicorp/consul/api"
+	log "github.com/sirupsen/logrus"
 )
 
 // ServiceDefinition is how a job communicates with the Consul service

--- a/docs/30-configuration/38-logging.md
+++ b/docs/30-configuration/38-logging.md
@@ -23,7 +23,7 @@ Logging Format Examples:
 2015/03/26 01:27:38 The ice breaks!
 ```
 
-`text` - [logrus TextFormatter](https://github.com/Sirupsen/logrus)
+`text` - [logrus TextFormatter](https://github.com/sirupsen/logrus)
 
 ```
 time="2015-03-26T01:27:38-04:00" level=debug msg="Started observing beach" animal=walrus number=8
@@ -35,7 +35,7 @@ time="2015-03-26T01:27:38-04:00" level=fatal msg="The ice breaks!" err=&{0x20822
 exit status 1
 ```
 
-`json` - [logrus JSONFormatter](https://github.com/Sirupsen/logrus)
+`json` - [logrus JSONFormatter](https://github.com/sirupsen/logrus)
 
 ```
 {"animal":"walrus","level":"info","msg":"A group of walrus emerges from the ocean","size":10,"time":"2014-03-10 19:57:38.562264131 -0400 EDT"}

--- a/events/bus.go
+++ b/events/bus.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // EventBus manages the state of and transmits messages to all its Subscribers

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c78fd9afa84fae131536303beb1a73af84291e218d904c7eddddae2275562c91
-updated: 2017-07-03T20:08:48.202257396Z
+hash: 4b8c67e1b2aaaea33326e14e86e182763cad4255d56133d414de5ca596d8621b
+updated: 2017-07-05T10:37:07.47857606-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -10,23 +10,19 @@ imports:
 - name: github.com/flynn/json5
   version: 7620272ed63390e979cf5882d2fa0506fe2a8db5
 - name: github.com/golang/protobuf
-  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
+  version: 6a1fa9404c0aebf36c879bc50152edcc953910d2
   subpackages:
   - proto
 - name: github.com/hashicorp/consul
   version: 2c7715154d8d4568524b76d2d4deb7ca6fd1b285
   subpackages:
   - api
-  - testutil
-  - testutil/retry
 - name: github.com/hashicorp/go-cleanhttp
   version: 3573b8b52aa7b37b9358d966a898feb387f62437
 - name: github.com/hashicorp/go-rootcerts
   version: 6bb64b370b90e7ef1fa532be9e591a81c3493e00
-- name: github.com/hashicorp/go-uuid
-  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
 - name: github.com/hashicorp/serf
-  version: 19f2c401e122352c047a84d6584dd51e2fb8fcc4
+  version: 91fd53b1d3e624389ed9a295a3fa380e5c7b9dfc
   subpackages:
   - coordinate
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -37,8 +33,6 @@ imports:
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
-- name: github.com/pkg/errors
-  version: c605e284fe17294bda444b34710735b29d1a9d90
 - name: github.com/prometheus/client_golang
   version: 90c15b5efa0dc32a7d259234e02ac9a99e6d3b82
   subpackages:
@@ -57,7 +51,7 @@ imports:
   version: 406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8
 - name: github.com/samalba/dockerclient
   version: a3036261847103270e9f732509f43b5f98710ace
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: golang.org/x/net
   version: 7f88271ea9913b72aca44fa7fc8af919eacc17ce
@@ -67,4 +61,4 @@ imports:
   version: 50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e
   subpackages:
   - unix
-testImports: []
+devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4b8c67e1b2aaaea33326e14e86e182763cad4255d56133d414de5ca596d8621b
-updated: 2017-07-05T10:37:07.47857606-04:00
+hash: 389075fdd1b1f3311d9db24221f793ad7351b0198a69683ca2f885666c375297
+updated: 2017-07-05T11:25:56.783852009-04:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -26,7 +26,7 @@ imports:
   subpackages:
   - coordinate
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/mitchellh/go-homedir
@@ -34,31 +34,29 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - name: github.com/prometheus/client_golang
-  version: 90c15b5efa0dc32a7d259234e02ac9a99e6d3b82
+  version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 40456948a47496dc22168e6af39297a2f8fbf38c
+  version: 0866df4b85a18d652b6965be022d007cdf076822
   subpackages:
   - expfmt
-  - internal/bitbucket.org/ww/goautoneg
   - model
+  - internal/bitbucket.org/ww/goautoneg
 - name: github.com/prometheus/procfs
-  version: 406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  subpackages:
+  - xfs
 - name: github.com/samalba/dockerclient
   version: a3036261847103270e9f732509f43b5f98710ace
 - name: github.com/sirupsen/logrus
   version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
-- name: golang.org/x/net
-  version: 7f88271ea9913b72aca44fa7fc8af919eacc17ce
-  subpackages:
-  - context
 - name: golang.org/x/sys
-  version: 50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e
+  version: 94b76065f2d2081d0fef24a6e67c571f51a6408a
   subpackages:
   - unix
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/joyent/containerpilot
 homepage: https://www.joyent.com/containerpilot
 license: MPL-2.0
 import:
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
   version: 1.0.0
 - package: github.com/hashicorp/consul
   version: ~0.8.4

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,35 +8,11 @@ import:
   version: ~0.8.4
   subpackages:
   - api
-- package: github.com/matttproud/golang_protobuf_extensions
-  version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
-  subpackages:
-  - pbutil
 - package: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - package: github.com/prometheus/client_golang
-  version: 90c15b5efa0dc32a7d259234e02ac9a99e6d3b82
+  version: 0.8.0
   subpackages:
   - prometheus
-- package: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
-  subpackages:
-  - go
-- package: github.com/prometheus/common
-  version: 40456948a47496dc22168e6af39297a2f8fbf38c
-  subpackages:
-  - expfmt
-  - internal/bitbucket.org/ww/goautoneg
-  - model
-- package: github.com/prometheus/procfs
-  version: 406e5b7bfd8201a36e2bb5f7bdae0b03380c2ce8
-- package: golang.org/x/net
-  version: 7f88271ea9913b72aca44fa7fc8af919eacc17ce
-  subpackages:
-  - context
-- package: golang.org/x/sys
-  version: 50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e
-  subpackages:
-  - unix
 - package: github.com/flynn/json5
   version: 7620272ed63390e979cf5882d2fa0506fe2a8db5

--- a/jobs/config.go
+++ b/jobs/config.go
@@ -6,11 +6,11 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/commands"
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/events"
 	"github.com/joyent/containerpilot/utils"
+	log "github.com/sirupsen/logrus"
 )
 
 const taskMinDuration = time.Millisecond

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/commands"
 	"github.com/joyent/containerpilot/discovery"
 	"github.com/joyent/containerpilot/events"
+	log "github.com/sirupsen/logrus"
 )
 
 // Some magic numbers used internally by restart limits

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main // import "github.com/joyent/containerpilot"
 import (
 	"runtime"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/core"
+	log "github.com/sirupsen/logrus"
 )
 
 // Main executes the containerpilot CLI

--- a/makefile
+++ b/makefile
@@ -62,7 +62,7 @@ release: build
 
 ## remove build/test artifacts, test fixtures, and vendor directories
 clean:
-	rm -rf build release cover vendor
+	rm -rf build release cover vendor .glide
 	docker rmi -f containerpilot_build > /dev/null 2>&1 || true
 	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
 	./scripts/test.sh clean

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -5,9 +5,9 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/joyent/containerpilot/events"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 )
 
 const eventBufferSize = 1000

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/joyent/containerpilot/events"
 )

--- a/utils/ips.go
+++ b/utils/ips.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // IPFromInterfaces ...


### PR DESCRIPTION
The logrus package had its name changed from `github.com/Sirupsen/logrus` to `github.com/sirupsen/logrus` (ref https://github.com/sirupsen/logrus/issues/553). This PR updates all our imports and our glide config to use the new package name.

Once this PR is merged, anyone developing on ContainerPilot will need to do a `make clean` to ensure they don't have any debris from the old vendor directory or project glide cache floating around.

