### PR TITLE
Upgrade ContainerPilot to Go 1.9.x and Consul 1.0.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
-FROM golang:1.8
+FROM golang:1.9
+
+ENV CONSUL_VERSION=1.0.0
+ENV GLIDE_VERSION=0.12.3
 
 RUN  apt-get update \
      && apt-get install -y unzip \
      && go get github.com/golang/lint/golint \
-     && curl -Lo /tmp/glide.tgz "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz" \
+     && curl -Lo /tmp/glide.tgz "https://github.com/Masterminds/glide/releases/download/v${GLIDE_VERSION}/glide-v${GLIDE_VERSION}-linux-amd64.tar.gz" \
      && tar -C /usr/bin -xzf /tmp/glide.tgz --strip=1 linux-amd64/glide \
-     && curl --fail -Lso consul.zip              "https://releases.hashicorp.com/consul/0.7.5/consul_0.7.5_linux_amd64.zip" \
+     && curl --fail -Lso consul.zip "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \
      && unzip consul.zip -d /usr/bin
 
 ENV CGO_ENABLED 0

--- a/discovery/consul_test.go
+++ b/discovery/consul_test.go
@@ -3,9 +3,9 @@ package discovery
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	consul "github.com/hashicorp/consul/api"
-	"github.com/hashicorp/consul/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,18 +77,18 @@ a Consul server for testing. The 'consul' binary must be in the $PATH
 ref https://github.com/hashicorp/consul/tree/master/testutil
 */
 
-var testServer *testutil.TestServer
+var testServer *TestServer
 
 func TestWithConsul(t *testing.T) {
 	var err error
-	testServer, err = testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
-		c.LogLevel = "err"
-	})
+	testServer, err = NewTestServer(8500)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	defer testServer.Stop()
+
+	time.Sleep(300 * time.Millisecond)
+
 	t.Run("TestConsulTTLPass", testConsulTTLPass)
 	t.Run("TestConsulReregister", testConsulReregister)
 	t.Run("TestConsulCheckForChanges", testConsulCheckForChanges)

