### PR TITLE
logging: JSON format now uses RFC3339Nano which includes milliseconds

### DIFF
--- a/config/logger/logging.go
+++ b/config/logger/logging.go
@@ -57,7 +57,9 @@ func (l *Config) Init() error {
 	case "text":
 		formatter = &logrus.TextFormatter{}
 	case "json":
-		formatter = &logrus.JSONFormatter{}
+		formatter = &logrus.JSONFormatter{
+			TimestampFormat: time.RFC3339Nano,
+		}
 	case "default":
 		formatter = &DefaultLogFormatter{
 			TimestampFormat: time.RFC3339Nano,


### PR DESCRIPTION
Ref: #545 

Please read the above issue (#545) for feedback on how this log format is changing.