### PR TITLE
Set health timeout to health interval if omitted.

### DIFF
--- a/jobs/config.go
+++ b/jobs/config.go
@@ -297,7 +297,7 @@ func (cfg *Config) validateHealthCheck() error {
 		}
 		checkTimeout = parsedTimeout
 	} else {
-		checkTimeout = cfg.execTimeout
+		checkTimeout = cfg.heartbeatInterval
 	}
 
 	if cfg.Health.CheckExec != nil {

--- a/jobs/config_test.go
+++ b/jobs/config_test.go
@@ -52,6 +52,21 @@ func TestJobConfigServiceWithPreStart(t *testing.T) {
 	assert.Nil(job1.serviceDefinition, "config for job1.serviceDefinition")
 }
 
+func TestJobConfigHealthTimeout(t *testing.T) {
+	jobs := loadTestConfig(t)
+	assert := assert.New(t)
+
+	job0 := jobs[0]
+	assert.Equal(job0.Name, "serviceA", "config for job0.Name")
+	assert.Equal(job0.heartbeatInterval, time.Duration(10) * time.Second, "config for job0.Health")
+	assert.Equal(job0.healthCheckExec.Timeout, time.Duration(5) * time.Second, "config for job0.Name.Health")
+
+	job1 := jobs[1]
+	assert.Equal(job1.Name, "serviceB", "config for job1.Name")
+	assert.Equal(job1.heartbeatInterval, time.Duration(10) * time.Second, "config for job1.Health")
+	assert.Equal(job1.healthCheckExec.Timeout, job1.heartbeatInterval, "config for job1.Health")
+}
+
 func TestJobConfigServiceWithArrayExec(t *testing.T) {
 	jobs := loadTestConfig(t)
 	assert := assert.New(t)

--- a/jobs/testdata/TestJobConfigHealthTimeout.json5
+++ b/jobs/testdata/TestJobConfigHealthTimeout.json5
@@ -1,0 +1,23 @@
+[
+  {
+    name: "serviceA",
+    port: 80,
+    exec: "/bin/serviceA",
+    health: {
+      exec: "/bin/healthCheckA.sh",
+      interval: 10,
+      ttl: 20,
+      timeout: "5s"
+    }
+  },
+  {
+    name: "serviceB",
+    port: 80,
+    exec: "/bin/serviceB",
+    health: {
+      exec: "/bin/healthCheckB.sh",
+      interval: 10,
+      ttl: 20,
+    }
+  }
+]


### PR DESCRIPTION
This sets the health check timeout to be the same as the health check interval if the timeout configuration is omitted. This is to make the configuration for health check timeouts and job exec timeouts consistent. Read more in the issue https://github.com/joyent/containerpilot/issues/549.