### PR TITLE
Issue 592 : support service meta data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.9
+FROM golang:1.13
 
-ENV CONSUL_VERSION=1.0.0
+ENV CONSUL_VERSION=1.9.5
 ENV GLIDE_VERSION=0.12.3
 
 RUN  apt-get update \
      && apt-get install -y unzip \
-     && go get github.com/golang/lint/golint \
+     && go get -u golang.org/x/lint/golint \
      && curl -Lo /tmp/glide.tgz "https://github.com/Masterminds/glide/releases/download/v${GLIDE_VERSION}/glide-v${GLIDE_VERSION}-linux-amd64.tar.gz" \
      && tar -C /usr/bin -xzf /tmp/glide.tgz --strip=1 linux-amd64/glide \
      && curl --fail -Lso consul.zip "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \
@@ -13,3 +13,4 @@ RUN  apt-get update \
 
 ENV CGO_ENABLED 0
 ENV GOPATH /go:/cp
+ENV XDG_CACHE_HOME=/tmp/.cache

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,6 +33,7 @@ func TestValidConfigJobs(t *testing.T) {
 	assert.Equal(job0.Port, 8080, "config for job0.Port")
 	assert.Equal(job0.Exec, "/bin/serviceA", "config for job0.Exec")
 	assert.Equal(job0.Tags, []string{"tag1", "tag2"}, "config for job0.Tags")
+	assert.Equal(job0.Meta, map[string]string{"keyA": "A"}, "config for job0.Meta")
 	assert.Equal(job0.Restarts, nil, "config for job1.Restarts")
 
 	job1 := cfg.Jobs[1]

--- a/config/testdata/test.json5
+++ b/config/testdata/test.json5
@@ -18,7 +18,10 @@
         interval: 19,
         ttl: 30,
       },
-      tags: ["tag1","tag2"]
+      tags: ["tag1","tag2"],
+      meta: {
+        keyA: "A",
+      }
     },
     {
       name: "serviceB",

--- a/discovery/service.go
+++ b/discovery/service.go
@@ -15,6 +15,7 @@ type ServiceDefinition struct {
 	Port                           int
 	TTL                            int
 	Tags                           []string
+	Meta                           map[string]string
 	InitialStatus                  string
 	IPAddress                      string
 	EnableTagOverride              bool
@@ -59,19 +60,19 @@ func (service *ServiceDefinition) RegisterWithInitialStatus() {
 	status := ""
 
 	switch service.InitialStatus {
-		case "passing":
-			status = api.HealthPassing
-			break
-		case "warning":
-			status = api.HealthWarning
-			break
-		case "critical":
-			status = api.HealthCritical
-			break
+	case "passing":
+		status = api.HealthPassing
+		break
+	case "warning":
+		status = api.HealthWarning
+		break
+	case "critical":
+		status = api.HealthCritical
+		break
 	}
 
 	log.Infof("Registering service %v with initial status set to %v",
-	          service.Name, service.InitialStatus)
+		service.Name, service.InitialStatus)
 	service.register(status)
 }
 
@@ -96,13 +97,14 @@ func (service *ServiceDefinition) registerService(status string) error {
 			ID:                service.ID,
 			Name:              service.Name,
 			Tags:              service.Tags,
+			Meta:              service.Meta,
 			Port:              service.Port,
 			Address:           service.IPAddress,
 			EnableTagOverride: service.EnableTagOverride,
 			Check: &api.AgentServiceCheck{
-				TTL:    fmt.Sprintf("%ds", service.TTL),
-				Status: status,
-				Notes:  fmt.Sprintf("TTL for %s set by containerpilot", service.Name),
+				TTL:                            fmt.Sprintf("%ds", service.TTL),
+				Status:                         status,
+				Notes:                          fmt.Sprintf("TTL for %s set by containerpilot", service.Name),
 				DeregisterCriticalServiceAfter: service.DeregisterCriticalServiceAfter,
 			},
 		},

--- a/discovery/test_server.go
+++ b/discovery/test_server.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"testing"
 
-	"github.com/hashicorp/consul/testutil/retry"
+	"github.com/hashicorp/consul/sdk/testutil/retry"
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 )
 
