### PR TITLE
Prevent overzealous collection of Metric events through Prometheus

### DIFF
--- a/events/bus.go
+++ b/events/bus.go
@@ -126,7 +126,11 @@ func (bus *EventBus) Publish(event Event) {
 	bus.lock.Lock()
 	defer bus.lock.Unlock()
 	log.Debugf("event: %v", event)
-	collector.WithLabelValues(event.Code.String(), event.Source).Inc()
+
+	if event.Code.String() != "Metric" {
+		collector.WithLabelValues(event.Code.String(), event.Source).Inc()
+	}
+
 	for subscriber := range bus.registry {
 		// sending to an unsubscribed Subscriber shouldn't be a runtime
 		// error, so this is in intentionally allowed to panic here


### PR DESCRIPTION
Ref: #536 

This prevents `Metric` events from being collected by the event bus Prometheus collector. This removes the issue where any number of unique values hitting a counter or gauge could be recorded as unique Metric events. This would eventually cause the endpoint to get sluggish from so many unique events.