### PR TITLE
Fix a goroutine leak in the signal handler code path

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -130,7 +130,7 @@ func (a *App) Run() {
 		}()
 
 		a.Bus = events.NewEventBus()
-		a.handleSignals(cancel)
+		a.handleSignals(ctx, cancel)
 		a.ControlServer.Run(ctx, a.Bus)
 		a.runTasks(ctx, completedCh)
 

--- a/core/app.go
+++ b/core/app.go
@@ -98,6 +98,8 @@ func getEnvVarNameFromService(service string) string {
 
 // Run starts the application and blocks until finished
 func (a *App) Run() {
+	a.handleSignals()
+
 	for {
 		ctx, cancel := context.WithCancel(context.Background())
 
@@ -130,7 +132,6 @@ func (a *App) Run() {
 		}()
 
 		a.Bus = events.NewEventBus()
-		a.handleSignals(ctx, cancel)
 		a.ControlServer.Run(ctx, a.Bus)
 		a.runTasks(ctx, completedCh)
 

--- a/core/app.go
+++ b/core/app.go
@@ -110,6 +110,14 @@ func (a *App) Run() {
 		// `IsComplete`, and shutdown ContainerPilot if all jobs are
 		// completed. This is because ContainerPilot is NOT a server and must
 		// shut down when no longer required (i.e. process containers).
+		//
+		// Consider that this fires the global context.CancelFunc after all jobs
+		// have completed. This means we'll serialize the shut down of all
+		// dependent services, control server, telemetry, watches, metrics,
+		// after jobs have finalized here (quit == true). This is the reason the
+		// signal handler above, and reload endpoint, only need to fire a
+		// GlobalShutdown across the event bus. Context handles everything after
+		// that process.
 		completedCh := make(chan bool)
 		go func() {
 			for {

--- a/core/signals.go
+++ b/core/signals.go
@@ -8,20 +8,26 @@ import (
 )
 
 // HandleSignals listens for and captures signals used for orchestration
-func (a *App) handleSignals(cancel context.CancelFunc) {
+func (a *App) handleSignals(ctx context.Context, cancel context.CancelFunc) {
 	recvSig := make(chan os.Signal, 1)
 	signal.Notify(recvSig, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
-		for sig := range recvSig {
-			switch sig {
-			case syscall.SIGINT:
-				a.Terminate()
-				break
-			case syscall.SIGTERM:
-				a.Terminate()
-				break
+		for {
+			select {
+			case sig := <-recvSig:
+				switch sig {
+				case syscall.SIGINT:
+					a.Terminate()
+					return
+				case syscall.SIGTERM:
+					a.Terminate()
+					return
+				default:
+				}
+			case <-ctx.Done():
+				return
+			default:
 			}
 		}
-		cancel()
 	}()
 }

--- a/core/signals.go
+++ b/core/signals.go
@@ -1,30 +1,24 @@
 package core
 
 import (
-	"context"
 	"os"
 	"os/signal"
 	"syscall"
 )
 
 // HandleSignals listens for and captures signals used for orchestration
-func (a *App) handleSignals(ctx context.Context, cancel context.CancelFunc) {
+func (a *App) handleSignals() {
 	recvSig := make(chan os.Signal, 1)
 	signal.Notify(recvSig, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		for {
-			select {
-			case sig := <-recvSig:
-				switch sig {
-				case syscall.SIGINT:
-					a.Terminate()
-					return
-				case syscall.SIGTERM:
-					a.Terminate()
-					return
-				default:
-				}
-			case <-ctx.Done():
+			sig := <-recvSig
+			switch sig {
+			case syscall.SIGINT:
+				a.Terminate()
+				return
+			case syscall.SIGTERM:
+				a.Terminate()
 				return
 			default:
 			}

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -72,10 +72,10 @@ func TestTerminateSignal(t *testing.T) {
 // Test that only ensures that we cover a straight-line run through
 // the handleSignals setup code
 func TestSignalWiring(t *testing.T) {
-	_, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	app := EmptyApp()
 	app.Bus = events.NewEventBus()
-	app.handleSignals(cancel)
+	app.handleSignals(ctx, cancel)
 	sendAndWaitForSignal(t, syscall.SIGTERM)
 }
 

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -72,10 +72,9 @@ func TestTerminateSignal(t *testing.T) {
 // Test that only ensures that we cover a straight-line run through
 // the handleSignals setup code
 func TestSignalWiring(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
 	app := EmptyApp()
 	app.Bus = events.NewEventBus()
-	app.handleSignals(ctx, cancel)
+	app.handleSignals()
 	sendAndWaitForSignal(t, syscall.SIGTERM)
 }
 


### PR DESCRIPTION
The root cause of this issue was regarding our change to shutting down via
context. While implementating that change set there was a goroutine leak
introduced that did not provide a clean way for shutting down and reloading the
signal handler. This caused signal handling to be duplicated across reloads.

Fixes: #521