### PR TITLE
docs: update terminology around 'hook'

### DIFF
--- a/docs/10-lifecycle.md
+++ b/docs/10-lifecycle.md
@@ -29,7 +29,7 @@ A watch is a configuration of a service to monitor in Consul. The watch monitors
 
 ## How do events trigger jobs?
 
-By default, a job's `exec` process starts as soon as ContainerPilot has finished startup. Many jobs will want to have a configuration that determines some specific event to wait for, using the `when` field. This field expects a `source` (the name of the event source) and either `once` (trigger one-time only) or `each` (trigger each time this event happens).
+By default, a job's `exec` process starts as soon as ContainerPilot has finished startup. Many jobs will want to have a configuration that hooks a specific event using the `when` field. This field expects a `source` (the name of the event source) and either `once` (trigger one-time only) or `each` (trigger each time this event happens).
 
 For example, if we want a job to run only once `myDb` is healthy (but not each time its health changes), we might use the following configuration:
 

--- a/docs/20-design.md
+++ b/docs/20-design.md
@@ -28,7 +28,7 @@ For more on this topic, see Casey Bisson's article on the ContainerSummit websit
 
 In theory it's possible for ContainerPilot to fire an event immediately after it `fork/exec`'s a job's process. But in practice this is not a useful event for an application developer and will cause hard-to-debug race conditions in your configuration. Processes like servers need to bind to an address before they can be considered "started." Other processes need to do other work during start like loading and interpreting byte code. A short-lived task might even complete all its work and exit before an event could be handled, leading to an unsolvable race condition.
 
-If ContainerPilot were to emit a `started` event then the job that emits the event will almost never be ready to do work when the event is handled. This means that jobs that depend on that job will need to implement some kind of health checking and retry logic anyways, and we would gain nothing at the cost of making configuration very confusing and error prone. Jobs that are dependent on another job should listen for the `healthy` event from their dependencies.
+If ContainerPilot were to emit a `started` event then the job that emits the event will almost never be ready to do work when the event is handled. This means that jobs that depend on that job will need to implement some kind of health checking and retry logic anyways, and we would gain nothing at the cost of making configuration very confusing and error prone. Jobs that are dependent on another job should set a `when` hook for the `healthy` event from their dependencies.
 
 
 ## Why Consul and not etcd or Zookeeper?

--- a/docs/30-configuration/34-jobs.md
+++ b/docs/30-configuration/34-jobs.md
@@ -102,7 +102,7 @@ The following fields define when a job starts, stops, restarts, and times out.
 
 ##### `when`
 
-The `when` field defines an event that starts the job's `exec`. By default, a job's `exec` process starts as soon as ContainerPilot has finished startup. Many jobs will want to have a configuration that determines some specific event to wait for, using the `when` field.
+The `when` field defines a hook for an event that starts the job's `exec`. By default, a job's `exec` process starts as soon as ContainerPilot has finished startup. Many jobs will want to have a configuration that determines some specific event to wait for, using the `when` field.
 
 - `source` is the source of the event that triggers the job.
 - `once` names an event that triggers the start of the job one time only.

--- a/docs/30-configuration/37-control-plane.md
+++ b/docs/30-configuration/37-control-plane.md
@@ -35,7 +35,7 @@ Usage of ./containerpilot:
 
 ##### `PutEnv POST /v3/env`
 
-This API allows a hook to update the environment variables that ContainerPilot provides to lifecycle hooks. The body of the POST must be in JSON format. The keys will be used as the environment variable to set, and the values will be the values to set for those environment variables. The environment variables take effect for all future processes spawned and override any existing environment variables. Unsetting an variable is supporting by passing an empty string or `null` as the JSON value for that key. This API returns HTTP400 if the key is not a valid environment variable name, otherwise HTTP200 with no body.
+This API allows a client to update the environment variables that ContainerPilot provides to jobs and health checks. The body of the POST must be in JSON format. The keys will be used as the environment variable to set, and the values will be the values to set for those environment variables. The environment variables take effect for all future processes spawned and override any existing environment variables. Unsetting an variable is supporting by passing an empty string or `null` as the JSON value for that key. This API returns HTTP400 if the key is not a valid environment variable name, otherwise HTTP200 with no body.
 
 *Example Subcommand*
 
@@ -54,7 +54,7 @@ curl -XPOST \
 
 ##### `PutMetric POST /v3/metric`
 
-This API allows a sensor hook to update Prometheus metrics. (This allows sensor hooks to do so without having to suppress their own logging, which is required under 2.x.) The body of the POST must be in JSON format. The keys will be used as the metric names to update, and the values will be the values to set/add for those metrics. The API will return HTTP400 if the metric is not one that ContainerPilot is configuring, otherwise HTTP200 with no body.
+This API allows a client to update Prometheus metrics. The body of the POST must be in JSON format. The keys will be used as the metric names to update, and the values will be the values to set/add for those metrics. The API will return HTTP400 if the metric is not one that ContainerPilot is configuring, otherwise HTTP200 with no body.
 
 *Example Subcommand*
 
@@ -73,7 +73,7 @@ curl -XPOST \
 
 ##### `Reload POST /v3/reload`
 
-This API allows a hook to force ContainerPilot to reload its configuration from file. This replaces the SIGHUP handler from 2.x and behaves identically: all pollables are stopped, the configuration file is reloaded, and the pollables are restarted without interfering with the services. This endpoint returns a HTTP200 with no body.
+This API allows a client to force ContainerPilot to reload its configuration from file. This replaces the SIGHUP handler from 2.x and behaves identically: all pollables are stopped, the configuration file is reloaded, and the pollables are restarted without interfering with the services. This endpoint returns a HTTP200 with no body.
 
 *Example Subcommand*
 

--- a/docs/40-support.md
+++ b/docs/40-support.md
@@ -37,7 +37,7 @@ ContainerPilot does not coordinate between instances of ContainerPilot except th
 
 The ContainerPilot configuration syntax will follow a semver approach. Fixing a bug in an existing feature will be a patch version bump. Adding a new configuration feature will result in a minor version bump. Existing features will not have their behavior or configuration syntax changed.
 
-The core behavior of behavior hooks fired by job exec, job health check, or sensor exec is to fork/exec the hook, forward stdout/stderr to ContainerPilot's own stdout/stderr, and interpret a non-zero exit code as an error which fires `ExitFailed` event, and a zero exit code as a success which fires an `ExitSuccess` event. This behavior is guaranteed to be stable for this major version (3.x).
+The core behavior of behavior hooks fired by job `exec` or health check `exec` is to fork/exec the hook, forward stdout/stderr to ContainerPilot's own stdout/stderr, and interpret a non-zero exit code as an error which fires `ExitFailed` event, and a zero exit code as a success which fires an `ExitSuccess` event. This behavior is guaranteed to be stable for this major version (3.x).
 
 ##### The internal ContainerPilot APIs with its golang packages
 


### PR DESCRIPTION
This PR clarifies the terminology "hook" by using it only to pertain to a `when` behavior, and removing the older (v2) sense where it pertained to the `exec` (particularly removing terminology like "sensor hook" which doesn't exist under v3).

cc @misterbisson @fitzage 