### PR TITLE
set job startEvent to NonEvent in all job-ending returns

### DIFF
--- a/docs/30-configuration/34-jobs.md
+++ b/docs/30-configuration/34-jobs.md
@@ -148,7 +148,7 @@ jobs: [
 
 The `restarts` field is the number of times the process will be restarted if it exits. This field supports any non-negative numeric value (ex. `0` or `1`) or the strings `"unlimited"` or `"never"`. This value is optional and defaults to `"never"`.
 
-It's important to understand how this field compares to the `when` field. A restart is run only when the job receives its own `exitSuccess` or `exitFailure` event. The `when` field is for triggering on other events. In the example below the `app` job is first started when the `db` job is `healthy`, but it will restart whenever it exits.
+It's important to understand how this field compares to the `when` field. A restart is run only when the job receives its own `exitSuccess` or `exitFailure` event. The `when` field is for triggering on other events. In the example below the `app` job is first started when the `db` job is `healthy`, but it will restart whenever it exits. Using `restarts` with the `each` option of `when` is not recommended because each time the `each` event triggers, it will spawn an `exec` that can restart after exit. In the case of `restarts: "unlimited"` this will use up all the resources in your container!
 
 ```json5
 jobs: [

--- a/docs/30-configuration/34-jobs.md
+++ b/docs/30-configuration/34-jobs.md
@@ -148,7 +148,7 @@ jobs: [
 
 The `restarts` field is the number of times the process will be restarted if it exits. This field supports any non-negative numeric value (ex. `0` or `1`) or the strings `"unlimited"` or `"never"`. This value is optional and defaults to `"never"`.
 
-It's important to understand how this field compares to the `when` field. A restart is run only when the job receives its own `exitSuccess` or `exitFailure` event. The `when` field is for triggering on other events. In the example below the `app` job is first started when the `db` job is `healthy`, but it will restart whenever it exits. Using `restarts` with the `each` option of `when` is not recommended because each time the `each` event triggers, it will spawn an `exec` that can restart after exit. In the case of `restarts: "unlimited"` this will use up all the resources in your container!
+It's important to understand how this field compares to the `when` field. A restart is run only when the job receives its own `exitSuccess` or `exitFailure` event. The `when` field is for triggering on other events. In the example below the `app` job is first started when the `db` job is `healthy`, but it will restart whenever it exits. Using `restarts` with the `each` option of `when` is not recommended because each time the `each` event triggers, it will spawn an `exec` that can restart after exit. In the case of unlimited restarts this would eventually use up all the resources in your container, so trying to use `restarts: "unlimited"` and `each` will return an error.
 
 ```json5
 jobs: [

--- a/jobs/config.go
+++ b/jobs/config.go
@@ -306,6 +306,9 @@ func (cfg *Config) validateRestarts() error {
 		cfg.restartLimit = 0
 		return nil
 	}
+	if cfg.When.Each != "" {
+		log.Warnf("job[%s].restarts field and job[%s].when.each field are both set and this may result in spawning infinite processes")
+	}
 
 	const msg = `job[%s].restarts field '%v' invalid: accepts positive integers, "unlimited", or "never"`
 

--- a/jobs/config.go
+++ b/jobs/config.go
@@ -306,8 +306,8 @@ func (cfg *Config) validateRestarts() error {
 		cfg.restartLimit = 0
 		return nil
 	}
-	if cfg.When.Each != "" {
-		log.Warnf("job[%s].restarts field and job[%s].when.each field are both set and this may result in spawning infinite processes")
+	if cfg.When.Each == "unlimited" {
+		return fmt.Errorf("job[%s].restarts field 'unlimited' invalid when job[%s].when.each is set because it may result in infinite processes", cfg.Name, cfg.Name)
 	}
 
 	const msg = `job[%s].restarts field '%v' invalid: accepts positive integers, "unlimited", or "never"`


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/417#issuecomment-315031863

When a job is out of executions, whether that's because `processEvent` returns true or because it's out of "starts" or "restarts", then the `startEvent` should *always* be set to the never-published `NonEvent`.

This PR adds a bunch more test logic to this section of code, fixes a couple bugs in the test code, and adds a warning to both the logs and docs about the interaction between using `restarts` and `when.each` together. I'd like to have a discussion about whether this should simply be an error or not. It seems like a footgun, at least with the `restarts: "unlimited"` value.

cc @cheapRoc @eliasbrange @misterbisson 

I've checked this against the test configuration provided by @eliasbrange in https://github.com/joyent/containerpilot/issues/417#issuecomment-315031863 and got the following (correct) log outputs:

```
./build/containerpilot -config local.json
2017-07-14T14:08:06.982271436-04:00 loaded config: {"Discovery":{},"LogConfig":{"level":"DEBUG","format":"default","output":"stdout"},"StopTimeout":5,"Jobs":[{"Name":"consul-agent","Exec":"sleep 1000","Port":0,"Interfaces":null,"Tags":null,"ConsulExtras":null,"Health":{"CheckExec":"sleep 1","CheckTimeout":"","Heartbeat":5,"TTL":10},"ExecTimeout":"","Restarts":"unlimited","StopTimeout":"","When":{"Frequency":"","Source":"","Once":"","Each":"","Timeout":""}},{"Name":"consul-template","Exec":"sleep 20","Port":0,"Interfaces":null,"Tags":null,"ConsulExtras":null,"Health":null,"ExecTimeout":"","Restarts":"unlimited","StopTimeout":"","When":{"Frequency":"","Source":"consul-agent","Once":"healthy","Each":"","Timeout":""}}],"Watches":null,"Telemetry":null,"Control":{"SocketPath":"cp.sock"}}
2017-07-14T14:08:06.9823803-04:00 control: initialized router for control server
2017-07-14T14:08:06.982552299-04:00 event: {Startup global}
2017-07-14T14:08:06.982627277-04:00 control: serving at cp.sock
2017-07-14T14:08:06.982776147-04:00 consul-agent.Run start
2017-07-14T14:08:11.984021944-04:00 check.consul-agent.Run start
2017-07-14T14:08:12.989849428-04:00 check.consul-agent exited without error
2017-07-14T14:08:12.989883206-04:00 event: {ExitSuccess check.consul-agent}
2017-07-14T14:08:12.989917696-04:00 check.consul-agent.Run end
2017-07-14T14:08:12.989947066-04:00 check.consul-agent.kill
2017-07-14T14:08:12.989954718-04:00 killing command 'check.consul-agent' at pid: 43000
2017-07-14T14:08:12.989974984-04:00 event: {StatusHealthy consul-agent}
2017-07-14T14:08:12.989995107-04:00 consul-template.Run start
2017-07-14T14:08:16.983162487-04:00 check.consul-agent.Run start
2017-07-14T14:08:17.992962688-04:00 check.consul-agent exited without error
2017-07-14T14:08:17.993004201-04:00 event: {ExitSuccess check.consul-agent}
2017-07-14T14:08:17.993070164-04:00 check.consul-agent.Run end
2017-07-14T14:08:17.993120334-04:00 check.consul-agent.kill
2017-07-14T14:08:17.993130371-04:00 killing command 'check.consul-agent' at pid: 43038
2017-07-14T14:08:17.993155493-04:00 event: {StatusHealthy consul-agent}
2017-07-14T14:08:21.987763079-04:00 check.consul-agent.Run start
2017-07-14T14:08:22.997097449-04:00 check.consul-agent exited without error
2017-07-14T14:08:22.99713015-04:00 event: {ExitSuccess check.consul-agent}
2017-07-14T14:08:22.997159504-04:00 check.consul-agent.Run end
2017-07-14T14:08:22.99719417-04:00 check.consul-agent.kill
2017-07-14T14:08:22.997207829-04:00 killing command 'check.consul-agent' at pid: 43039
2017-07-14T14:08:22.997224147-04:00 event: {StatusHealthy consul-agent}
2017-07-14T14:08:26.986255731-04:00 check.consul-agent.Run start
2017-07-14T14:08:27.992939951-04:00 check.consul-agent exited without error
2017-07-14T14:08:27.992976713-04:00 event: {ExitSuccess check.consul-agent}
2017-07-14T14:08:27.993008539-04:00 check.consul-agent.Run end
2017-07-14T14:08:27.993047673-04:00 check.consul-agent.kill
2017-07-14T14:08:27.993056231-04:00 killing command 'check.consul-agent' at pid: 43076
2017-07-14T14:08:27.993076207-04:00 event: {StatusHealthy consul-agent}
2017-07-14T14:08:31.984102322-04:00 check.consul-agent.Run start
2017-07-14T14:08:32.99263318-04:00 check.consul-agent exited without error
2017-07-14T14:08:32.992669022-04:00 event: {ExitSuccess check.consul-agent}
2017-07-14T14:08:32.992813516-04:00 check.consul-agent.Run end
2017-07-14T14:08:32.992853923-04:00 check.consul-agent.kill
2017-07-14T14:08:32.992862962-04:00 killing command 'check.consul-agent' at pid: 43077
2017-07-14T14:08:32.992896355-04:00 event: {StatusHealthy consul-agent}
2017-07-14T14:08:32.995453866-04:00 consul-template exited without error
2017-07-14T14:08:32.995473034-04:00 event: {ExitSuccess consul-template}
2017-07-14T14:08:32.995498465-04:00 consul-template.Run end
2017-07-14T14:08:32.995530611-04:00 consul-template.kill
2017-07-14T14:08:32.995540696-04:00 killing command 'consul-template' at pid: 43001
2017-07-14T14:08:32.99555718-04:00 consul-template.Run start
```