--- a/discovery/consul_test.go
+++ b/discovery/consul_test.go
@@ -80,9 +80,14 @@ ref https://github.com/hashicorp/consul/tree/master/testutil
 var testServer *testutil.TestServer
 
 func TestWithConsul(t *testing.T) {
-	testServer, _ = testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
+	var err error
+	testServer, err = testutil.NewTestServerConfigT(t, func(c *testutil.TestServerConfig) {
 		c.LogLevel = "err"
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	defer testServer.Stop()
 	t.Run("TestConsulTTLPass", testConsulTTLPass)
 	t.Run("TestConsulReregister", testConsulReregister)

--- a/discovery/test_server.go
+++ b/discovery/test_server.go
@@ -1,0 +1,55 @@
+package discovery
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// TestServer represents a Consul server we can run our tests against. Depends
+// on a local `consul` binary installed into our environ's PATH.
+type TestServer struct {
+	cmd      *exec.Cmd
+	HTTPAddr string
+}
+
+// NewTestServer constructs a new TestServer by including the httpPort as well.
+func NewTestServer(httpPort int) (*TestServer, error) {
+	path, err := exec.LookPath("consul")
+	if err != nil || path == "" {
+		return nil, fmt.Errorf("consul not found on $PATH - download and install " +
+			"consul or skip this test")
+	}
+
+	args := []string{"agent", "-dev"}
+	cmd := exec.Command("consul", args...)
+	cmd.Stdout = io.Writer(os.Stdout)
+	cmd.Stderr = io.Writer(os.Stderr)
+	if err := cmd.Start(); err != nil {
+		return nil, errors.New("failed starting command")
+	}
+
+	httpAddr := fmt.Sprintf("127.0.0.1:%d", httpPort)
+
+	return &TestServer{
+		cmd:      cmd,
+		HTTPAddr: httpAddr,
+	}, nil
+}
+
+// Stop stops a TestServer
+func (s *TestServer) Stop() error {
+	if s.cmd == nil {
+		return nil
+	}
+
+	if s.cmd.Process != nil {
+		if err := s.cmd.Process.Signal(os.Interrupt); err != nil {
+			return errors.New("failed to kill consul server")
+		}
+	}
+
+	return s.cmd.Wait()
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 35866aee7d26c8bf31a492efa451621e3d62b1ab62ccfd646460318b91bba833
-updated: 2017-11-12T11:32:01.653670901-05:00
+hash: c13286385a0d957eb3b4e47af1f85b6cd8d8b084c846737477f46ac04d2c44f2
+updated: 2017-11-13T21:22:43.229954534-05:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -17,15 +17,11 @@ imports:
   version: 783a405d781ffc5edaf2d6b5eff41e22df96644f
   subpackages:
   - api
-  - lib/freeport
-  - testutil
   - testutil/retry
 - name: github.com/hashicorp/go-cleanhttp
   version: 3573b8b52aa7b37b9358d966a898feb387f62437
 - name: github.com/hashicorp/go-rootcerts
   version: 6bb64b370b90e7ef1fa532be9e591a81c3493e00
-- name: github.com/hashicorp/go-uuid
-  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
 - name: github.com/hashicorp/serf
   version: 91fd53b1d3e624389ed9a295a3fa380e5c7b9dfc
   subpackages:
@@ -36,12 +32,8 @@ imports:
   - pbutil
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
-- name: github.com/mitchellh/go-testing-interface
-  version: a61a99592b77c9ba629d254a693acffaeb4b7e28
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
-- name: github.com/pkg/errors
-  version: c605e284fe17294bda444b34710735b29d1a9d90
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: a730729c91753fec77a0c9b4084e37a07ab19dceb8f5c4f8b134eee0d7980df9
-updated: 2017-07-05T15:36:19.413681678-04:00
+hash: 35866aee7d26c8bf31a492efa451621e3d62b1ab62ccfd646460318b91bba833
+updated: 2017-11-12T11:32:01.653670901-05:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
-- name: github.com/docker/go-units
-  version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
+- name: github.com/client9/reopen
+  version: 1a6ccbeaae3f56aa0058f5491382cb21726e214e
 - name: github.com/flynn/json5
   version: 7620272ed63390e979cf5882d2fa0506fe2a8db5
 - name: github.com/golang/protobuf
@@ -14,9 +14,10 @@ imports:
   subpackages:
   - proto
 - name: github.com/hashicorp/consul
-  version: 2c7715154d8d4568524b76d2d4deb7ca6fd1b285
+  version: 783a405d781ffc5edaf2d6b5eff41e22df96644f
   subpackages:
   - api
+  - lib/freeport
   - testutil
   - testutil/retry
 - name: github.com/hashicorp/go-cleanhttp
@@ -35,6 +36,8 @@ imports:
   - pbutil
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
+- name: github.com/mitchellh/go-testing-interface
+  version: a61a99592b77c9ba629d254a693acffaeb4b7e28
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - name: github.com/pkg/errors
@@ -57,8 +60,6 @@ imports:
   version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
   - xfs
-- name: github.com/samalba/dockerclient
-  version: a3036261847103270e9f732509f43b5f98710ace
 - name: github.com/sirupsen/logrus
   version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: golang.org/x/sys
@@ -66,9 +67,15 @@ imports:
   subpackages:
   - unix
 testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
-- name: github.com/client9/reopen
-  version: 1a6ccbeaae3f56aa0058f5491382cb21726e214e

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: 1.0.0
 - package: github.com/hashicorp/consul
-  version: 1.0.1-rc1
+  version: ~1.0.0
   subpackages:
   - api
 - package: github.com/mitchellh/mapstructure

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: 1.0.0
 - package: github.com/hashicorp/consul
-  version: ~0.8.4
+  version: 1.0.1-rc1
   subpackages:
   - api
 - package: github.com/mitchellh/mapstructure

--- a/makefile
+++ b/makefile
@@ -21,6 +21,9 @@ GOARCH ?= $(shell go env GOARCH)
 CGO_ENABLED := 0
 GOEXPERIMENT := framepointer
 
+CONSUL_VERSION := 1.0.0
+GLIDE_VERSION := 0.12.3
+
 ## display this help message
 help:
 	@echo -e "\033[32m"
@@ -94,13 +97,13 @@ dep-add: build/containerpilot_build
 # run 'GOOS=darwin make tools' if you're installing on MacOS
 ## set up local dev environment
 tools:
-	@go version | grep 1.[8,9] || (echo 'go1.8 or go1.9 should be installed')
+	@go version | grep 1.9 || (echo 'WARNING: go1.9 should be installed!')
 	@$(if $(value GOPATH),, $(error 'GOPATH not set'))
 	go get github.com/golang/lint/golint
-	curl --fail -Lso glide.tgz "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-$(GOOS)-$(GOARCH).tar.gz"
+	curl --fail -Lso glide.tgz "https://github.com/Masterminds/glide/releases/download/v$(GLIDE_VERSION)/glide-v$(GLIDE_VERSION)-$(GOOS)-$(GOARCH).tar.gz"
 	tar -C "$(GOPATH)/bin" -xzf glide.tgz --strip=1 $(GOOS)-$(GOARCH)/glide
 	rm glide.tgz
-	curl --fail -Lso consul.zip "https://releases.hashicorp.com/consul/0.7.5/consul_0.7.5_$(GOOS)_$(GOARCH).zip"
+	curl --fail -Lso consul.zip "https://releases.hashicorp.com/consul/$(CONSUL_VERSION)/consul_$(CONSUL_VERSION)_$(GOOS)_$(GOARCH).zip"
 	unzip consul.zip -d "$(GOPATH)/bin"
 	rm consul.zip
 


### PR DESCRIPTION
Ref: #519 

This is a WIP PR. 

EDIT: Note that Consul is pegged at 1.0.1-rc1 and we'll want to finalize once a GM is released. 