### PR TITLE
add pointers to godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://travis-ci.org/joyent/containerpilot.svg)](https://travis-ci.org/joyent/containerpilot)
 [![MPL licensed](https://img.shields.io/badge/license-MPL_2.0-blue.svg)](https://github.com/joyent/containerpilot/blob/master/LICENSE)
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot)
 
 ## What is ContainerPilot?
 

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,3 @@
+## client
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/client)

--- a/client/client.go
+++ b/client/client.go
@@ -1,3 +1,5 @@
+// Package client provides a HTTP client used to send commands to the
+// ContainerPilot control socket
 package client
 
 import (

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,0 +1,3 @@
+## commands
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/commands)

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -1,3 +1,6 @@
+// Package commands provides a wrapper around os/exec to consistently
+// manage process execution, cancellation of their child processes,
+// timeouts, logging, arg parsing, and correct shutdown.
 package commands
 
 import (

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,3 @@
+## config
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/config)

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,4 @@
+// Package config is the top-level configuration parsing package
 package config
 
 import (

--- a/config/decode/README.md
+++ b/config/decode/README.md
@@ -1,0 +1,3 @@
+## decode
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/config/decode)

--- a/config/decode/decode.go
+++ b/config/decode/decode.go
@@ -1,3 +1,5 @@
+// Package decode contains helper functions for turning  mapstructure
+// interfaces into simpler structs for configs
 package decode
 
 import (

--- a/config/logger/README.md
+++ b/config/logger/README.md
@@ -1,0 +1,3 @@
+## logger
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/config/logger)

--- a/config/logger/logging.go
+++ b/config/logger/logging.go
@@ -1,3 +1,4 @@
+// Package logger manages the configuration of logging
 package logger
 
 import (

--- a/config/services/README.md
+++ b/config/services/README.md
@@ -1,0 +1,3 @@
+## services
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/config/services)

--- a/config/services/docs.go
+++ b/config/services/docs.go
@@ -1,0 +1,3 @@
+// Package services contains miscellaneous configuration validation for
+// service names and IP addresses registered with Consul
+package services

--- a/config/template/README.md
+++ b/config/template/README.md
@@ -1,0 +1,3 @@
+## template
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/config/template)

--- a/config/template/template.go
+++ b/config/template/template.go
@@ -1,3 +1,5 @@
+// Package template provides rendering for the configuration files and
+// the extra functions for use by the golang templating engine.
 package template
 
 import (

--- a/config/timing/README.md
+++ b/config/timing/README.md
@@ -1,0 +1,3 @@
+## timing
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/config/timing)

--- a/config/timing/duration.go
+++ b/config/timing/duration.go
@@ -1,3 +1,5 @@
+// Package timing provides functions for parsing time configurations
+// into time.Duration instances
 package timing
 
 import (

--- a/control/README.md
+++ b/control/README.md
@@ -1,0 +1,3 @@
+## control
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/control)

--- a/control/control.go
+++ b/control/control.go
@@ -1,3 +1,5 @@
+// Package control provides a HTTP server listening on the unix domain
+// socket for use as a control plane, as well as all the HTTP endpoints.
 package control
 
 import (

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,3 @@
+## core
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/core)

--- a/core/app.go
+++ b/core/app.go
@@ -1,3 +1,4 @@
+// Package core contains the main control loop.
 package core
 
 import (

--- a/discovery/README.md
+++ b/discovery/README.md
@@ -1,0 +1,3 @@
+## discovery
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/discovery)

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,3 +1,5 @@
+// Package discovery manages the configuration of the Consul clients and
+// the functions used to update/query Consul with service discovery data.
 package discovery
 
 import "github.com/hashicorp/consul/api"

--- a/events/README.md
+++ b/events/README.md
@@ -1,0 +1,3 @@
+## events
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/events)

--- a/events/events.go
+++ b/events/events.go
@@ -1,3 +1,5 @@
+// Package events contains the internal message bus used to broadcast
+// events between goroutines representing jobs, watches, etc.
 package events
 
 import (

--- a/jobs/README.md
+++ b/jobs/README.md
@@ -1,0 +1,3 @@
+## jobs
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/jobs)

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -1,3 +1,4 @@
+// Package jobs manages the configuration and execution of the jobs
 package jobs
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// ContainerPilot is an init system for cloud-native distributed applications
+// that automates the process of service discovery, configuration, and
+// lifecycle management inside the container, so you can focus on your apps.
 package main // import "github.com/joyent/containerpilot"
 
 import (

--- a/subcommands/README.md
+++ b/subcommands/README.md
@@ -1,0 +1,3 @@
+## subcommands
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/subcommands)

--- a/subcommands/subcommands.go
+++ b/subcommands/subcommands.go
@@ -1,3 +1,5 @@
+// Package subcommands provides all the alternative top-level functions
+// that run one-off commands that don't run the main event loop.
 package subcommands
 
 import (

--- a/sup/README.md
+++ b/sup/README.md
@@ -1,0 +1,3 @@
+## sup
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/sup)

--- a/sup/sup.go
+++ b/sup/sup.go
@@ -1,3 +1,4 @@
+// Package sup provides the child process reaper for PID1
 package sup
 
 import (

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,0 +1,3 @@
+## telemetry
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/telemetry)

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -1,3 +1,5 @@
+// Package telemetry provides a Prometheus client and the configuration
+// for metrics collectors
 package telemetry
 
 import (

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+## tests
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/tests)

--- a/tests/mocks/README.md
+++ b/tests/mocks/README.md
@@ -1,0 +1,3 @@
+## mocks
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/tests/mocks)

--- a/version/README.md
+++ b/version/README.md
@@ -1,0 +1,3 @@
+## version
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/version)

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,4 @@
+// Package version only provides some package variables set at build time
 package version
 
 var (

--- a/watches/README.md
+++ b/watches/README.md
@@ -1,0 +1,3 @@
+## watches
+
+[![GoDoc](https://godoc.org/github.com/joyent/containerpilot?status.svg)](https://godoc.org/github.com/joyent/containerpilot/watches)

--- a/watches/watches.go
+++ b/watches/watches.go
@@ -1,3 +1,5 @@
+// Package watches manages the configuration and running of Consul
+// service monitoring
 package watches
 
 import (


### PR DESCRIPTION
This PR adds some badges pointing to the appropriate places on http://godoc.org/github.com/joyent/containerpilot and also makes sure we have at least some cursory package-level docstrings.

cc @cheapRoc 