### PR TITLE
discovery: fix tls config for Consul

### DIFF
--- a/discovery/config.go
+++ b/discovery/config.go
@@ -40,7 +40,7 @@ func getTLSConfig(parsed *parsedConfig) api.TLSConfig {
 		parsed.TLS.HTTPClientKey = clientKey
 	}
 	if serverName := os.Getenv("CONSUL_TLS_SERVER_NAME"); serverName != "" {
-		parsed.TLS.HTTPClientKey = serverName
+		parsed.TLS.HTTPTLSServerName = serverName
 	}
 	verify := os.Getenv("CONSUL_HTTP_SSL_VERIFY")
 	switch strings.ToLower(verify) {
@@ -51,8 +51,9 @@ func getTLSConfig(parsed *parsedConfig) api.TLSConfig {
 	}
 	tlsConfig := api.TLSConfig{
 		Address:            parsed.TLS.HTTPTLSServerName,
-		CAFile:             parsed.TLS.HTTPCAPath,
-		CertFile:           parsed.TLS.HTTPCAPath,
+		CAFile:             parsed.TLS.HTTPCAFile,
+		CAPath:             parsed.TLS.HTTPCAPath,
+		CertFile:           parsed.TLS.HTTPClientCert,
 		KeyFile:            parsed.TLS.HTTPClientKey,
 		InsecureSkipVerify: !parsed.TLS.HTTPSSLVerify,
 	}


### PR DESCRIPTION
- A description of what you did for the changelog:
I've changed discovery/config.go to correct assignment of parsed values

- An explanation of why ContainerPilot needs this change
Registering in TLS-enabled Consul doesn't work

- How to verify that it works (most PRs need tests!)
Try to register your service in TLS-enabled Consul. It'll fail constantly without this fix.

- A link to the GitHub issue that it addresses
#482 
