### PR TITLE
allow unit tests to run w/o inet interface

### DIFF
--- a/config/testdata/test.json5
+++ b/config/testdata/test.json5
@@ -7,7 +7,7 @@
       // "coprocess", "task", "prestart", etc. to make their role clear
       name: "serviceA",
       port: 8080,
-      interfaces: "inet",
+      interfaces: ["inet", "lo0"],
       exec: "/bin/serviceA",
       when: {
         source: "preStart",
@@ -23,7 +23,7 @@
     {
       name: "serviceB",
       port: 5000,
-      interfaces: ["ethwe","eth0", "inet"],
+      interfaces: ["ethwe","eth0", "inet", "lo0"],
       exec: ["/bin/serviceB", "B"],
       health:{
         exec: ["/bin/to/healthcheck/for/service/B.sh", "B"],
@@ -94,7 +94,7 @@
   ],
   telemetry: {
     port: 9000,
-    interfaces: ["inet"],
+    interfaces: ["inet", "lo0"],
     tags: ["dev"],
     metrics: [
       {

--- a/core/app_test.go
+++ b/core/app_test.go
@@ -67,7 +67,7 @@ func TestMetricServiceCreation(t *testing.T) {
 	f := testCfgToTempFile(t, `{
     "consul": "consul:8500",
     "telemetry": {
-      "interfaces": ["inet"],
+      "interfaces": ["inet", "lo0"],
       "port": 9090
     }
   }`)

--- a/jobs/config_test.go
+++ b/jobs/config_test.go
@@ -222,16 +222,16 @@ func TestJobConfigValidateName(t *testing.T) {
 func TestJobConfigValidateDiscovery(t *testing.T) {
 	assert := assert.New(t)
 
-	cfgA := `[{name: "myName", port: 80}]`
+	cfgA := `[{name: "myName", port: 80, interfaces: ["inet", "lo0"]}]`
 	_, err := NewConfigs(tests.DecodeRawToSlice(cfgA), noop)
 	assert.Error(err, "job[myName].health must be set if 'port' is set")
 
-	cfgB := `[{name: "myName", port: 80, health: {interval: 1}}]`
+	cfgB := `[{name: "myName", port: 80, interfaces: ["inet", "lo0"], health: {interval: 1}}]`
 	_, err = NewConfigs(tests.DecodeRawToSlice(cfgB), noop)
 	assert.Error(err, "job[myName].health.ttl must be > 0")
 
 	// no health check shouldn't return an error
-	cfgD := `[{name: "myName", port: 80, health: {interval: 1, ttl: 1}}]`
+	cfgD := `[{name: "myName", port: 80, interfaces: ["inet", "lo0"], health: {interval: 1, ttl: 1}}]`
 	if _, err = NewConfigs(tests.DecodeRawToSlice(cfgD), noop); err != nil {
 		t.Fatalf("expected no error", err)
 	}

--- a/jobs/testdata/TestJobConfigConsulExtras.json5
+++ b/jobs/testdata/TestJobConfigConsulExtras.json5
@@ -2,7 +2,7 @@
   {
     name: "serviceA",
     port: 8080,
-    interfaces: "inet",
+    interfaces: ["inet", "lo0"],
     exec: "/bin/serviceA",
     health: {
       exec: "/bin/to/healthcheck/for/service/A.sh",

--- a/jobs/testdata/TestJobConfigServiceWithArrayExec.json5
+++ b/jobs/testdata/TestJobConfigServiceWithArrayExec.json5
@@ -4,7 +4,7 @@
     // so that we exercise the parsing for arrays
     name: "serviceB",
     port: 5000,
-    interfaces: ["ethwe","eth0", "inet"],
+    interfaces: ["ethwe","eth0", "inet", "lo0"],
     exec: ["/bin/serviceB", "B"],
     health: {
       exec: ["/bin/healthCheckB.sh", "B1", "B2"],

--- a/jobs/testdata/TestJobConfigServiceWithPreStart.json5
+++ b/jobs/testdata/TestJobConfigServiceWithPreStart.json5
@@ -2,7 +2,7 @@
   {
     name: "serviceA",
     port: 8080,
-    interfaces: "inet",
+    interfaces: ["inet", "lo0"],
     exec: "/bin/serviceA.sh",
     when: {
       source: "preStart",

--- a/jobs/testdata/TestJobConfigServiceWithStopping.json5
+++ b/jobs/testdata/TestJobConfigServiceWithStopping.json5
@@ -2,6 +2,7 @@
   {
     name: "serviceA",
     port: 8080,
+    interfaces: ["inet", "lo0"],
     exec: "/bin/serviceA.sh",
     when: {
       source: "preStart",

--- a/jobs/testdata/TestJobConfigSmokeTest.json5
+++ b/jobs/testdata/TestJobConfigSmokeTest.json5
@@ -2,7 +2,7 @@
   {
     name: "serviceA",
     port: 8080,
-    interfaces: "inet",
+    interfaces: ["inet", "lo0"],
     exec: "/bin/serviceA",
     when: {
       source: "preStart",
@@ -18,7 +18,7 @@
   {
     name: "serviceB",
     port: 5000,
-    interfaces: ["ethwe","eth0", "inet"],
+    interfaces: ["ethwe","eth0", "inet", "lo0"],
     exec: ["/bin/serviceB", "B"],
     health: {
       exec: ["/bin/to/healthcheck/for/service/B.sh", "B"],

--- a/telemetry/status_test.go
+++ b/telemetry/status_test.go
@@ -43,7 +43,8 @@ func TestStatusServerGet(t *testing.T) {
 		tests.DecodeRawToSlice(
 			`[{name: "myjob1", exec: "sleep 10"},
              {name: "myjob2", exec: "sleep 10",
-             port: 80, health: { exec: "true", interval: 1, ttl: 2}}]`),
+             port: 80, interfaces: ["inet", "lo0"],
+             health: { exec: "true", interval: 1, ttl: 2}}]`),
 		noop)
 	if err != nil {
 		t.Fatal(err)

--- a/telemetry/telemetry_config_test.go
+++ b/telemetry/telemetry_config_test.go
@@ -29,7 +29,7 @@ func TestTelemetryConfigParse(t *testing.T) {
 }
 
 func TestTelemetryConfigBadMetric(t *testing.T) {
-	testCfg := tests.DecodeRaw(`{"metrics": [{}], "interfaces": ["inet"]}`)
+	testCfg := tests.DecodeRaw(`{"metrics": [{}], "interfaces": ["inet", "lo0"]}`)
 	_, err := NewConfig(testCfg, &mocks.NoopDiscoveryBackend{})
 	expected := "invalid metric type"
 	if err == nil || !strings.Contains(err.Error(), expected) {

--- a/telemetry/testdata/TestTelemetryConfigParse.json5
+++ b/telemetry/testdata/TestTelemetryConfigParse.json5
@@ -1,6 +1,6 @@
 {
   port: 8000,
-  interfaces: ["inet"],
+  interfaces: ["inet", "lo0"],
   metrics: [
     {
       namespace: "telemetry",


### PR DESCRIPTION
For #414 

This PR allows our unit tests to run even in the case where the test runner has no inet interface (ex. your wifi is disabled and you're on a plane, which is the circumstances under which I tested all this). There are a couple tests that get skipped in `config/services/ip_test.go:TestGetIp` where we do need the inet interface just so that we have more than one interface to pick from, but so long as this isn't the typical way we run our tests (i.e. in CI) I think that's a decent tradeoff.

cc @cheapRoc 