### PR TITLE
Update 32-configuration-file.md to fix missing end quote for template default example

### DIFF
--- a/docs/30-configuration/32-configuration-file.md
+++ b/docs/30-configuration/32-configuration-file.md
@@ -267,7 +267,7 @@ ContainerPilot configuration has template support. If you have an environment va
 
 ##### `default`
 
-Provides a default value if the variable is empty. For example: `{{ .CONSUL | default "localhost}}` would output `localhost` if the `CONSUL` env var is not set.
+Provides a default value if the variable is empty. For example: `{{ .CONSUL | default "localhost"}}` would output `localhost` if the `CONSUL` env var is not set.
 
 ##### `split` and `join`
 


### PR DESCRIPTION
Fix missing end quote for template default example.