### PR TITLE
Register critical services in consul.

### DIFF
--- a/discovery/service.go
+++ b/discovery/service.go
@@ -15,7 +15,7 @@ type ServiceDefinition struct {
 	Port                           int
 	TTL                            int
 	Tags                           []string
-	InitialStatus									 string
+	InitialStatus                  string
 	IPAddress                      string
 	EnableTagOverride              bool
 	DeregisterCriticalServiceAfter string

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -15,6 +15,7 @@ type ServiceDefinition struct {
 	Port                           int
 	TTL                            int
 	Tags                           []string
+	InitialStatus									 string
 	IPAddress                      string
 	EnableTagOverride              bool
 	DeregisterCriticalServiceAfter string
@@ -49,9 +50,29 @@ func (service *ServiceDefinition) SendHeartbeat() error {
 	return nil
 }
 
-// RegisterUnhealthy registers the service with status set to critical.
-func (service *ServiceDefinition) RegisterUnhealthy() {
-	service.register(api.HealthCritical)
+// Register the service with its configured initial status.
+func (service *ServiceDefinition) RegisterWithInitialStatus() {
+	if service.wasRegistered {
+		return
+	}
+
+	status := ""
+
+	switch service.InitialStatus {
+		case "passing":
+			status = api.HealthPassing
+			break
+		case "warning":
+			status = api.HealthWarning
+			break
+		case "critical":
+			status = api.HealthCritical
+			break
+	}
+
+	log.Infof("Registering service %v with initial status set to %v",
+	          service.Name, service.InitialStatus)
+	service.register(status)
 }
 
 // Register registers the service with the given status in Consul.

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -25,43 +25,51 @@ type ServiceDefinition struct {
 
 // Deregister removes the service from Consul.
 func (service *ServiceDefinition) Deregister() {
-	service.MarkForMaintenance()
-}
-
-// MarkForMaintenance removes the service from Consul.
-func (service *ServiceDefinition) MarkForMaintenance() {
 	log.Debugf("deregistering: %s", service.ID)
 	if err := service.Consul.ServiceDeregister(service.ID); err != nil {
 		log.Infof("deregistering failed: %s", err)
 	}
 }
 
-// SendHeartbeat writes a TTL check status=ok to the consul store.
-// If consul has never seen this service, we register the service and
-// its TTL check.
+// MarkForMaintenance removes the service from Consul.
+func (service *ServiceDefinition) MarkForMaintenance() {
+	service.Deregister()
+}
+
+// SendHeartbeat writes a TTL check status=ok to the Consul store.
 func (service *ServiceDefinition) SendHeartbeat() error {
-	if !service.wasRegistered {
-		if err := service.registerService(); err != nil {
-			log.Warnf("service registration failed: %s", err)
-			return err
-		}
-		service.wasRegistered = true
-		return nil
-	}
+	// Make sure the service is registered.
+	service.register(api.HealthPassing)
+
 	checkID := fmt.Sprintf("service:%s", service.ID)
 	if err := service.Consul.UpdateTTL(checkID, "ok", "pass"); err != nil {
-		log.Infof("service not registered: %v", err)
-		if err = service.registerService(); err != nil {
+		log.Warnf("service update TTL failed: %s", err)
+	}
+
+	return nil
+}
+
+// RegisterUnhealthy registers the service with status set to critical.
+func (service *ServiceDefinition) RegisterUnhealthy() {
+	service.register(api.HealthCritical)
+}
+
+// Register registers the service with the given status in Consul.
+func (service *ServiceDefinition) register(status string) error {
+	if !service.wasRegistered {
+		if err := service.registerService(status); err != nil {
 			log.Warnf("service registration failed: %s", err)
 			return err
 		}
 		log.Infof("Service registered: %v", service.Name)
+		service.wasRegistered = true
 	}
+
 	return nil
 }
 
 // registers the service along with a check set to the passing state
-func (service *ServiceDefinition) registerService() error {
+func (service *ServiceDefinition) registerService(status string) error {
 	return service.Consul.ServiceRegister(
 		&api.AgentServiceRegistration{
 			ID:                service.ID,
@@ -72,7 +80,7 @@ func (service *ServiceDefinition) registerService() error {
 			EnableTagOverride: service.EnableTagOverride,
 			Check: &api.AgentServiceCheck{
 				TTL:    fmt.Sprintf("%ds", service.TTL),
-				Status: api.HealthPassing,
+				Status: status,
 				Notes:  fmt.Sprintf("TTL for %s set by containerpilot", service.Name),
 				DeregisterCriticalServiceAfter: service.DeregisterCriticalServiceAfter,
 			},

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -50,7 +50,7 @@ func (service *ServiceDefinition) SendHeartbeat() error {
 	return nil
 }
 
-// Register the service with its configured initial status.
+// RegisterWithInitialStatus registers the service with its configured initial status.
 func (service *ServiceDefinition) RegisterWithInitialStatus() {
 	if service.wasRegistered {
 		return

--- a/docs/30-configuration/34-jobs.md
+++ b/docs/30-configuration/34-jobs.md
@@ -76,6 +76,7 @@ jobs: [
     // 'port', 'tags', 'interfaces', and 'consul' define options for
     // service discovery with Consul
     port: 80,
+    initialStatus: "warning", // optional status to immediately register service with
     tags: [
       "app",
       "prod"
@@ -223,6 +224,10 @@ jobs: [
   }
 ]
 ```
+
+##### `initialStatus`
+
+The `initialStatus` field is optional and specifies which status to immediately register the service with. If not specified, the service will not be registered in consul until after the first successful health check. Valid values are `passing`, `warning` or `critical`.
 
 ##### `tags`
 

--- a/jobs/config.go
+++ b/jobs/config.go
@@ -168,7 +168,7 @@ func (cfg *Config) valdiateInitialStatus() error {
 	if cfg.InitialStatus != "passing" &&
 		cfg.InitialStatus != "warning" &&
 		cfg.InitialStatus != "critical" {
-		return fmt.Errorf("job[%s].initialStatus must be one of 'passing', 'warning' or 'critical'.",
+		return fmt.Errorf("job[%s].initialStatus must be one of 'passing', 'warning' or 'critical'",
 			cfg.Name)
 	}
 

--- a/jobs/config.go
+++ b/jobs/config.go
@@ -24,7 +24,7 @@ type Config struct {
 
 	// service discovery
 	Port              int           `mapstructure:"port"`
-	InitialStatus     string        `mapstructure:"initialStatus"`
+	InitialStatus     string        `mapstructure:"initial_status"`
 	Interfaces        interface{}   `mapstructure:"interfaces"`
 	Tags              []string      `mapstructure:"tags"`
 	ConsulExtras      *ConsulExtras `mapstructure:"consul"`

--- a/jobs/config_test.go
+++ b/jobs/config_test.go
@@ -111,6 +111,21 @@ func TestJobConfigServiceNonAdvertised(t *testing.T) {
 	assert.Equal(job.restartLimit, unlimited, "config for job.restartLimit")
 }
 
+func TestJobConfigServiceWithInitialStatus(t *testing.T) {
+	jobs := loadTestConfig(t)
+	assert := assert.New(t)
+
+	job0 := jobs[0]
+	assert.Equal(job0.Name, "serviceA", "config for job0.Name")
+	assert.Equal(job0.Port, 8080, "config for job0.Port")
+	assert.Equal(job0.InitialStatus, "warning", "config for job0.InitialStatus")
+
+	// job1.InitialStatus should not be validated since the job has no service.
+	job1 := jobs[1]
+	assert.Equal(job1.Name, "serviceB", "config for job1.Name")
+	assert.Equal(job1.InitialStatus, "invalid-value", "config for job1.InitialStatus")
+}
+
 func TestJobConfigPeriodicTask(t *testing.T) {
 	job := loadTestConfig(t)[0]
 	assert := assert.New(t)
@@ -242,6 +257,10 @@ func TestJobConfigValidateDiscovery(t *testing.T) {
 	cfgB := `[{name: "myName", port: 80, interfaces: ["inet", "lo0"], health: {interval: 1}}]`
 	_, err = NewConfigs(tests.DecodeRawToSlice(cfgB), noop)
 	assert.Error(err, "job[myName].health.ttl must be > 0")
+
+	cfgC := `[{name: "myName", port: 80, initialStatus: "invalid", interfaces: ["inet", "lo0"], health: {interval: 1, ttl: 1}}]`
+	_, err = NewConfigs(tests.DecodeRawToSlice(cfgC), noop)
+	assert.Error(err, "job[myName].intialStatus must be one of 'passing', 'warning' or 'critical'.")
 
 	// no health check shouldn't return an error
 	cfgD := `[{name: "myName", port: 80, interfaces: ["inet", "lo0"], health: {interval: 1, ttl: 1}}]`

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -98,8 +98,8 @@ func FromConfigs(cfgs []*Config) []*Job {
 	return jobs
 }
 
-// sendHeartbeat sends a heartbeat for this Job's service
-func (job *Job) sendHeartbeat() {
+// SendHeartbeat sends a heartbeat for this Job's service
+func (job *Job) SendHeartbeat() {
 	if job.Service != nil {
 		job.Service.SendHeartbeat()
 	}
@@ -250,7 +250,7 @@ func (job *Job) onHeartbeatTimerExpired(ctx context.Context) processEventStatus 
 		} else if job.Service != nil {
 			// this is the case for non-checked but advertised
 			// services like the telemetry endpoint
-			job.sendHeartbeat()
+			job.SendHeartbeat()
 		}
 	}
 	return jobContinue
@@ -287,7 +287,7 @@ func (job *Job) onHealthCheckPassed(ctx context.Context) processEventStatus {
 	if job.GetStatus() != statusMaintenance {
 		job.setStatus(statusHealthy)
 		job.Publish(events.Event{events.StatusHealthy, job.Name})
-		job.sendHeartbeat()
+		job.SendHeartbeat()
 	}
 	return jobContinue
 }

--- a/jobs/testdata/TestJobConfigServiceWithInitialStatus.json5
+++ b/jobs/testdata/TestJobConfigServiceWithInitialStatus.json5
@@ -1,0 +1,18 @@
+[
+  {
+    name: "serviceA",
+    port: 8080,
+    initialStatus: "warning",
+    exec: "/bin/serviceA",
+    health: {
+      exec: "/bin/to/healthcheck/for/service/A.sh",
+      interval: 10,
+      ttl: 30,
+    },
+  },
+  {
+    name: "serviceB",
+    initialStatus: "invalid-value",
+    exec: "/bin/serviceB",
+  }
+]

--- a/jobs/testdata/TestJobConfigServiceWithInitialStatus.json5
+++ b/jobs/testdata/TestJobConfigServiceWithInitialStatus.json5
@@ -2,7 +2,7 @@
   {
     name: "serviceA",
     port: 8080,
-    initialStatus: "warning",
+    initial_status: "warning",
     exec: "/bin/serviceA",
     health: {
       exec: "/bin/to/healthcheck/for/service/A.sh",
@@ -12,7 +12,7 @@
   },
   {
     name: "serviceB",
-    initialStatus: "invalid-value",
+    initial_status: "invalid-value",
     exec: "/bin/serviceB",
   }
 ]


### PR DESCRIPTION
Fixes #552 

This PR adds the functionality to register services in consul that never gets healthy to be able to filter on failed services in consul and see that they are misbehaving. 

I've added a method for registering a service with the status set to critical. This is called in `onHealthChechFailed`, but only if the service hasn't already been registered. I've also made some minor refactoring in `services/services.go`, i.e. having `MarkForMaintenance` call `Deregister` instead of the other way around.
