### PR TITLE
refactor processEvent

### DIFF
--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -18,36 +18,6 @@ const (
 	eventBufferSize = 1000
 )
 
-// JobStatus is an enum of job health status
-type JobStatus int
-
-// JobStatus enum
-const (
-	statusIdle JobStatus = iota // will be default value before starting
-	statusUnknown
-	statusHealthy
-	statusUnhealthy
-	statusMaintenance
-	statusAlwaysHealthy
-)
-
-func (i JobStatus) String() string {
-	switch i {
-	case 2:
-		return "healthy"
-	case 3:
-		return "unhealthy"
-	case 4:
-		return "maintenance"
-	case 5:
-		// for hardcoded "always healthy" jobs
-		return "healthy"
-	default:
-		// both idle and unknown return unknown for purposes of serialization
-		return "unknown"
-	}
-}
-
 // Job manages the state of a job and its start/stop conditions
 type Job struct {
 	Name string

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -12,10 +12,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Some magic numbers used internally by restart limits
+type processEventStatus bool
+
+// Some magic numbers used internally by processEvent
 const (
-	unlimited       = -1
-	eventBufferSize = 1000
+	unlimited                          = -1
+	eventBufferSize                    = 1000
+	jobContinue     processEventStatus = false
+	jobHalt         processEventStatus = true
 )
 
 // Job manages the state of a job and its start/stop conditions
@@ -153,13 +157,6 @@ func (job *Job) Run() {
 		}
 	}()
 }
-
-type processEventStatus bool
-
-const (
-	jobContinue processEventStatus = false
-	jobHalt     processEventStatus = true
-)
 
 func (job *Job) processEvent(ctx context.Context, event events.Event) processEventStatus {
 	runEverySource := fmt.Sprintf("%s.run-every", job.Name)

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -258,7 +258,7 @@ func TestJobProcessEvent(t *testing.T) {
 			statusLock:   &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
-		assert.False(t, got, "processEvent after 1st startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st startEvent")
 		assert.Equal(t, job.Status, statusUnknown)
 		assert.Equal(t, job.startsRemain, 0)
 		assert.Equal(t, job.startEvent, events.NonEvent)
@@ -281,24 +281,24 @@ func TestJobProcessEvent(t *testing.T) {
 			statusLock:     &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
-		assert.False(t, got, "processEvent after 1st startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st startEvent")
 		assert.Equal(t, job.Status, statusUnknown)
 		assert.Equal(t, job.startsRemain, 0)
 		assert.Equal(t, job.startEvent, events.NonEvent)
 
 		got = job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
-		assert.False(t, got, "processEvent after 2nd startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 2nd startEvent")
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after 1st exit")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st exit")
 		assert.Equal(t, job.restartsRemain, 1)
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after 2nd exit")
+		assert.Equal(t, got, jobContinue, "processEvent after 2nd exit")
 		assert.Equal(t, job.restartsRemain, 0)
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.True(t, got, "processEvent after 3rd exit")
+		assert.Equal(t, got, jobHalt, "processEvent after 3rd exit")
 	})
 
 	t.Run("start once unlimited restarts", func(t *testing.T) {
@@ -319,20 +319,20 @@ func TestJobProcessEvent(t *testing.T) {
 			statusLock:     &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
-		assert.False(t, got, "processEvent after 1st startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st startEvent")
 		assert.Equal(t, job.Status, statusUnknown)
 		assert.Equal(t, job.startsRemain, 0)
 		assert.Equal(t, job.startEvent, events.NonEvent)
 
 		got = job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
-		assert.False(t, got, "processEvent after 2nd startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 2nd startEvent")
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after 1st exit")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st exit")
 		assert.Equal(t, job.restartsRemain, -2)
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after 2nd exit")
+		assert.Equal(t, got, jobContinue, "processEvent after 2nd exit")
 		assert.Equal(t, job.restartsRemain, -3)
 	})
 
