### PR TITLE
add internal prometheus metrics

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -8,12 +8,23 @@ import (
 	"os"
 	"time"
 
-	"github.com/joyent/containerpilot/events"
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/joyent/containerpilot/events"
 )
 
 // SocketType is the default listener type
 var SocketType = "unix"
+
+var collector *prometheus.CounterVec
+
+func init() {
+	collector = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "containerpilot_control_http_requests",
+		Help: "count of requests to control socket, partitioned by path and HTTP code",
+	}, []string{"code", "path"})
+}
 
 // HTTPServer contains the state of the HTTP Server used by ContainerPilot's
 // HTTP transport control plane. Currently this is listening via a UNIX socket

--- a/control/control.go
+++ b/control/control.go
@@ -24,6 +24,7 @@ func init() {
 		Name: "containerpilot_control_http_requests",
 		Help: "count of requests to control socket, partitioned by path and HTTP code",
 	}, []string{"code", "path"})
+	prometheus.MustRegister(collector)
 }
 
 // HTTPServer contains the state of the HTTP Server used by ContainerPilot's

--- a/control/endpoints.go
+++ b/control/endpoints.go
@@ -27,6 +27,8 @@ func (pw PostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		failedStatus := http.StatusMethodNotAllowed
 		http.Error(w, http.StatusText(failedStatus), failedStatus)
+		collector.WithLabelValues(
+			string(http.StatusMethodNotAllowed), r.URL.Path).Add(1)
 		return
 	}
 	resp, status := pw(r)
@@ -43,6 +45,7 @@ func (pw PostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, http.StatusText(status), status)
 	}
+	collector.WithLabelValues(string(status), r.URL.Path).Add(1)
 }
 
 // PutEnviron handles incoming HTTP POST requests containing JSON environment

--- a/control/endpoints.go
+++ b/control/endpoints.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/joyent/containerpilot/events"
 	log "github.com/sirupsen/logrus"
@@ -28,7 +29,7 @@ func (pw PostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		failedStatus := http.StatusMethodNotAllowed
 		http.Error(w, http.StatusText(failedStatus), failedStatus)
 		collector.WithLabelValues(
-			string(http.StatusMethodNotAllowed), r.URL.Path).Add(1)
+			strconv.Itoa(http.StatusMethodNotAllowed), r.URL.Path).Inc()
 		return
 	}
 	resp, status := pw(r)
@@ -45,7 +46,7 @@ func (pw PostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, http.StatusText(status), status)
 	}
-	collector.WithLabelValues(string(status), r.URL.Path).Add(1)
+	collector.WithLabelValues(strconv.Itoa(status), r.URL.Path).Inc()
 }
 
 // PutEnviron handles incoming HTTP POST requests containing JSON environment
@@ -129,5 +130,6 @@ func (e Endpoints) PostMetric(r *http.Request) (interface{}, int) {
 func GetPing(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	w.WriteHeader(http.StatusOK)
+	collector.WithLabelValues("200", r.URL.Path).Inc()
 	io.WriteString(w, "\n")
 }

--- a/events/bus.go
+++ b/events/bus.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -56,6 +57,16 @@ func (bus *EventBus) mod(p int) int {
 	return p % len(bus.buf)
 }
 
+var collector *prometheus.CounterVec
+
+func init() {
+	collector = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "containerpilot_events",
+		Help: "count of ContainerPilot events, partitioned by type and source",
+	}, []string{"code", "source"})
+	prometheus.MustRegister(collector)
+}
+
 // NewEventBus initializes an EventBus. We need this rather than a struct
 // literal so that we know our channels are non-nil (which block sends).
 func NewEventBus() *EventBus {
@@ -100,6 +111,7 @@ func (bus *EventBus) Publish(event Event) {
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
 	log.Debugf("event: %v", event)
+	collector.WithLabelValues(event.Code.String(), event.Source).Add(1)
 	for subscriber := range bus.registry {
 		// sending to an unsubscribed Subscriber shouldn't be a runtime
 		// error, so this is in intentionally allowed to panic here

--- a/events/bus.go
+++ b/events/bus.go
@@ -111,7 +111,7 @@ func (bus *EventBus) Publish(event Event) {
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
 	log.Debugf("event: %v", event)
-	collector.WithLabelValues(event.Code.String(), event.Source).Add(1)
+	collector.WithLabelValues(event.Code.String(), event.Source).Inc()
 	for subscriber := range bus.registry {
 		// sending to an unsubscribed Subscriber shouldn't be a runtime
 		// error, so this is in intentionally allowed to panic here

--- a/integration_tests/tests/test_telemetry/containerpilot.json5
+++ b/integration_tests/tests/test_telemetry/containerpilot.json5
@@ -25,6 +25,12 @@
       }
     }
   ],
+  watches: [
+    {
+      name: "otherapp",
+      interval: 1
+    }
+  ],
   telemetry: {
     port: 9090,
     metrics: [


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/374

This PR gives us a lot of the items described in issue #374, because most of the things that ContainerPilot does pass through the event bus `Publish` method. The list of events this will catch are:

- *ExitSuccess*: any `exec` (job or health check) completes with 0 exit code
- *ExitFailed*: any `exec` (job or health check) completes with 0 exit code
- *Stopping*: a job in this container is about to stop
- *Stopped*: a job in this container has stopped
- *StatusHealthy*: a job (or watched job) is healthy
- *StatusUnhealthy*: a job (or watched job) is unhealthy
- *StatusChanged*: a job (or watched job) status has changed
- *EnterMaintenance*: entered maintenance mode
- *ExitMaintenance*: exited maintenance mode
- *Error*: an `exec` couldn't start or was forced to cancel with an error b/c it timed out (will always have *ExitFailed* too, but *ExitFailed* might not include *Error*).
- *Metric*: a user-defined metric was recorded
- *Startup*: global ContainerPilot startup
- *Shutdown*: global ContainerPilot shutdown

(The internal *TimerExpired* and *Quit* events you can find in [events/events.go](https://github.com/joyent/containerpilot/blob/master/events/events.go) are never broadcast across the event bus so won't show up here.)

This Prometheus collector here is a vec counter, or in other words a counter that's annotated with labels. The output looks like this:

```
curl -s localhost:9090/metrics | grep containerpilot
# HELP containerpilot_events count of ContainerPilot events, partitioned by type and source
# TYPE containerpilot_events counter
containerpilot_events{code="ExitSuccess",source="check.app1"} 3
containerpilot_events{code="Startup",source="global"} 1
containerpilot_events{code="StatusHealthy",source="app1"} 3
```


This PR needs tests too, but I wanted to use this for discussion.
cc @cheapRoc @misterbisson @geek 