### PR TITLE
Migrate from deprecated Consul API call PassTTL to UpdateTTL (#515)

### DIFF
--- a/discovery/consul.go
+++ b/discovery/consul.go
@@ -57,10 +57,10 @@ func NewConsul(config interface{}) (*Consul, error) {
 	return consul, nil
 }
 
-// PassTTL wraps the Consul.Agent's PassTTL method, and is used to set a
-// TTL check to the passing state
-func (c *Consul) PassTTL(name, note string) error {
-	return c.Agent().PassTTL(name, note)
+// UpdateTTL wraps the Consul.Agent's UpdateTTL method, and is used to set a TTL
+// check to the passing state
+func (c *Consul) UpdateTTL(checkID, output, status string) error {
+	return c.Agent().UpdateTTL(checkID, output, status)
 }
 
 // CheckRegister wraps the Consul.Agent's CheckRegister method,

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -8,7 +8,7 @@ import "github.com/hashicorp/consul/api"
 type Backend interface {
 	CheckForUpstreamChanges(service, tag, dc string) (bool, bool)
 	CheckRegister(check *api.AgentCheckRegistration) error
-	PassTTL(checkID, note string) error
+	UpdateTTL(checkID, output, status string) error
 	ServiceDeregister(serviceID string) error
 	ServiceRegister(service *api.AgentServiceRegistration) error
 }

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -49,7 +49,7 @@ func (service *ServiceDefinition) SendHeartbeat() error {
 		return nil
 	}
 	checkID := fmt.Sprintf("service:%s", service.ID)
-	if err := service.Consul.PassTTL(checkID, "ok"); err != nil {
+	if err := service.Consul.UpdateTTL(checkID, "ok", "pass"); err != nil {
 		log.Infof("service not registered: %v", err)
 		if err = service.registerService(); err != nil {
 			log.Warnf("service registration failed: %s", err)

--- a/tests/mocks/discovery.go
+++ b/tests/mocks/discovery.go
@@ -25,8 +25,8 @@ func (noop *NoopDiscoveryBackend) CheckRegister(check *api.AgentCheckRegistratio
 	return nil
 }
 
-// PassTTL (required for mock interface)
-func (noop *NoopDiscoveryBackend) PassTTL(checkID, note string) error {
+// UpdateTTL (required for mock interface)
+func (noop *NoopDiscoveryBackend) UpdateTTL(checkID, output, status string) error {
 	return nil
 }
 


### PR DESCRIPTION
Ref: #515 

This starts a PR fixes the Consul API deprecation and begins exploring what other deprecations/dependencies we can clean up.

~~FTM we'll keep this open.~~