### PR TITLE
add raw logging field to bypass logger for exec

### DIFF
--- a/commands/args.go
+++ b/commands/args.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"errors"
-	"os/exec"
 	"strings"
 
 	"github.com/joyent/containerpilot/config/decode"
@@ -29,12 +28,4 @@ func ParseArgs(raw interface{}) (executable string, args []string, err error) {
 		args = args[1:]
 	}
 	return executable, args, err
-}
-
-// ArgsToCmd creates a command from a list of arguments
-func ArgsToCmd(executable string, args []string) *exec.Cmd {
-	if len(args) == 0 {
-		return exec.Command(executable)
-	}
-	return exec.Command(executable, args...)
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -59,7 +59,7 @@ func (c *Command) Run(pctx context.Context, bus *events.EventBus) {
 	c.lock.Lock()
 	log.Debugf("%s.Run start", c.Name)
 
-	cmd := ArgsToCmd(c.Exec, c.Args)
+	cmd := exec.Command(c.Exec, c.Args...)
 	if c.logger.Logger != nil {
 		cmd.Stdout = c.logger.Writer()
 		cmd.Stderr = c.logger.Writer()

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -29,15 +30,19 @@ func NewCommand(rawArgs interface{}, timeout time.Duration, fields log.Fields) (
 	if err != nil {
 		return nil, err
 	}
-	logger := log.WithFields(fields)
 	cmd := &Command{
 		Name:    exec, // override this in caller
 		Exec:    exec,
 		Args:    args,
 		Timeout: timeout,
 		lock:    &sync.Mutex{},
-		logger:  *logger,
 	} // exec.Cmd created at Run
+
+	if fields != nil {
+		// don't attach the logger if we don't have fields set, so that
+		// we can pass-thru the logs raw
+		cmd.logger = *log.WithFields(fields)
+	}
 	return cmd, nil
 }
 
@@ -55,8 +60,13 @@ func (c *Command) Run(pctx context.Context, bus *events.EventBus) {
 	log.Debugf("%s.Run start", c.Name)
 
 	cmd := ArgsToCmd(c.Exec, c.Args)
-	cmd.Stdout = c.logger.Writer()
-	cmd.Stderr = c.logger.Writer()
+	if c.logger.Logger != nil {
+		cmd.Stdout = c.logger.Writer()
+		cmd.Stderr = c.logger.Writer()
+	} else {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	c.Cmd = cmd
 	ctx, cancel := getContext(pctx, c.Timeout)

--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -3,10 +3,13 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/joyent/containerpilot/events"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCommandRunWithTimeoutZero(t *testing.T) {
@@ -74,6 +77,16 @@ func TestCommandRunReuseCmd(t *testing.T) {
 	cmd, _ := NewCommand("true", time.Duration(0), nil)
 	runtestCommandRun(cmd)
 	runtestCommandRun(cmd)
+}
+
+func TestCommandPassthru(t *testing.T) {
+	cmd, _ := NewCommand("true", time.Duration(0), nil)
+	runtestCommandRun(cmd)
+	assert.Equal(t, cmd.Cmd.Stdout, os.Stdout)
+
+	cmd, _ = NewCommand("true", time.Duration(0), log.Fields{"job": "trueDat"})
+	runtestCommandRun(cmd)
+	assert.NotEqual(t, cmd.Cmd.Stdout, os.Stdout)
 }
 
 // test helpers

--- a/docs/30-configuration/34-jobs.md
+++ b/docs/30-configuration/34-jobs.md
@@ -38,7 +38,9 @@ jobs: [
   {
     name: "app",
     exec: "/bin/app",
-    passthru: false,
+    logging: {
+      raw: false
+    },
 
     // 'when' defines the events that cause the job to run
     when: {
@@ -96,9 +98,9 @@ The `name` field is the name of the job as it will appear in logs and events. It
 
 The `exec` field is the executable (and its arguments) that is called when the job runs. This field can contain a string or an array of strings ([see below](#exec-arguments) for details on the format). The command to be run will have a process group set and this entire process group will be reaped by ContainerPilot when the process exits. The process will be run concurrently to all other work, so the process won't block the processing of other ContainerPilot events.
 
-##### `passthru`
+##### `logging`
 
-When the `passthru` field is set to `false` (the default), ContainerPilot will wrap each line of output from an `exec` process's stdout/stderr in a log line. If set to `true`, ContainerPilot will attach the stdout/stderr of the process to the container's stdout/stderr and these streams will be unmodified by ContainerPilot. The latter option can be useful if the process emits structured logs in its own format.
+Jobs and health checks have a `logging` configuration block with a single option: `raw`. When the `raw`field is set to `false` (the default), ContainerPilot will wrap each line of output from an `exec` process's stdout/stderr in a log line. If set to `true`, ContainerPilot will attach the stdout/stderr of the process to the container's stdout/stderr and these streams will be unmodified by ContainerPilot. The latter option can be useful if the process emits structured logs in its own format.
 
 #### Running and timing fields
 

--- a/docs/30-configuration/34-jobs.md
+++ b/docs/30-configuration/34-jobs.md
@@ -38,6 +38,7 @@ jobs: [
   {
     name: "app",
     exec: "/bin/app",
+    passthru: false,
 
     // 'when' defines the events that cause the job to run
     when: {
@@ -95,6 +96,9 @@ The `name` field is the name of the job as it will appear in logs and events. It
 
 The `exec` field is the executable (and its arguments) that is called when the job runs. This field can contain a string or an array of strings ([see below](#exec-arguments) for details on the format). The command to be run will have a process group set and this entire process group will be reaped by ContainerPilot when the process exits. The process will be run concurrently to all other work, so the process won't block the processing of other ContainerPilot events.
 
+##### `passthru`
+
+When the `passthru` field is set to `false` (the default), ContainerPilot will wrap each line of output from an `exec` process's stdout/stderr in a log line. If set to `true`, ContainerPilot will attach the stdout/stderr of the process to the container's stdout/stderr and these streams will be unmodified by ContainerPilot. The latter option can be useful if the process emits structured logs in its own format.
 
 #### Running and timing fields
 

--- a/docs/30-configuration/38-logging.md
+++ b/docs/30-configuration/38-logging.md
@@ -8,7 +8,7 @@ The optional logging config adjusts the output format and verbosity of Container
 
 There are two sources of log data with ContainerPilot. First, ContainerPilot logs information about its own state, such as when jobs fail to run or events are triggered. Please note that `DEBUG` logging includes every event that's emitted by every job, and this can be quite a lot of information.
 
-The second source of logs are the processes run by jobs and their health checks. ContainerPilot attaches to stdout and stderr for every process it starts, and streams these logs to the logging framework. These logs will be emitted at `INFO` level, with one log entry per line emitted to `stdout` or `stderr`. The child process should terminate its output with newlines.
+The second source of logs are the processes run by jobs and their health checks. By default, ContainerPilot attaches to stdout and stderr for every process it starts, and streams these logs to the logging framework. These logs will be emitted at `INFO` level, with one log entry per line emitted to `stdout` or `stderr`. The child process should terminate its output with newlines. The user can turn off this behavior for a job or its health check by setting `passthru` to `true`.
 
 Logging Format Examples:
 

--- a/docs/30-configuration/38-logging.md
+++ b/docs/30-configuration/38-logging.md
@@ -8,7 +8,7 @@ The optional logging config adjusts the output format and verbosity of Container
 
 There are two sources of log data with ContainerPilot. First, ContainerPilot logs information about its own state, such as when jobs fail to run or events are triggered. Please note that `DEBUG` logging includes every event that's emitted by every job, and this can be quite a lot of information.
 
-The second source of logs are the processes run by jobs and their health checks. By default, ContainerPilot attaches to stdout and stderr for every process it starts, and streams these logs to the logging framework. These logs will be emitted at `INFO` level, with one log entry per line emitted to `stdout` or `stderr`. The child process should terminate its output with newlines. The user can turn off this behavior for a job or its health check by setting `passthru` to `true`.
+The second source of logs are the processes run by jobs and their health checks. By default, ContainerPilot attaches to stdout and stderr for every process it starts, and streams these logs to the logging framework. These logs will be emitted at `INFO` level, with one log entry per line emitted to `stdout` or `stderr`. The child process should terminate its output with newlines. The user can turn off this behavior for a job or its health check by setting the `raw` field of its `logging` configuration to `true`.
 
 Logging Format Examples:
 

--- a/integration_tests/tests/test_logging/containerpilot.json5
+++ b/integration_tests/tests/test_logging/containerpilot.json5
@@ -14,7 +14,7 @@
       name: "job2",
       // this echo is not wrapped in a log line
       exec: "echo job2 exec",
-      passthru: true,
+      logging: { raw: true },
     },
     {
       name: "job3",
@@ -23,7 +23,7 @@
       health: {
          // this echo is not wrapped in a log line
         exec: "echo job3 health",
-        passthru: true,
+        logging: { raw: true },
         interval: 1,
         ttl: 5
       }

--- a/integration_tests/tests/test_logging/containerpilot.json5
+++ b/integration_tests/tests/test_logging/containerpilot.json5
@@ -1,0 +1,43 @@
+{
+  consul: "consul:8500",
+  logging: {
+    level: "DEBUG",
+    format: "text"
+  },
+  jobs: [
+    {
+      name: "job1",
+      // this echo gets wrapped in a log line
+      exec: "echo job1 exec",
+    },
+    {
+      name: "job2",
+      // this echo is not wrapped in a log line
+      exec: "echo job2 exec",
+      passthru: true,
+    },
+    {
+      name: "job3",
+      port: 8000,
+      exec: "sleep 5",
+      health: {
+         // this echo is not wrapped in a log line
+        exec: "echo job3 health",
+        passthru: true,
+        interval: 1,
+        ttl: 5
+      }
+    },
+    {
+      name: "job4",
+      port: 9000,
+      exec: "sleep 5",
+      health: {
+         // this echo gets wrapped in a log line
+        exec: "echo job4 health",
+        interval: 1,
+        ttl: 5
+      }
+    }
+  ]
+}

--- a/integration_tests/tests/test_logging/docker-compose.yml
+++ b/integration_tests/tests/test_logging/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     mem_limit: 128m
     links:
       - consul:consul
-    ports:
-      - 9090:9090
     volumes:
+      - './containerpilot.json5:/etc/containerpilot.json5'
       - '${CONTAINERPILOT_BIN}:/bin/containerpilot:ro'

--- a/integration_tests/tests/test_logging/run.sh
+++ b/integration_tests/tests/test_logging/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function finish {
     result=$?
@@ -13,8 +14,13 @@ docker-compose up -d consul app
 docker exec -it "$(docker-compose ps -q consul)" assert ready
 
 app=$(docker-compose ps -q app)
+sleep 1 # need time for 1st health checks to fire
 logs=$(docker logs "$app")
-result=1
-if [[ $logs == *"loaded config:"* ]]; then
-    result=0
-fi
+
+# ensure that correct log level, log format, and passthru/nonpassthru
+# settings are respected for ContainerPilot and each of the 4 jobs
+echo "$logs" | grep -q 'loaded config\:' || (echo "did not show loading config" && exit 1)
+echo "$logs" | grep -q 'msg=\"job1 exec' || (echo "bad job1 exec log" && exit 1)
+echo "$logs" | grep -q '^job2 exec' || (echo "bad job2 exec log" && exit 1)
+echo "$logs" | grep -q '^job3 health' || (echo "bad job3 health log" && exit 1)
+echo "$logs" | grep -q 'msg=\"job4 health' || (echo "bad job4 health log" && exit 1)


### PR DESCRIPTION
For #437

This PR implements a "raw" logging option for `exec` fields using the field name `passthru` (which I thought might be more descriptive than "raw"), so that we can pass the stdout/stderr for either job exec or health check exec without wrapping entries in a log. The intent is that the exec structures its own logs, and that users will configure the ContainerPilot logging to one of the structured log formats that matches. Some example configurations from the included integration test:

```json5
jobs: [
  {
    name: "job1",
    exec: "echo job1 exec",  // this echo gets wrapped in a log line
  },
  {
    name: "job2",
    exec: "echo job2 exec", // this echo is not wrapped in a log line
    passthru: true,
  },
  {
    name: "job3",
    port: 8000,
    exec: "sleep 5",
    health: {
      exec: "echo job3 health", // this echo is not wrapped in a log line
      passthru: true,
      interval: 1,
      ttl: 5
    }
  },
  {
    name: "job4",
    port: 9000,
    exec: "sleep 5",
    health: {
      exec: "echo job4 health", // this echo gets wrapped in a log line
      interval: 1,
      ttl: 5
    }
  }
]
```

cc @inetfuture @cheapRoc @misterbisson 