### PR TITLE
reap in its own goroutine so it can't block other signal handlers

### DIFF
--- a/sup/sup.go
+++ b/sup/sup.go
@@ -38,7 +38,7 @@ func handleSignals(pid int) {
 			case syscall.SIGTERM:
 				syscall.Kill(pid, syscall.SIGTERM)
 			case syscall.SIGCHLD:
-				reap()
+				go reap()
 			}
 		}
 	}()


### PR DESCRIPTION
I discovered this while working on #447. It's possible for the supervisor's reaping to block the handling of other signal handlers like SIGTERM. In v3 this is much less noticeable because we don't use signals for control, but we should fix it anyways.

cc @cheapRoc 