@@ -349,22 +349,22 @@ func TestJobProcessEvent(t *testing.T) {
 			statusLock:   &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
-		assert.False(t, got, "processEvent after 1st startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st startEvent")
 		assert.Equal(t, job.Status, statusUnknown)
 		assert.Equal(t, job.startsRemain, unlimited)
 		assert.Equal(t, job.startEvent, events.Event{events.StatusChanged, "upstream"})
 
 		got = job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
-		assert.False(t, got, "processEvent after 2nd startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 2nd startEvent")
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after exit")
+		assert.Equal(t, got, jobContinue, "processEvent after exit")
 		assert.Equal(t, job.Status, statusUnknown)
 		assert.Equal(t, job.startsRemain, unlimited)
 		assert.Equal(t, job.startEvent, events.Event{events.StatusChanged, "upstream"})
 
 		got = job.processEvent(nil, events.Event{events.StatusChanged, "upstream"})
-		assert.False(t, got, "processEvent after 3rd startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 3rd startEvent")
 	})
 
 	t.Run("global start with unlimited restarts", func(t *testing.T) {
@@ -384,10 +384,10 @@ func TestJobProcessEvent(t *testing.T) {
 
 		// should return False after each exit which means we don't stop job
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after 1st exit")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st exit")
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after 2nd exit")
+		assert.Equal(t, got, jobContinue, "processEvent after 2nd exit")
 	})
 
 	t.Run("restart once on exit", func(t *testing.T) {
@@ -406,10 +406,10 @@ func TestJobProcessEvent(t *testing.T) {
 		assert.Equal(t, job.startEvent, events.NonEvent)
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after 1st exit")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st exit")
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.True(t, got, "processEvent after 2nd exit")
+		assert.Equal(t, got, jobHalt, "processEvent after 2nd exit")
 	})
 
 	t.Run("start each startEvent with unlimited restarts", func(t *testing.T) {
@@ -427,19 +427,19 @@ func TestJobProcessEvent(t *testing.T) {
 			statusLock:     &sync.RWMutex{},
 		}
 		got := job.processEvent(nil, startEvent)
-		assert.False(t, got, "processEvent after 1st startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 1st startEvent")
 		assert.Equal(t, job.Status, statusUnknown)
 		assert.Equal(t, job.startsRemain, unlimited)
 		assert.Equal(t, job.startEvent, startEvent)
 
 		got = job.processEvent(nil, startEvent)
-		assert.False(t, got, "processEvent after 2nd startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 2nd startEvent")
 
 		got = job.processEvent(nil, events.Event{events.ExitSuccess, "testJob"})
-		assert.False(t, got, "processEvent after exit")
+		assert.Equal(t, got, jobContinue, "processEvent after exit")
 
 		got = job.processEvent(nil, startEvent)
-		assert.False(t, got, "processEvent after 3rd startEvent")
+		assert.Equal(t, got, jobContinue, "processEvent after 3rd startEvent")
 	})
 
 }

--- a/jobs/status.go
+++ b/jobs/status.go
@@ -1,0 +1,31 @@
+package jobs
+
+// JobStatus is an enum of job health status
+type JobStatus int
+
+// JobStatus enum
+const (
+	statusIdle JobStatus = iota // will be default value before starting
+	statusUnknown
+	statusHealthy
+	statusUnhealthy
+	statusMaintenance
+	statusAlwaysHealthy
+)
+
+func (i JobStatus) String() string {
+	switch i {
+	case 2:
+		return "healthy"
+	case 3:
+		return "unhealthy"
+	case 4:
+		return "maintenance"
+	case 5:
+		// for hardcoded "always healthy" jobs
+		return "healthy"
+	default:
+		// both idle and unknown return unknown for purposes of serialization
+		return "unknown"
+	}
+}


### PR DESCRIPTION
The code in `Job.processEvent` had high cyclomatic complexity because the switch in its main body contained routines which themselves were starting to get gnarly. This PR moves most of these out into their own functions. Each of these takes the job's context so we can leverage it for canceling tasks down the call graph.

I've also moved the `JobStatus` struct out to its own file to reduce the length of the `jobs.go` file, and swapped out `processEvent`'s `bool` return for a type alias to improve clarity.

cc @cheapRoc 
(the [split diff](https://github.com/joyent/containerpilot/pull/467/files?diff=split) view may be helpful here for reviewing)