### PR TITLE
Refactor shutdown with new pub/sub interfaces ~ WIP

### DIFF
--- a/control/control.go
+++ b/control/control.go
@@ -74,7 +74,8 @@ func (srv HTTPServer) Validate() error {
 
 // Run executes the event loop for the control server
 func (srv *HTTPServer) Run(bus *events.EventBus) {
-	srv.Subscribe(bus, true)
+	// NOTE: Deprecate when we pull EventHandler out of HTTPServer
+	srv.Subscribe(bus)
 	srv.Bus = bus
 	srv.Start()
 
@@ -158,7 +159,8 @@ func (srv *HTTPServer) Stop() error {
 		return err
 	}
 
-	srv.Unsubscribe(srv.Bus, true)
+	// NOTE: Deprecate when we pull EventHandler out of HTTPServer
+	srv.Unsubscribe()
 	close(srv.Rx)
 	log.Debug("control: completed graceful shutdown of control server")
 	return nil

--- a/control/control.go
+++ b/control/control.go
@@ -73,8 +73,17 @@ func (srv HTTPServer) Validate() error {
 
 // Run executes the event loop for the control server
 func (srv *HTTPServer) Run(ctx context.Context, bus *events.EventBus) {
-	defer srv.Stop(ctx)
 	srv.Start(bus)
+
+	go func() {
+		defer srv.Stop(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 // Start sets up API routes with the event bus, listens on the control

--- a/core/app.go
+++ b/core/app.go
@@ -103,7 +103,7 @@ func (a *App) Run() {
 		a.handleSignals(cancel)
 
 		a.Bus = events.NewEventBus()
-		a.ControlServer.Run(ctx)
+		a.ControlServer.Run(ctx, a.Bus)
 		a.runTasks(ctx)
 
 		if !a.Bus.Wait() {

--- a/core/app.go
+++ b/core/app.go
@@ -2,6 +2,7 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -97,11 +98,14 @@ func getEnvVarNameFromService(service string) string {
 
 // Run starts the application and blocks until finished
 func (a *App) Run() {
-	a.handleSignals()
 	for {
+		ctx, cancel := context.WithCancel(context.Background())
+		a.handleSignals(cancel)
+
 		a.Bus = events.NewEventBus()
 		a.ControlServer.Run(a.Bus)
-		a.handlePolling()
+		a.handlePolling(ctx)
+
 		if !a.Bus.Wait() {
 			if a.StopTimeout > 0 {
 				log.Debugf("killing all processes in %v seconds", a.StopTimeout)
@@ -128,6 +132,11 @@ func (a *App) Terminate() {
 	a.Bus.Shutdown()
 }
 
+// NEW
+func (a *App) SetReload() {
+	a.Bus.SetReloadFlag()
+}
+
 // reload does the actual work of reloading the configuration and
 // updating the App with those changes. The EventBus should be
 // already shut down before we call this.
@@ -148,16 +157,16 @@ func (a *App) reload() error {
 
 // HandlePolling sets up polling functions and write their quit channels
 // back to our config
-func (a *App) handlePolling() {
-
+func (a *App) handlePolling(ctx context.Context) {
 	// we need to subscribe to events before we Run all the jobs
 	// to avoid races where a job finishes and fires events before
 	// other jobs are even subscribed to listen for them.
 	for _, job := range a.Jobs {
 		job.Subscribe(a.Bus)
+		job.Register(a.Bus)
 	}
 	for _, job := range a.Jobs {
-		job.Run()
+		job.Run(ctx)
 	}
 	for _, watch := range a.Watches {
 		watch.Run(a.Bus)

--- a/core/app.go
+++ b/core/app.go
@@ -163,6 +163,7 @@ func (a *App) runTasks(ctx context.Context) {
 	// other jobs are even subscribed to listen for them.
 	for _, job := range a.Jobs {
 		job.Subscribe(a.Bus)
+		job.Register(a.Bus)
 	}
 	for _, job := range a.Jobs {
 		job.Run(ctx)

--- a/core/app.go
+++ b/core/app.go
@@ -103,8 +103,8 @@ func (a *App) Run() {
 		a.handleSignals(cancel)
 
 		a.Bus = events.NewEventBus()
-		a.ControlServer.Run(a.Bus)
-		a.handlePolling(ctx)
+		a.ControlServer.Run(ctx)
+		a.runTasks(ctx)
 
 		if !a.Bus.Wait() {
 			if a.StopTimeout > 0 {
@@ -157,25 +157,24 @@ func (a *App) reload() error {
 
 // HandlePolling sets up polling functions and write their quit channels
 // back to our config
-func (a *App) handlePolling(ctx context.Context) {
+func (a *App) runTasks(ctx context.Context) {
 	// we need to subscribe to events before we Run all the jobs
 	// to avoid races where a job finishes and fires events before
 	// other jobs are even subscribed to listen for them.
 	for _, job := range a.Jobs {
 		job.Subscribe(a.Bus)
-		job.Register(a.Bus)
 	}
 	for _, job := range a.Jobs {
 		job.Run(ctx)
 	}
 	for _, watch := range a.Watches {
-		watch.Run(a.Bus)
+		watch.Run(ctx, a.Bus)
 	}
 	if a.Telemetry != nil {
-		for _, sensor := range a.Telemetry.Metrics {
-			sensor.Run(a.Bus)
+		for _, metric := range a.Telemetry.Metrics {
+			metric.Run(ctx, a.Bus)
 		}
-		a.Telemetry.Run(a.Bus)
+		a.Telemetry.Run(ctx)
 	}
 	// kick everything off
 	a.Bus.Publish(events.GlobalStartup)

--- a/core/signals.go
+++ b/core/signals.go
@@ -1,23 +1,26 @@
 package core
 
 import (
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
 )
 
 // HandleSignals listens for and captures signals used for orchestration
-func (a *App) handleSignals() {
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+func (a *App) handleSignals(cancel context.CancelFunc) {
+	recvSig := make(chan os.Signal, 1)
+	signal.Notify(recvSig, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 	go func() {
-		for signal := range sig {
-			switch signal {
-			case syscall.SIGINT:
-				a.Terminate()
-			case syscall.SIGTERM:
-				a.Terminate()
-			}
+		sig := <-recvSig
+		switch sig {
+		case syscall.SIGINT:
+			a.Terminate()
+		case syscall.SIGTERM:
+			a.Terminate()
+		case syscall.SIGHUP:
+			a.SetReload()
 		}
+		cancel()
 	}()
 }

--- a/core/signals.go
+++ b/core/signals.go
@@ -12,14 +12,15 @@ func (a *App) handleSignals(cancel context.CancelFunc) {
 	recvSig := make(chan os.Signal, 1)
 	signal.Notify(recvSig, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 	go func() {
-		sig := <-recvSig
-		switch sig {
-		case syscall.SIGINT:
-			a.Terminate()
-		case syscall.SIGTERM:
-			a.Terminate()
-		case syscall.SIGHUP:
-			a.SetReload()
+		for sig := range recvSig {
+			switch sig {
+			case syscall.SIGINT:
+				a.Terminate()
+			case syscall.SIGTERM:
+				a.Terminate()
+			case syscall.SIGHUP:
+				a.SetReload()
+			}
 		}
 		cancel()
 	}()

--- a/events/bus.go
+++ b/events/bus.go
@@ -81,29 +81,45 @@ func NewEventBus() *EventBus {
 	return bus
 }
 
-// Register the Subscriber for all Events
-func (bus *EventBus) Register(subscriber Subscriber, isInternal ...bool) {
+// Register the Publisher for all Events
+func (bus *EventBus) Register(publisher EventPublisher) {
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
-	bus.registry[subscriber] = true
+	bus.done.Add(1)
+}
+
+// Unregister the Publisher from all Events
+func (bus *EventBus) Unregister(publisher EventPublisher) {
+	bus.lock.Lock()
+	defer bus.lock.Unlock()
+	bus.done.Done()
+}
+
+// Subscribe the Subscriber for all Events
+func (bus *EventBus) Subscribe(subscriber EventSubscriber) {
+	bus.lock.Lock()
+	defer bus.lock.Unlock()
+	sub := subscriber.(Subscriber)
+	bus.registry[sub] = true
 
 	// internal subscribers like the control socket and telemetry server
 	// will never unregister from events, but we want to be able to exit
-	if len(isInternal) == 0 || !isInternal[0] {
-		bus.done.Add(1)
-	}
+	// if len(isInternal) == 0 || !isInternal[0] {
+	bus.done.Add(1)
+	// }
 }
 
-// Unregister the Subscriber from all Events
-func (bus *EventBus) Unregister(subscriber Subscriber, isInternal ...bool) {
+// Unsubscribe the Subscriber from all Events
+func (bus *EventBus) Unsubscribe(subscriber EventSubscriber) {
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
-	if _, ok := bus.registry[subscriber]; ok {
-		delete(bus.registry, subscriber)
+	sub := subscriber.(Subscriber)
+	if _, ok := bus.registry[sub]; ok {
+		delete(bus.registry, sub)
 	}
-	if len(isInternal) == 0 || !isInternal[0] {
-		bus.done.Done()
-	}
+	// if len(isInternal) == 0 || !isInternal[0] {
+	bus.done.Done()
+	// }
 }
 
 // Publish an Event to all Subscribers

--- a/events/bus.go
+++ b/events/bus.go
@@ -10,7 +10,7 @@ import (
 
 // EventBus manages the state of and transmits messages to all its Subscribers
 type EventBus struct {
-	registry map[Subscriber]bool
+	registry map[*Subscriber]bool
 	lock     *sync.RWMutex
 	reload   bool
 	done     sync.WaitGroup
@@ -71,7 +71,7 @@ func init() {
 // literal so that we know our channels are non-nil (which block sends).
 func NewEventBus() *EventBus {
 	lock := &sync.RWMutex{}
-	reg := make(map[Subscriber]bool)
+	reg := make(map[*Subscriber]bool)
 	buf := make([]Event, 10)
 	for i := range buf {
 		buf[i] = Event{}
@@ -99,7 +99,7 @@ func (bus *EventBus) Unregister(publisher EventPublisher) {
 func (bus *EventBus) Subscribe(subscriber EventSubscriber) {
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
-	sub := subscriber.(Subscriber)
+	sub := subscriber.(*Subscriber)
 	bus.registry[sub] = true
 
 	// internal subscribers like the control socket and telemetry server
@@ -113,7 +113,7 @@ func (bus *EventBus) Subscribe(subscriber EventSubscriber) {
 func (bus *EventBus) Unsubscribe(subscriber EventSubscriber) {
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
-	sub := subscriber.(Subscriber)
+	sub := subscriber.(*Subscriber)
 	if _, ok := bus.registry[sub]; ok {
 		delete(bus.registry, sub)
 	}

--- a/events/handler.go
+++ b/events/handler.go
@@ -30,17 +30,17 @@ func (evh *EventHandler) InitRx() {
 
 // Subscribe adds the EventHandler to the list of handlers that
 // receive all messages from the EventBus.
-func (evh *EventHandler) Subscribe(bus *EventBus, isInternal ...bool) {
+func (evh *EventHandler) Subscribe(bus *EventBus) {
 	evh.wg.Add(1)
-	bus.Register(evh, isInternal...)
+	bus.Subscribe(evh)
 	evh.Bus = bus
 }
 
 // Unsubscribe removes the EventHandler from the list of handlers
 // that receive messages from the EventBus.
-func (evh *EventHandler) Unsubscribe(bus *EventBus, isInternal ...bool) {
+func (evh *EventHandler) Unsubscribe() {
 	evh.wg.Done()
-	bus.Unregister(evh, isInternal...)
+	evh.Bus.Unsubscribe(evh)
 }
 
 // Receive accepts an Event for the EventHandler's receive channel.

--- a/events/publisher.go
+++ b/events/publisher.go
@@ -26,3 +26,7 @@ func (p *Publisher) Unregister() {
 func (p *Publisher) Wait() {
 	p.Bus.done.Wait()
 }
+
+func (p *Publisher) Quit() {
+	p.Bus.done.Wait()
+}

--- a/events/publisher.go
+++ b/events/publisher.go
@@ -1,0 +1,28 @@
+package events
+
+type EventPublisher interface {
+	Publish(Event)
+	Register(*EventBus)
+	Unregister()
+}
+
+type Publisher struct {
+	Bus *EventBus
+}
+
+func (p *Publisher) Publish(event Event) {
+	p.Bus.Publish(event)
+}
+
+func (p *Publisher) Register(bus *EventBus) {
+	p.Bus = bus
+	bus.Register(p)
+}
+
+func (p *Publisher) Unregister() {
+	p.Bus.Unregister(p)
+}
+
+func (p *Publisher) Wait() {
+	p.Bus.done.Wait()
+}

--- a/events/subscriber.go
+++ b/events/subscriber.go
@@ -2,9 +2,30 @@ package events
 
 // Subscriber is an interface for types that will receive messages
 // from an EventBus
-type Subscriber interface {
-	Subscribe(*EventBus, ...bool)
-	Unsubscribe(*EventBus, ...bool)
+type EventSubscriber interface {
+	Subscribe(*EventBus)
+	Unsubscribe()
 	Receive(Event)
-	Quit()
+}
+
+type Subscriber struct {
+	Rx  chan Event
+	Bus *EventBus
+}
+
+func (s *Subscriber) Subscribe(bus *EventBus) {
+	s.Bus = bus
+	bus.Subscribe(s)
+}
+
+func (s *Subscriber) Unsubscribe() {
+	s.Bus.Unsubscribe(s)
+}
+
+func (s *Subscriber) Receive(event Event) {
+	s.Rx <- event
+}
+
+func (s *Subscriber) Wait() {
+	s.Bus.done.Wait()
 }

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -357,6 +357,7 @@ func (job *Job) cleanup(ctx context.Context, cancel context.CancelFunc) {
 		job.Service.Deregister() // deregister from Consul
 	}
 	job.Unsubscribe() // deregister from events
+	job.Unregister()
 	job.Publish(events.Event{Code: events.Stopped, Source: job.Name})
 }
 

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -50,6 +50,8 @@ type Job struct {
 	restartsRemain int
 	frequency      time.Duration
 
+	Bus *events.EventBus
+
 	events.Subscriber
 	events.Publisher
 }
@@ -70,7 +72,6 @@ func NewJob(cfg *Config) *Job {
 		restartLimit:      cfg.restartLimit,
 		restartsRemain:    cfg.restartLimit,
 		frequency:         cfg.freqInterval,
-		rx:                make(chan string, 20),
 	}
 	// job.InitRx()
 	job.statusLock = &sync.RWMutex{}
@@ -355,7 +356,7 @@ func (job *Job) cleanup(ctx context.Context, cancel context.CancelFunc) {
 	if job.Service != nil {
 		job.Service.Deregister() // deregister from Consul
 	}
-	job.Unsubscribe(job.Bus) // deregister from events
+	job.Unsubscribe() // deregister from events
 	job.Bus.Publish(events.Event{Code: events.Stopped, Source: job.Name})
 }
 

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -51,8 +51,6 @@ type Job struct {
 	restartsRemain int
 	frequency      time.Duration
 
-	Bus *events.EventBus
-
 	events.Subscriber
 	events.Publisher
 }
@@ -206,7 +204,7 @@ func (job *Job) startJobExec(ctx context.Context) {
 	job.startTimeoutEvent = events.NonEvent
 	job.setStatus(statusUnknown)
 	if job.exec != nil {
-		job.exec.Run(ctx, job.Bus)
+		job.exec.Run(ctx, job.Publisher.Bus)
 	}
 }
 
@@ -214,7 +212,7 @@ func (job *Job) onHeartbeatTimerExpired(ctx context.Context) processEventStatus 
 	status := job.GetStatus()
 	if status != statusMaintenance && status != statusIdle {
 		if job.healthCheckExec != nil {
-			job.healthCheckExec.Run(ctx, job.Bus)
+			job.healthCheckExec.Run(ctx, job.Publisher.Bus)
 		} else if job.Service != nil {
 			// this is the case for non-checked but advertised
 			// services like the telemetry endpoint

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -41,7 +41,7 @@ func NewMetric(cfg *MetricConfig) *Metric {
 		Type:      cfg.metricType,
 		collector: cfg.collector,
 	}
-	// metric.InitRx()
+	metric.Rx = make(chan events.Event, eventBufferSize)
 	return metric
 }
 

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -31,7 +31,7 @@ type Metric struct {
 	Type      MetricType
 	collector prometheus.Collector
 
-	events.EventHandler // Event handling
+	events.Subscriber
 }
 
 // NewMetric creates a Metric from a validated MetricConfig
@@ -41,7 +41,7 @@ func NewMetric(cfg *MetricConfig) *Metric {
 		Type:      cfg.metricType,
 		collector: cfg.collector,
 	}
-	metric.InitRx()
+	// metric.InitRx()
 	return metric
 }
 
@@ -80,14 +80,14 @@ func (metric *Metric) record(metricValue string) {
 }
 
 // Run executes the event loop for the Metric
-func (metric *Metric) Run(bus *events.EventBus) {
+func (metric *Metric) Run(pctx context.Context, bus *events.EventBus) {
 	metric.Subscribe(bus)
-	metric.Bus = bus
-	ctx, cancel := context.WithCancel(context.Background())
+	// metric.Bus = bus
+	ctx, cancel := context.WithCancel(pctx)
 	go func() {
 		defer func() {
 			cancel()
-			metric.Unsubscribe(metric.Bus)
+			metric.Unsubscribe()
 		}()
 		for {
 			select {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -53,8 +53,16 @@ func NewTelemetry(cfg *Config) *Telemetry {
 
 // Run executes the event loop for the telemetry server
 func (t *Telemetry) Run(ctx context.Context) {
-	defer t.Stop(ctx)
 	t.Start()
+	go func() {
+		defer t.Stop(ctx)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 // Start starts serving the telemetry service

--- a/watches/watches.go
+++ b/watches/watches.go
@@ -76,7 +76,6 @@ func (watch *Watch) Run(pctx context.Context, bus *events.EventBus) {
 	go func() {
 		defer func() {
 			cancel()
-			// watch.Unsubscribe(watch.Bus)
 			watch.Unregister()
 		}()
 		for {

--- a/watches/watches.go
+++ b/watches/watches.go
@@ -62,16 +62,16 @@ func (watch *Watch) Tick() time.Duration {
 }
 
 // Run executes the event loop for the Watch
-func (watch *Watch) Run(ctx context.Context, bus *events.EventBus) {
+func (watch *Watch) Run(pctx context.Context, bus *events.EventBus) {
 	watch.Register(bus)
-	watch.Bus = bus
-	ctx2, cancel := context.WithCancel(ctx)
+	// watch.Bus = bus
+	ctx, cancel := context.WithCancel(pctx)
 
 	// timerSource := fmt.Sprintf("%s.poll", watch.Name)
 	timerSource := watch.Name + ".poll"
 	// NOTE: replace by implementing a timer that's only used within the local
 	// scope of this watch Run func.
-	events.NewEventTimer(ctx2, watch.rx, watch.Tick(), timerSource)
+	events.NewEventTimer(ctx, watch.rx, watch.Tick(), timerSource)
 
 	go func() {
 		defer func() {
@@ -104,7 +104,7 @@ func (watch *Watch) Run(ctx context.Context, bus *events.EventBus) {
 					events.GlobalShutdown:
 					return
 				}
-			case <-ctx2.Done():
+			case <-ctx.Done():
 				watch.Unregister()
 				watch.Wait()
 				return

--- a/watches/watches_test.go
+++ b/watches/watches_test.go
@@ -1,6 +1,7 @@
 package watches
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -43,7 +44,8 @@ func runWatchTest(cfg *Config, count int, disc discovery.Backend) map[events.Eve
 	bus := events.NewEventBus()
 	cfg.Validate(disc)
 	watch := NewWatch(cfg)
-	watch.Run(bus)
+	ctx := context.Background()
+	watch.Run(ctx, bus)
 
 	poll := events.Event{events.TimerExpired, fmt.Sprintf("%s.poll", cfg.Name)}
 	bus.Publish(poll)


### PR DESCRIPTION
**\*WIP\*** This is highly in flux, no tests, and I've broken everything. I'm working through the interfaces to see where I need to focus and make changes so I needed review as I step through this.

Included...
- Passing `context` up from `app.go`.
- Stubbed out new `Publisher` and `Subscriber` under `events/`.
- I've begun integrating `Publisher` and `Subscriber` into `Job`.
- I think I've fully covered `Publisher` into `Watch` (minus refactoring out Timeout event).
- Working `Subscriber` into `Metric`.
- Ripping `EventHandler` out (it isn't used anymore).
- Passing `context` into the control and telemetry servers and handling shutdown there.

Missing...
- Control and Telemetry reloading behavior.
- Control bus for publishing Endpoint events.
- Test changes to accommodate everything.