### PR TITLE
send SIGTERM rather than SIGKILL on non-timeout Command exits

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -117,7 +117,7 @@ func (c *Command) Kill() {
 	}
 }
 
-// Kill sends a terminate signal to the underlying process if it still exists,
+// Term sends a terminate signal to the underlying process if it still exists,
 // as well as all its children
 func (c *Command) Term() {
 	log.Debugf("%s.term", c.Name)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -71,8 +71,10 @@ func (c *Command) Run(pctx context.Context, bus *events.EventBus) {
 		defer c.lock.Unlock()
 		if ctx.Err() == context.DeadlineExceeded {
 			log.Warnf("%s timeout after %s: '%s'", c.Name, c.Timeout, c.Args)
+			c.Kill()
+			return
 		}
-		c.Kill()
+		c.Term()
 	}()
 
 	go func() {
@@ -112,5 +114,15 @@ func (c *Command) Kill() {
 	if c.Cmd != nil && c.Cmd.Process != nil {
 		log.Debugf("killing command '%v' at pid: %d", c.Name, c.Cmd.Process.Pid)
 		syscall.Kill(-c.Cmd.Process.Pid, syscall.SIGKILL)
+	}
+}
+
+// Kill sends a terminate signal to the underlying process if it still exists,
+// as well as all its children
+func (c *Command) Term() {
+	log.Debugf("%s.term", c.Name)
+	if c.Cmd != nil && c.Cmd.Process != nil {
+		log.Debugf("terminating command '%v' at pid: %d", c.Name, c.Cmd.Process.Pid)
+		syscall.Kill(-c.Cmd.Process.Pid, syscall.SIGTERM)
 	}
 }

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -164,11 +164,7 @@ func (job *Job) StartJob(ctx context.Context) {
 // Kill sends SIGTERM to the Job's executable, if any
 func (job *Job) Kill() {
 	if job.exec != nil {
-		if job.exec.Cmd != nil {
-			if job.exec.Cmd.Process != nil {
-				job.exec.Cmd.Process.Kill()
-			}
-		}
+		job.exec.Kill()
 	}
 }
 


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/448

This PR fixes the problem noticed by @jonfox where `Commands` that weren't exiting on their own or hitting a timeout were being forced to exit via SIGKILL rather than SIGTERM. I've make the SIGTERM behavior default and made it so that the SIGKILL is only hit when the `exec` timeout is reached or when the global shutdown has decided it's time to kill all the processes whether they're ready or not.