### PR TITLE
fix job status endpoint

### DIFF
--- a/integration_tests/tests/test_telemetry/check.sh
+++ b/integration_tests/tests/test_telemetry/check.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eo pipefail
+
+IP="$1"
+curl -s "${IP}:9090/status" | json -a .Services.0.Status | grep "healthy"
+curl -s "${IP}:9090/status" | json -a .Services.1.Status | grep "healthy"

--- a/integration_tests/tests/test_telemetry/docker-compose.yml
+++ b/integration_tests/tests/test_telemetry/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - 9090:9090
     volumes:
       - './containerpilot.json5:/etc/containerpilot.json5'
+      - './check.sh:/check.sh'
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'
 
   test:

--- a/integration_tests/tests/test_telemetry/run.sh
+++ b/integration_tests/tests/test_telemetry/run.sh
@@ -41,7 +41,7 @@ echo "$metrics" | grep 'containerpilot_watch_instances' || \
     ( echo 'no containerpilot_watch_instances metrics' && exit 1 )
 
 # Check the status endpoint too
-docker exec -it "${APP_ID}" curl -s "${IP}:9090/status" | grep 'app'
+docker exec -it "${APP_ID}" /check.sh "${IP}"
 result=$?
 set -e
 if [ $result -ne 0 ]; then exit $result; fi

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -28,6 +28,7 @@ const (
 	statusHealthy
 	statusUnhealthy
 	statusMaintenance
+	statusAlwaysHealthy
 )
 
 func (i JobStatus) String() string {
@@ -38,6 +39,9 @@ func (i JobStatus) String() string {
 		return "unhealthy"
 	case 4:
 		return "maintenance"
+	case 5:
+		// for hardcoded "always healthy" jobs
+		return "healthy"
 	default:
 		// both idle and unknown return unknown for purposes of serialization
 		return "unknown"
@@ -97,7 +101,7 @@ func NewJob(cfg *Config) *Job {
 		// right now this hardcodes the telemetry service to
 		// be always "healthy", but maybe we want to have it verify itself
 		// before heartbeating in the future?
-		job.setStatus(statusHealthy)
+		job.setStatus(statusAlwaysHealthy)
 	}
 	return job
 }
@@ -129,7 +133,9 @@ func (job *Job) GetStatus() JobStatus {
 func (job *Job) setStatus(status JobStatus) {
 	job.statusLock.Lock()
 	defer job.statusLock.Unlock()
-	job.Status = status
+	if job.Status != statusAlwaysHealthy {
+		job.Status = status
+	}
 }
 
 // MarkForMaintenance marks this Job's service for maintenance
@@ -156,6 +162,7 @@ func (job *Job) HealthCheck(ctx context.Context) {
 
 // StartJob runs the Job's executable
 func (job *Job) StartJob(ctx context.Context) {
+	job.setStatus(statusUnknown)
 	if job.exec != nil {
 		job.exec.Run(ctx, job.Bus)
 	}
@@ -289,6 +296,7 @@ func (job *Job) processEvent(ctx context.Context, event events.Event) bool {
 		}
 		log.Debugf("job exited but restart not permitted: %v", job.Name)
 		job.startEvent = events.NonEvent
+		job.setStatus(statusUnknown)
 		return true
 	case job.startEvent:
 		if job.startsRemain == 0 {
@@ -305,7 +313,6 @@ func (job *Job) processEvent(ctx context.Context, event events.Event) bool {
 				job.startEvent = events.NonEvent
 			}
 		}
-		job.setStatus(statusUnknown)
 		job.StartJob(ctx)
 	}
 	return false

--- a/telemetry/status.go
+++ b/telemetry/status.go
@@ -15,7 +15,7 @@ import (
 type Status struct {
 	Version  string
 	jobs     []*jobs.Job
-	Services []jobStatusResponse
+	Services []*jobStatusResponse
 	Watches  []string
 }
 
@@ -62,7 +62,7 @@ func (t *Telemetry) MonitorJobs(jobs []*jobs.Job) {
 	if t != nil {
 		for _, job := range jobs {
 			if job.Service != nil && job.Service.Port != 0 {
-				service := jobStatusResponse{
+				service := &jobStatusResponse{
 					Name:    job.Name,
 					Address: job.Service.IPAddress,
 					Port:    job.Service.Port,


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/445

From the ticket, we have two bugs in the status endpoint:
- When we set up the status handler we pre-create the response body, but we set it as a struct value rather than a pointer, which means the value we're trying to set isn't mutable.
- When a job starts, it's status is set to "unknown", which is overriding the hard-coded ContainerPilot status. We don't health check ourselves, so we then never set the status to be healthy.

This PR fixes both. We can't really exercise this in the unit test because it's a cross-package concern, but I've added a check to the `test_telemetry` integration test to ensure we catch any regressions on this in the future.

cc @cheapRoc @ramitos
