### PR TITLE
fix GOOS setting in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ docker := docker run --rm -e LDFLAGS="${LDFLAGS}" $(RUNNER)
 export PATH :=$(PATH):$(GOPATH)/bin
 
 # flags for local development
-GOOS := $(shell uname -s | tr A-Z a-iz)
+GOOS := $(shell uname -s | tr A-Z a-z)
 GOARCH := amd64
 CGO_ENABLED := 0
 GOEXPERIMENT := framepointer


### PR DESCRIPTION
While building on Linux I noticed our makefile has a typo in it, which causes the installation of `glide` and other tools to fail when we do `make tools` because `GOOS` gets set to `zinux` instead of `linux`.

cc @cheapRoc 