### PR TITLE
centralize Rx chan initialization and increase buffer to avoid deadlock

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -46,7 +46,7 @@ func NewHTTPServer(cfg *Config) (*HTTPServer, error) {
 	srv := &HTTPServer{
 		Addr: cfg.SocketPath,
 	}
-	srv.Rx = make(chan events.Event, 10)
+	srv.InitRx()
 	return srv, nil
 }
 

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -50,7 +50,7 @@ type TestSubscriber struct {
 
 func NewTestSubscriber(bus *EventBus) *TestSubscriber {
 	my := &TestSubscriber{lock: &sync.RWMutex{}, results: []Event{}}
-	my.Rx = make(chan Event, 1000)
+	my.InitRx()
 	my.Bus = bus
 	return my
 }

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -16,10 +16,9 @@ type processEventStatus bool
 
 // Some magic numbers used internally by processEvent
 const (
-	unlimited                          = -1
-	eventBufferSize                    = 1000
-	jobContinue     processEventStatus = false
-	jobHalt         processEventStatus = true
+	unlimited                      = -1
+	jobContinue processEventStatus = false
+	jobHalt     processEventStatus = true
 )
 
 // Job manages the state of a job and its start/stop conditions
@@ -70,7 +69,7 @@ func NewJob(cfg *Config) *Job {
 		restartsRemain:    cfg.restartLimit,
 		frequency:         cfg.freqInterval,
 	}
-	job.Rx = make(chan events.Event, eventBufferSize)
+	job.InitRx()
 	job.statusLock = &sync.RWMutex{}
 	if job.Name == "containerpilot" {
 		// right now this hardcodes the telemetry service to

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -41,7 +41,7 @@ func NewMetric(cfg *MetricConfig) *Metric {
 		Type:      cfg.metricType,
 		collector: cfg.collector,
 	}
-	metric.Rx = make(chan events.Event, eventBufferSize)
+	metric.InitRx()
 	return metric
 }
 

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -45,7 +45,7 @@ func NewTelemetry(cfg *Config) *Telemetry {
 		sensor := NewMetric(sensorCfg)
 		t.Metrics = append(t.Metrics, sensor)
 	}
-	t.Rx = make(chan events.Event, 10)
+	t.InitRx()
 	return t
 }
 

--- a/watches/watches.go
+++ b/watches/watches.go
@@ -9,8 +9,6 @@ import (
 	"github.com/joyent/containerpilot/events"
 )
 
-const eventBufferSize = 1000
-
 // Watch represents an event to signal when something changes
 type Watch struct {
 	Name             string
@@ -33,7 +31,7 @@ func NewWatch(cfg *Config) *Watch {
 		poll:             cfg.Poll,
 		discoveryService: cfg.discoveryService,
 	}
-	watch.Rx = make(chan events.Event, eventBufferSize)
+	watch.InitRx()
 	return watch
 }
 


### PR DESCRIPTION
For #465 

Whenever we reload or shutdown, event handlers both deregister themselves and publish all their normal events around shutdown. When the event buffer size for a handler is too small, then enough events to fill the buffer can be published in the window between the handler exiting its own `select` and deregistering from new messages. This causes publishing of events to block and that can deadlock the deregistration process.

This PR increases the buffer size for the `telemetry` and `control` event handlers to match that of `jobs`, which are oversized. This is a patch fix that works for all sane cases, but I'll want to circle back to this at some point and make the solution more robust against extreme edge cases (ex. containers running hundreds of different jobs). I've also centralized the logic for initializing the event handler `Rx` buffers so that we can make future fixes to this in one place.

cc @cheapRoc @aleerizw