### PR TITLE
split SIGCHLD from all other signal handlers in supervisor (v3)

### DIFF
--- a/sup/sup.go
+++ b/sup/sup.go
@@ -22,27 +22,39 @@ func Run() {
 	if err != nil {
 		log.Fatal("failed to start ContainerPilot worker process:", err)
 	}
-	handleSignals(proc.Pid)
+	passThroughSignals(proc.Pid)
+	handleReaping(proc.Pid)
 	proc.Wait()
 }
 
-// handleSignals listens for signals used to gracefully shutdown and
+// passThroughSignals listens for signals used to gracefully shutdown and
 // passes them thru to the ContainerPilot worker process.
-func handleSignals(pid int) {
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT, syscall.SIGCHLD, syscall.SIGUSR1)
+func passThroughSignals(pid int) {
+	sigRecv := make(chan os.Signal, 1)
+	signal.Notify(sigRecv, syscall.SIGTERM, syscall.SIGINT, syscall.SIGUSR1)
 	go func() {
-		for signal := range sig {
-			switch signal {
+		for sig := range sigRecv {
+			switch sig {
 			case syscall.SIGINT:
 				syscall.Kill(pid, syscall.SIGINT)
 			case syscall.SIGTERM:
 				syscall.Kill(pid, syscall.SIGTERM)
 			case syscall.SIGUSR1:
 				syscall.Kill(pid, syscall.SIGUSR1)
-			case syscall.SIGCHLD:
-				go reap()
 			}
+		}
+	}()
+}
+
+// handleReaping listens for the SIGCHLD signal only and triggers
+// reaping of child processes
+func handleReaping(pid int) {
+	sigRecv := make(chan os.Signal, 1)
+	signal.Notify(sigRecv, syscall.SIGCHLD)
+	go func() {
+		for {
+			<-sigRecv
+			reap()
 		}
 	}()
 }


### PR DESCRIPTION
For https://github.com/joyent/containerpilot/issues/490, in v3

This PR splits out the goroutine that handles the `SIGCHLD` signal from all other signal handlers. This lets us loop on that handler without worrying about spawning additional goroutines for each signal received and should prevent resource growth in the case where many `SIGCHLD` signals land during the handling of one of them.

cc @cheapRoc 