### PR TITLE
logging: Ignore debug logs of timer ticks for internal telemetry health checks

### DIFF
--- a/events/timer.go
+++ b/events/timer.go
@@ -58,7 +58,12 @@ func NewEventTimer(
 				return
 			case <-ticker.C:
 				event := Event{Code: TimerExpired, Source: name}
-				log.Debugf("timer: %v", event)
+				// do not log the telemetry health check timer ticks since this
+				// log statement is called once for every internal heartbeat
+				// check, which is a bit excessive under DEBUG logging [GH-556]
+				if event.Source != "containerpilot.heartbeat" {
+					log.Debugf("timer: %v", event)
+				}
 				rx <- event
 			}
 		}


### PR DESCRIPTION
Fixes: #556

This removes excessive logging of internal timer ticks used for monitoring the health of telemetry server. Considering this is a service of ContainerPilot itself and the DEBUG statements are an attempt to help users debug their configurations, I feel we can safely ignore this.