### PR TITLE
Post release patches for various shutdown bits

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -118,7 +118,7 @@ func (a *App) Run() {
 		// signal handler above, and reload endpoint, only need to fire a
 		// GlobalShutdown across the event bus. Context handles everything after
 		// that process.
-		completedCh := make(chan bool)
+		completedCh := make(chan struct{}, 1)
 		go func() {
 			for {
 				select {
@@ -159,7 +159,6 @@ func (a *App) Run() {
 			log.Error(err)
 			break
 		}
-		cancel()
 		close(completedCh)
 	}
 }
@@ -198,7 +197,7 @@ func (a *App) reload() error {
 
 // HandlePolling sets up polling functions and write their quit channels
 // back to our config
-func (a *App) runTasks(ctx context.Context, completedCh chan bool) {
+func (a *App) runTasks(ctx context.Context, completedCh chan struct{}) {
 	// we need to subscribe to events before we Run all the jobs
 	// to avoid races where a job finishes and fires events before
 	// other jobs are even subscribed to listen for them.

--- a/core/signals.go
+++ b/core/signals.go
@@ -19,17 +19,12 @@ func (a *App) handleSignals() {
 		for {
 			sig := <-recvSig
 			switch sig {
-			case syscall.SIGINT:
+			case syscall.SIGINT, syscall.SIGTERM:
 				a.Terminate()
-				return
-			case syscall.SIGTERM:
-				a.Terminate()
-				return
 			case syscall.SIGHUP, syscall.SIGUSR2:
 				if s := toString(sig); s != "" {
 					a.SignalEvent(s)
 				}
-			default:
 			}
 		}
 	}()

--- a/core/signals_test.go
+++ b/core/signals_test.go
@@ -62,7 +62,7 @@ func getSignalEventTestConfig(signals []string) *App {
 // by this same test, but that we don't have a separate unit test
 // because they'll interfere with each other's state.
 func TestTerminateSignal(t *testing.T) {
-	stopCh := make(chan bool)
+	stopCh := make(chan struct{}, 1)
 	app := getSignalTestConfig()
 	bus := app.Bus
 	ctx, cancel := context.WithCancel(context.Background())
@@ -93,7 +93,7 @@ func TestTerminateSignal(t *testing.T) {
 // Test handler for handling signal events SIGHUP (and SIGUSR2). Note that the
 // SIGUSR1 is currently setup to handle reloading ContainerPilot's log file.
 func TestSignalEvent(t *testing.T) {
-	stopCh := make(chan bool)
+	stopCh := make(chan struct{}, 1)
 	signals := []string{"SIGHUP", "SIGUSR2"}
 	app := getSignalEventTestConfig(signals)
 	bus := app.Bus

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestJobRunSafeClose(t *testing.T) {
 	bus := events.NewEventBus()
-	stopCh := make(chan bool)
+	stopCh := make(chan struct{}, 1)
 	cfg := &Config{
 		Name: "myjob",
 		Exec: "sleep 10",
@@ -50,7 +50,7 @@ func TestJobRunSafeClose(t *testing.T) {
 // A Job should timeout if not started before the startupTimeout
 func TestJobRunStartupTimeout(t *testing.T) {
 	bus := events.NewEventBus()
-	stopCh := make(chan bool)
+	stopCh := make(chan struct{}, 1)
 	cfg := &Config{Name: "myjob", Exec: "true",
 		When: &WhenConfig{Source: "never", Once: "startup", Timeout: "100ms"}}
 	cfg.Validate(noop)
@@ -88,7 +88,7 @@ func TestJobRunStartupTimeout(t *testing.T) {
 // A Job should not timeout if started before the startupTimeout
 func TestJobRunStartupNoTimeout(t *testing.T) {
 	bus := events.NewEventBus()
-	stopCh := make(chan bool)
+	stopCh := make(chan struct{}, 1)
 	cfg := &Config{Name: "myjob", Exec: "sleep 5",
 		When: &WhenConfig{Timeout: "500ms"}}
 	cfg.Validate(noop)
@@ -127,7 +127,7 @@ func TestJobRunStartupNoTimeout(t *testing.T) {
 func TestJobRunRestarts(t *testing.T) {
 	runRestartsTest := func(restarts interface{}, expected int) {
 		bus := events.NewEventBus()
-		stopCh := make(chan bool)
+		stopCh := make(chan struct{}, 1)
 		cfg := &Config{
 			Name:            "myjob",
 			whenEvent:       events.GlobalStartup,
@@ -165,7 +165,7 @@ func TestJobRunRestarts(t *testing.T) {
 
 func TestJobRunPeriodic(t *testing.T) {
 	bus := events.NewEventBus()
-	stopCh := make(chan bool)
+	stopCh := make(chan struct{}, 1)
 	cfg := &Config{
 		Name: "myjob",
 		Exec: []string{"./testdata/test.sh", "doStuff", "runPeriodicTest"},
@@ -208,7 +208,7 @@ func TestJobRunPeriodic(t *testing.T) {
 func TestJobMaintenance(t *testing.T) {
 	testFunc := func(t *testing.T, startingState JobStatus, event events.Event) JobStatus {
 		bus := events.NewEventBus()
-		stopCh := make(chan bool)
+		stopCh := make(chan struct{}, 1)
 		cfg := &Config{
 			Name: "myjob",
 			Exec: "true",


### PR DESCRIPTION
This PR touches up a few areas of previously released shutdown patches.

- Use a composite literal of type `struct{}` as the sender type for the `completedCh` channel.
- Add a shared lock so that Jobs block when being marked `IsComplete`.
- Remove a redundant `cancel()` during app reload/shutdown.
- Clean-up signal handler since it's only run once per-app process.
- `SIGINT` and `SIGTERM` no longer exit the signal handler and can be called multiple times.

Most of these are just preventive measures for various bits around the new shutdown logic.