### PR TITLE
move defer out of loop so as not to leak a closure

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -97,10 +97,10 @@ func getEnvVarNameFromService(service string) string {
 
 // Run starts the application and blocks until finished
 func (a *App) Run() {
+	a.handleSignals()
 	for {
 		a.Bus = events.NewEventBus()
 		a.ControlServer.Run(a.Bus)
-		a.handleSignals()
 		a.handlePolling()
 		if !a.Bus.Wait() {
 			if a.StopTimeout > 0 {

--- a/events/timer.go
+++ b/events/timer.go
@@ -41,18 +41,18 @@ func NewEventTimer(
 ) {
 	go func() {
 		ticker := time.NewTicker(tick)
+		// sending the timeout event potentially races with a closing
+		// rx channel, so just recover from the panic and exit
+		defer func() {
+			if r := recover(); r != nil {
+				return
+			}
+		}()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				// sending the timeout event potentially races with a closing
-				// rx channel, so just recover from the panic and exit
-				defer func() {
-					if r := recover(); r != nil {
-						return
-					}
-				}()
 				rx <- Event{Code: TimerExpired, Source: name}
 			}
 		}


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/464

This may not be the complete fix for that #464 but it's definitely contributing. We’re creating a `defer` in the `for` loop, but that loop never exits, and so on each tick we just create a new closure. By moving that defer to the top of the goroutine we create it only once.

cc @cheapRoc 