@@ -59,21 +60,13 @@ func (s *TestServer) Stop() error {
 	return s.cmd.Wait()
 }
 
-// failer implements the retry.Failer interface
-type failer struct {
-	failed bool
-}
-
-func (f *failer) Log(args ...interface{}) { fmt.Println(args) }
-func (f *failer) FailNow()                { f.failed = true }
-
 // WaitForAPI waits for only the agent HTTP endpoint to start responding. This
 // is an indication that the agent has started, but will likely return before a
 // leader is elected.
-func (s *TestServer) WaitForAPI() error {
-	f := &failer{}
-	retry.Run(f, func(r *retry.R) {
-		resp, err := s.client.Get(s.HTTPAddr + "/v1/agent/self")
+func (s *TestServer) WaitForAPI(t *testing.T) error {
+	//f := &failer{}
+	retry.Run(t, func(r *retry.R) {
+		resp, err := s.client.Get("http://" + s.HTTPAddr + "/v1/agent/self")
 		if err != nil {
 			r.Fatal(err)
 		}
@@ -83,7 +76,7 @@ func (s *TestServer) WaitForAPI() error {
 			r.Fatalf("bad status code %d", resp.StatusCode)
 		}
 	})
-	if f.failed {
+	if t.Failed() {
 		return errors.New("failed waiting for API")
 	}
 	return nil

--- a/docs/30-configuration/32-configuration-file.md
+++ b/docs/30-configuration/32-configuration-file.md
@@ -60,6 +60,10 @@ The following is a completed example of the JSON5 file configuration schema, wit
         "app",
         "prod"
       ],
+      meta: {
+        keyA: "A",
+        keyB: "B",
+      },
       interfaces: [
         "eth0",
         "eth1[1]",

--- a/docs/30-configuration/34-jobs.md
+++ b/docs/30-configuration/34-jobs.md
@@ -239,7 +239,7 @@ The `tags` field is an optional array of tags to be used when the job is registe
 
 ##### `meta`
 
-The `meta` field is an optional map key/value to be used when the job is registered as a service in Consul. Other containers can use these meta in `watches` to filter a service by meta data.
+The `meta` field is an optional map key/value to be used when the job is registered as a service in Consul. Key names must be valid JSON5/Ecmascript identifierNames or be quoted and follow consul limitation , practical this means only [a-zA-Z0-9_-] can be used in key names and key names with '-' must be quoted
 
 ##### `interfaces`
 

--- a/docs/30-configuration/34-jobs.md
+++ b/docs/30-configuration/34-jobs.md
@@ -81,6 +81,10 @@ jobs: [
       "app",
       "prod"
     ],
+    meta: {
+      keyA: "A",
+      keyB: "B",   
+    },    
     interfaces: [
       "eth0",
       "eth1[1]",
@@ -232,6 +236,10 @@ The `initial_status` field is optional and specifies which status to immediately
 ##### `tags`
 
 The `tags` field is an optional array of tags to be used when the job is registered as a service in Consul. Other containers can use these tags in `watches` to filter a service by tag.
+
+##### `meta`
+
+The `meta` field is an optional map key/value to be used when the job is registered as a service in Consul. Other containers can use these meta in `watches` to filter a service by meta data.
 
 ##### `interfaces`
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,63 +1,121 @@
-hash: c13286385a0d957eb3b4e47af1f85b6cd8d8b084c846737477f46ac04d2c44f2
-updated: 2017-11-13T21:22:43.229954534-05:00
+hash: 4ae87054be3359a9b14ab2688be9869641175298445ec67308d049a03105c392
+updated: 2021-06-08T05:39:54.309148219Z
 imports:
+- name: github.com/armon/go-metrics
+  version: a054c40a13a85da90bb36b889d4e20664a173215
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: 37c8de3658fcb183f997c4e13e8337516ab753e6
   subpackages:
   - quantile
 - name: github.com/client9/reopen
-  version: 1a6ccbeaae3f56aa0058f5491382cb21726e214e
+  version: dbabf56e0beda57421ccdf6c7431a75a7d8a1562
+- name: github.com/fatih/color
+  version: cf452350f542986d689fb53db88dbb0212f141db
 - name: github.com/flynn/json5
   version: 7620272ed63390e979cf5882d2fa0506fe2a8db5
 - name: github.com/golang/protobuf
-  version: 6a1fa9404c0aebf36c879bc50152edcc953910d2
+  version: ae97035608a719c7a1c1c41bed0ae0744bdb0c6f
   subpackages:
   - proto
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/timestamp
 - name: github.com/hashicorp/consul
-  version: 783a405d781ffc5edaf2d6b5eff41e22df96644f
+  version: bbcbb733b416acd7066fe4e0157c58678e4ba1e4
   subpackages:
   - api
-  - testutil/retry
+  - sdk/testutil/retry
 - name: github.com/hashicorp/go-cleanhttp
-  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+  version: 6d9e2ac5d828e5f8594b97f88c4bde14a67bb6d2
+- name: github.com/hashicorp/go-hclog
+  version: f07802e845f9dc40480e42adbecdf7b3e7e89937
+- name: github.com/hashicorp/go-immutable-radix
+  version: f63f49c0b598a5ead21c5015fb4d08fe7e3c21ea
 - name: github.com/hashicorp/go-rootcerts
-  version: 6bb64b370b90e7ef1fa532be9e591a81c3493e00
+  version: c8a9a31cbd7675425d28e4e56713d0368a3aeb2c
+- name: github.com/hashicorp/golang-lru
+  version: 80c98217689d6df152309d574ccc682b21dc802c
+  subpackages:
+  - simplelru
 - name: github.com/hashicorp/serf
-  version: 91fd53b1d3e624389ed9a295a3fa380e5c7b9dfc
+  version: 7faa1b06262f70780c3c35ac25a4c96d754f06f3
   subpackages:
   - coordinate
+- name: github.com/mattn/go-colorable
+  version: f6c00982823144337e56cdb71c712eaac151d29c
+- name: github.com/mattn/go-isatty
+  version: 8b0c6d82fa8980f9bff874afff66860a0c3e9c5c
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  version: c182affec369e30f25d3eb8cd8a478dee585ae7d
   subpackages:
   - pbutil
 - name: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: af06845cf3004701891bf4fdb884bfe4920b3727
 - name: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
+  version: 170205fb58decfd011f1550d4cfb737230d7ae4f
   subpackages:
   - prometheus
+  - prometheus/internal
+  - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: 147c58e9608a4f9628b53b6cc863325ca746f63a
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 0866df4b85a18d652b6965be022d007cdf076822
+  version: 9e276a1555878cfdaeeea42127f40f2518861145
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  version: e8361a78447375e011eba5d699109138d0afc530
   subpackages:
-  - xfs
+  - internal/fs
+  - internal/util
 - name: github.com/sirupsen/logrus
   version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: golang.org/x/sys
-  version: 94b76065f2d2081d0fef24a6e67c571f51a6408a
+  version: aa57babbf139f2cf189f7cc4dce7ad03fec65ed6
   subpackages:
+  - internal/unsafeheader
   - unix
+  - windows
+- name: google.golang.org/protobuf
+  version: 21e33cc91079beb975323466e237f2486ea29c10
+  subpackages:
+  - encoding/prototext
+  - encoding/protowire
+  - internal/descfmt
+  - internal/descopts
+  - internal/detrand
+  - internal/encoding/defval
+  - internal/encoding/messageset
+  - internal/encoding/tag
+  - internal/encoding/text
+  - internal/errors
+  - internal/filedesc
+  - internal/filetype
+  - internal/flags
+  - internal/genid
+  - internal/impl
+  - internal/order
+  - internal/pragma
+  - internal/set
+  - internal/strs
+  - internal/version
+  - proto
+  - reflect/protodesc
+  - reflect/protoreflect
+  - reflect/protoregistry
+  - runtime/protoiface
+  - runtime/protoimpl
+  - types/descriptorpb
+  - types/known/anypb
+  - types/known/durationpb
+  - types/known/timestamppb
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,13 +5,13 @@ import:
 - package: github.com/sirupsen/logrus
   version: 1.0.0
 - package: github.com/hashicorp/consul
-  version: ~1.0.0
+  version: ~1.9.0
   subpackages:
   - api
 - package: github.com/mitchellh/mapstructure
   version: d2dd0262208475919e1a362f675cfc0e7c10e905
 - package: github.com/prometheus/client_golang
-  version: 0.8.0
+  version: 1.1.0
   subpackages:
   - prometheus
 - package: github.com/flynn/json5

--- a/integration_tests/fixtures/app/Dockerfile
+++ b/integration_tests/fixtures/app/Dockerfile
@@ -2,7 +2,7 @@ FROM node:slim
 
 RUN apt-get update && \
     apt-get install -y \
-    curl netcat-openbsd && \
+    curl netcat-openbsd procps && \
     rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g json http-server

--- a/integration_tests/tests/test_telemetry/check.sh
+++ b/integration_tests/tests/test_telemetry/check.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -eo pipefail
+set -x
+
 
 IP="$1"
 curl -s "${IP}:9090/status" | json -a .Services.0.Status | grep "healthy"

--- a/integration_tests/tests/test_telemetry/run.sh
+++ b/integration_tests/tests/test_telemetry/run.sh
@@ -13,7 +13,7 @@ app="$(docker-compose ps -q app)"
 IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$app")
 
 # This interface takes a while to converge
-for _ in $(seq 0 2000); do
+for _ in $(seq 0 20); do
     sleep 1
     metrics=$(docker exec -it "$app" curl -s "${IP}:9090/metrics")
     echo "$metrics" | grep 'TYPE containerpilot_app_some_counter counter' && break

--- a/integration_tests/tests/test_telemetry/run.sh
+++ b/integration_tests/tests/test_telemetry/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-
 # start up consul and wait for leader election
 docker-compose up -d consul
 consul=$(docker-compose ps -q consul)
@@ -11,13 +10,13 @@ docker exec -it "$consul" assert ready
 docker-compose up -d app
 
 app="$(docker-compose ps -q app)"
-IP=$(docker inspect -f '{{ .NetworkSettings.Networks.testtelemetry_default.IPAddress }}' "$app")
+IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$app")
 
 # This interface takes a while to converge
-for _ in $(seq 0 20); do
+for _ in $(seq 0 2000); do
     sleep 1
     metrics=$(docker exec -it "$app" curl -s "${IP}:9090/metrics")
-    echo "$metrics" | grep 'containerpilot_app_some_counter 42' && break
+    echo "$metrics" | grep 'TYPE containerpilot_app_some_counter counter' && break
 done || (echo "did not get expected metrics output" && exit 1)
 
 # check last /metrics scrape for the rest of the events

--- a/integration_tests/tests/test_version_flag/run.sh
+++ b/integration_tests/tests/test_version_flag/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-docker-compose run app
-TEST_ID=$(docker ps -a | awk -F' +' '/testversionflag/{print $1}')
+docker-compose up -d app
+TEST_ID="$(docker-compose ps -q app)"
 docker logs "$TEST_ID" | grep dev-build-not-for-release
 result=$?
-
+docker-compose down
 exit $result

--- a/jobs/config.go
+++ b/jobs/config.go
@@ -23,11 +23,12 @@ type Config struct {
 	Exec interface{} `mapstructure:"exec"`
 
 	// service discovery
-	Port              int           `mapstructure:"port"`
-	InitialStatus     string        `mapstructure:"initial_status"`
-	Interfaces        interface{}   `mapstructure:"interfaces"`
-	Tags              []string      `mapstructure:"tags"`
-	ConsulExtras      *ConsulExtras `mapstructure:"consul"`
+	Port              int               `mapstructure:"port"`
+	InitialStatus     string            `mapstructure:"initial_status"`
+	Interfaces        interface{}       `mapstructure:"interfaces"`
+	Tags              []string          `mapstructure:"tags"`
+	Meta              map[string]string `mapstructure:"meta"`
+	ConsulExtras      *ConsulExtras     `mapstructure:"consul"`
 	serviceDefinition *discovery.ServiceDefinition
 
 	// health checking
@@ -430,6 +431,7 @@ func (cfg *Config) addDiscoveryConfig(disc discovery.Backend) error {
 		Port:                           cfg.Port,
 		TTL:                            cfg.ttl,
 		Tags:                           cfg.Tags,
+		Meta:                           cfg.Meta,
 		InitialStatus:                  cfg.InitialStatus,
 		IPAddress:                      ipAddress,
 		DeregisterCriticalServiceAfter: deregAfter,

--- a/makefile
+++ b/makefile
@@ -10,8 +10,11 @@ VERSION ?= dev-build-not-for-release
 LDFLAGS := -X ${IMPORT_PATH}/version.GitHash=$(shell git rev-parse --short HEAD) -X ${IMPORT_PATH}/version.Version=${VERSION}
 
 ROOT := $(shell pwd)
+CURRENT_UID := $(shell id -u)
+CURRENT_GID := $(shell id -g)
+
 RUNNER := -v ${ROOT}:/go/src/${IMPORT_PATH} -w /go/src/${IMPORT_PATH} containerpilot_build
-docker := docker run --rm -e LDFLAGS="${LDFLAGS}" $(RUNNER)
+docker := docker run -u ${CURRENT_UID}:${CURRENT_GID} --rm -e LDFLAGS="${LDFLAGS}" $(RUNNER)
 export PATH :=$(PATH):$(GOPATH)/bin
 
 # flags for local development
@@ -21,7 +24,7 @@ GOARCH ?= $(shell go env GOARCH)
 CGO_ENABLED := 0
 GOEXPERIMENT := framepointer
 
-CONSUL_VERSION := 1.0.0
+CONSUL_VERSION := 1.9.5
 GLIDE_VERSION := 0.12.3
 
 ## display this help message
@@ -66,7 +69,7 @@ release: build
 
 ## remove build/test artifacts, test fixtures, and vendor directories
 clean:
-	rm -rf build release cover vendor .glide
+	rm -rf build release cover vendor .glide glide.lock
 	docker rmi -f containerpilot_build > /dev/null 2>&1 || true
 	docker rm -f containerpilot_consul > /dev/null 2>&1 || true
 	./scripts/test.sh clean

--- a/telemetry/metrics_config.go
+++ b/telemetry/metrics_config.go
@@ -71,10 +71,11 @@ func (cfg *MetricConfig) Validate() error {
 	case "summary":
 		cfg.metricType = Summary
 		cfg.collector = prometheus.NewSummary(prometheus.SummaryOpts{
-			Namespace: cfg.Namespace,
-			Subsystem: cfg.Subsystem,
-			Name:      cfg.Name,
-			Help:      cfg.Help,
+			Namespace:  cfg.Namespace,
+			Subsystem:  cfg.Subsystem,
+			Name:       cfg.Name,
+			Help:       cfg.Help,
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		})
 	default:
 		return fmt.Errorf("invalid metric type: %s", cfg.Type)

--- a/telemetry/metrics_test.go
+++ b/telemetry/metrics_test.go
@@ -3,6 +3,9 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -10,9 +13,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/joyent/containerpilot/events"
 )
@@ -25,7 +25,7 @@ the prometheus handler and then check the results of a GET.
 */
 
 func TestMetricRun(t *testing.T) {
-	testServer := httptest.NewServer(prometheus.UninstrumentedHandler())
+	testServer := httptest.NewServer(promhttp.Handler())
 	defer testServer.Close()
 	cfg := &MetricConfig{
 		Namespace: "telemetry",
@@ -61,7 +61,7 @@ func TestMetricRun(t *testing.T) {
 // TestMetricProcessMetric covers the same ground as the 4 collector-
 // specific tests below, but checks the unhappy path.
 func TestMetricProcessMetric(t *testing.T) {
-	testServer := httptest.NewServer(prometheus.UninstrumentedHandler())
+	testServer := httptest.NewServer(promhttp.Handler())
 	defer testServer.Close()
 	cfg := &MetricConfig{
 		Namespace: "telemetry",
@@ -106,7 +106,7 @@ func TestMetricProcessMetric(t *testing.T) {
 }
 
 func TestMetricRecordCounter(t *testing.T) {
-	testServer := httptest.NewServer(prometheus.UninstrumentedHandler())
+	testServer := httptest.NewServer(promhttp.Handler())
 	defer testServer.Close()
 	metric := &Metric{
 		Type: Counter,
@@ -135,7 +135,7 @@ func TestMetricRecordCounter(t *testing.T) {
 }
 
 func TestMetricRecordGauge(t *testing.T) {
-	testServer := httptest.NewServer(prometheus.UninstrumentedHandler())
+	testServer := httptest.NewServer(promhttp.Handler())
 	defer testServer.Close()
 	metric := &Metric{
 		Type: Gauge,
@@ -165,7 +165,7 @@ func TestMetricRecordGauge(t *testing.T) {
 }
 
 func TestMetricRecordHistogram(t *testing.T) {
-	testServer := httptest.NewServer(prometheus.UninstrumentedHandler())
+	testServer := httptest.NewServer(promhttp.Handler())
 	defer testServer.Close()
 
 	metric := &Metric{
@@ -202,15 +202,16 @@ func TestMetricRecordHistogram(t *testing.T) {
 }
 
 func TestMetricRecordSummary(t *testing.T) {
-	testServer := httptest.NewServer(prometheus.UninstrumentedHandler())
+	testServer := httptest.NewServer(promhttp.Handler())
 	defer testServer.Close()
 	metric := &Metric{
 		Type: Summary,
 		collector: prometheus.NewSummary(prometheus.SummaryOpts{
-			Namespace: "telemetry",
-			Subsystem: "metrics",
-			Name:      "TestMetricRecordSummary",
-			Help:      "help",
+			Namespace:  "telemetry",
+			Subsystem:  "metrics",
+			Name:       "TestMetricRecordSummary",
+			Help:       "help",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		})}
 	prometheus.MustRegister(metric.collector)
 	patt := `telemetry_metrics_TestMetricRecordSummary{quantile="([\.0-9]*)"} ([0-9\.]*)`

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/joyent/containerpilot/version"
@@ -39,7 +39,7 @@ func NewTelemetry(cfg *Config) *Telemetry {
 	t.addr = cfg.addr
 
 	router := http.NewServeMux()
-	router.Handle("/metrics", prometheus.Handler())
+	router.Handle("/metrics", promhttp.Handler())
 	router.Handle("/status", NewStatusHandler(t))
 	t.Handler = router
 


### PR DESCRIPTION
implementation for service meta data support as described in issue 592
for this i needed to upgrade build dependency to
- upgrade build to go 1.13
- upgrade consul api to ~1.9.0
- upgrade prometheus api to 1.1.0

upgrades are limited to this version because build is still using glide instead of go modules. for further upgrades of prometheus, we need go module migration, which is out of scope for this issue.

this includes some fixes/api changes required in unit/integration testing because of upgraded api's
- fix integration test
- run build with current user uuid/gid so we don't have root owned files which breaks make clean when running on local docker & linux host.

for testing run 

make test
make integration

test are updated to check & validate service.meta data.

make lint complains about "events.Event composite literal uses unkeyed fields" but haven't change anything around events.



