### PR TITLE
Patch RFC3339 formatting to remove incomplete writer type

### DIFF
--- a/config/logger/logging.go
+++ b/config/logger/logging.go
@@ -59,7 +59,9 @@ func (l *Config) Init() error {
 	case "json":
 		formatter = &logrus.JSONFormatter{}
 	case "default":
-		formatter = &DefaultLogFormatter{}
+		formatter = &DefaultLogFormatter{
+			TimestampFormat: time.RFC3339Nano,
+		}
 	default:
 		return fmt.Errorf("Unknown log format '%s'", l.Format)
 	}
@@ -86,13 +88,14 @@ func (l *Config) Init() error {
 
 // DefaultLogFormatter delegates formatting to standard go log package
 type DefaultLogFormatter struct {
+	TimestampFormat string
 }
 
 // Format formats the logrus entry by passing it to the "log" package
 func (f *DefaultLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
 	logger := log.New(b, "", 0)
-	logger.Println(time.Now().Format(time.RFC3339Nano) + " " + string(entry.Message))
+	logger.Println(time.Now().Format(f.TimestampFormat) + " " + string(entry.Message))
 	// Panic and Fatal are handled by logrus automatically
 	return b.Bytes(), nil
 }

--- a/config/logger/logging.go
+++ b/config/logger/logging.go
@@ -88,20 +88,11 @@ func (l *Config) Init() error {
 type DefaultLogFormatter struct {
 }
 
-// RFC3339logWriter io.Writer that outputs RFC3339 dates
-type RFC3339logWriter struct {
-}
-
-func (writer RFC3339logWriter) Write(bytes []byte) (int, error) {
-	return fmt.Print(time.Now().Format(time.RFC3339Nano) + " " + string(bytes))
-}
-
 // Format formats the logrus entry by passing it to the "log" package
 func (f *DefaultLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-
 	b := &bytes.Buffer{}
-	logger := log.New(new(RFC3339logWriter), "", 0)
-	logger.Println(entry.Message)
+	logger := log.New(b, "", 0)
+	logger.Println(time.Now().Format(time.RFC3339Nano) + " " + string(entry.Message))
 	// Panic and Fatal are handled by logrus automatically
 	return b.Bytes(), nil
 }


### PR DESCRIPTION
Ref: #540 

I believe this patch fixes the issues surrounding an incomplete community contribution. The problem is that the bytes returned from the buffer are never actually utilized (the buffer is only init'd as 0-byte and never used). Also, logging (`fmt.Print`) was being handled by the defunct writer type itself and not properly through Logrus as it was before the commit. I've removed the cruft and attempted to keep the formatting.

I need to run tests and verify that this doesn't have any other residuals first but this will make a quick patch release for 3.6.2 by EOW.
  