### PR TITLE
logging: Add job name and PID to default log output lines ~ WIP

### DIFF
--- a/config/logger/logging.go
+++ b/config/logger/logging.go
@@ -95,7 +95,18 @@ type DefaultLogFormatter struct {
 func (f *DefaultLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	b := &bytes.Buffer{}
 	logger := log.New(b, "", 0)
-	logger.Println(time.Now().Format(f.TimestampFormat) + " " + string(entry.Message))
+
+	fields := ""
+	if len(entry.Data) != 0 {
+		if jobName := entry.Data["job"]; jobName != nil {
+			fields = fmt.Sprintf("%s %s", fields, jobName)
+		}
+		if pidID := entry.Data["pid"]; pidID != nil {
+			fields = fmt.Sprintf("%s %d", fields, pidID)
+		}
+	}
+
+	logger.Println(time.Now().Format(f.TimestampFormat) + fields + " " + string(entry.Message))
 	// Panic and Fatal are handled by logrus automatically
 	return b.Bytes(), nil
 }


### PR DESCRIPTION
Ref: #544 

This PR introduces job name and PID into the default text log output.