### PR TITLE
Small typos

### DIFF
--- a/docs/30-configuration/33-consul.md
+++ b/docs/30-configuration/33-consul.md
@@ -4,7 +4,7 @@ ContainerPilot uses Hashicorp's [Consul](https://www.consul.io/) to register job
 
 ## Client configuration
 
-The `consul` field in the ContainerPilot config file configures ContainerPilot's Consul client. For use with Consul's ACL system, use the `CONSUL_HTTP_TOKEN` environment variable. If you are communicating with Consul over TLS you may include the scheme (ex. https://consul:8500). Note that generally the Consul client will be communicating to an agent on localhost, so TLS may not b necessary. If you need extra configuration options for TLS, you can use the following optional fields (or environment variable options described in the [Consul documentation](https://www.consul.io/docs/commands/index.html#environment-variables))instead of a simple string:
+The `consul` field in the ContainerPilot config file configures ContainerPilot's Consul client. For use with Consul's ACL system, use the `CONSUL_HTTP_TOKEN` environment variable. If you are communicating with Consul over TLS you may include the scheme (ex. https://consul:8500). Note that generally the Consul client will be communicating to an agent on localhost, so TLS may not be necessary. If you need extra configuration options for TLS, you can use the following optional fields (or environment variable options described in the [Consul documentation](https://www.consul.io/docs/commands/index.html#environment-variables)) instead of a simple string:
 
 ```json5
 consul: {


### PR DESCRIPTION
b => be
and a space before "instead"