### PR TITLE
Fix when->timeout canceling running jobs

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -148,8 +148,15 @@ func (a *App) reload() error {
 // HandlePolling sets up polling functions and write their quit channels
 // back to our config
 func (a *App) handlePolling() {
+
+	// we need to subscribe to events before we Run all the jobs
+	// to avoid races where a job finishes and fires events before
+	// other jobs are even subscribed to listen for them.
 	for _, job := range a.Jobs {
-		job.Run(a.Bus)
+		job.Subscribe(a.Bus)
+	}
+	for _, job := range a.Jobs {
+		job.Run()
 	}
 	for _, watch := range a.Watches {
 		watch.Run(a.Bus)

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -43,7 +43,8 @@ func getSignalTestConfig(t *testing.T) *App {
 func TestTerminateSignal(t *testing.T) {
 	app := getSignalTestConfig(t)
 	bus := app.Bus
-	app.Jobs[0].Run(bus)
+	app.Jobs[0].Subscribe(bus)
+	app.Jobs[0].Run()
 
 	app.Terminate()
 	bus.Wait()

--- a/events/handler.go
+++ b/events/handler.go
@@ -20,6 +20,7 @@ type EventHandler struct {
 func (evh *EventHandler) Subscribe(bus *EventBus, isInternal ...bool) {
 	evh.wg.Add(1)
 	bus.Register(evh, isInternal...)
+	evh.Bus = bus
 }
 
 // Unsubscribe removes the EventHandler from the list of handlers

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -176,9 +176,7 @@ func (job *Job) Kill() {
 }
 
 // Run executes the event loop for the Job
-func (job *Job) Run(bus *events.EventBus) {
-	job.Subscribe(bus)
-	job.Bus = bus
+func (job *Job) Run() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	if job.frequency > 0 {

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -16,7 +16,8 @@ func TestJobRunSafeClose(t *testing.T) {
 	cfg := &Config{Name: "myjob", Exec: "sleep 10"} // don't want exec to finish
 	cfg.Validate(noop)
 	job := NewJob(cfg)
-	job.Run(bus)
+	job.Subscribe(bus)
+	job.Run()
 	bus.Publish(events.GlobalStartup)
 	job.Quit()
 	bus.Wait()
@@ -46,7 +47,8 @@ func TestJobRunStartupTimeout(t *testing.T) {
 		When: &WhenConfig{Source: "never", Once: "startup", Timeout: "100ms"}}
 	cfg.Validate(noop)
 	job := NewJob(cfg)
-	job.Run(bus)
+	job.Subscribe(bus)
+	job.Run()
 	job.Bus.Publish(events.GlobalStartup)
 
 	time.Sleep(200 * time.Millisecond)
@@ -88,7 +90,8 @@ func TestJobRunRestarts(t *testing.T) {
 		cfg.Validate(noop)
 		job := NewJob(cfg)
 
-		job.Run(bus)
+		job.Subscribe(bus)
+		job.Run()
 		job.Bus.Publish(events.GlobalStartup)
 		time.Sleep(100 * time.Millisecond) // TODO: we can't force this, right?
 		exitOk := events.Event{Code: events.ExitSuccess, Source: "myjob"}
@@ -125,7 +128,8 @@ func TestJobRunPeriodic(t *testing.T) {
 	}
 	cfg.Validate(noop)
 	job := NewJob(cfg)
-	job.Run(bus)
+	job.Subscribe(bus)
+	job.Run()
 	job.Bus.Publish(events.GlobalStartup)
 	exitOk := events.Event{Code: events.ExitSuccess, Source: "myjob"}
 	exitFail := events.Event{Code: events.ExitFailed, Source: "myjob"}
@@ -159,7 +163,8 @@ func TestJobMaintenance(t *testing.T) {
 		cfg.Validate(noop)
 		job := NewJob(cfg)
 		job.setStatus(startingState)
-		job.Run(bus)
+		job.Subscribe(bus)
+		job.Run()
 		job.Bus.Publish(event)
 		job.Quit()
 		return job.GetStatus()


### PR DESCRIPTION
For #456 

This PR includes:
- make separate calls to `Job.Subscribe` and `Job.Run` during startup so that we're sure all job that start later than others don't miss events emitted by the earlier jobs.
- make jobs ignore the `when->timeout` timer once they've started by setting their timeout event to the never-published `NonEvent`.

We could probably handle the latter by creating a new context in `events.NewTimeout` from the job's context, and returning a `context.CancelFunc` which `Job.StartJob` could call, but when I actually tried that we end up passing the `CancelFunc` all over the place and it got really messy. We can probably come back to that the next time we take a pass through to clean up the `Job` type's functions.

cc @cheapRoc @wheleph @ewjmulder