### PR TITLE
add go vet to linting, fix lints this finds

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -58,7 +58,7 @@ func NewHTTPServer(cfg *Config) (*HTTPServer, error) {
 
 // Validate validates the state of the control server and ensures that the
 // socket does not exist prior to setting up the listener (bind).
-func (srv HTTPServer) Validate() error {
+func (srv *HTTPServer) Validate() error {
 	if srv.Addr == "" {
 		return ErrMissingAddr
 	}

--- a/jobs/config_test.go
+++ b/jobs/config_test.go
@@ -145,7 +145,7 @@ func TestJobConfigSmokeTest(t *testing.T) {
 	}
 
 	if len(jobs) != 7 {
-		t.Fatalf("expected 7 jobs ", jobs)
+		t.Fatalf("expected 7 jobs, got %v", jobs)
 	}
 	job0 := jobs[0]
 
@@ -236,7 +236,7 @@ func TestJobConfigValidateDiscovery(t *testing.T) {
 	// no health check shouldn't return an error
 	cfgD := `[{name: "myName", port: 80, interfaces: ["inet", "lo0"], health: {interval: 1, ttl: 1}}]`
 	if _, err = NewConfigs(tests.DecodeRawToSlice(cfgD), noop); err != nil {
-		t.Fatalf("expected no error", err)
+		t.Fatalf("expected no error, got %v", err)
 	}
 }
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 result=0
-for pkg in $(go list ./... | grep -v '/vendor/\|_test' | sed 's+_/'$(pwd)'+github.com/joyent/containerpilot+'); do
-  if ! golint -set_exit_status $pkg; then
-    result=1
-  fi
+for pkg in $(glide novendor)
+do
+    golint -set_exit_status "$pkg" || result=1
+    go vet "$pkg" || result=1
 done
 exit $result


### PR DESCRIPTION
This PR adds `go vet` to our linting, greatly speeds up the enumeration of the packages by leveraging glide to do it, and fixes the 3 linting problems that `go vet` finds.